### PR TITLE
content: A1 mocks 06-10 (Arbeit, Freizeit, Gesundheit, Reisen, Einkaufen)

### DIFF
--- a/assets/content/A1/mock_06.json
+++ b/assets/content/A1/mock_06.json
@@ -2,12 +2,714 @@
   "id": "A1_mock_06",
   "level": "A1",
   "title": "Übungstest 6",
-  "version": 0,
-  "_stub": true,
+  "version": 1,
   "sections": {
-    "listening": { "totalTimeMinutes": 20, "parts": [] },
-    "reading": { "totalTimeMinutes": 25, "parts": [] },
-    "writing": { "totalTimeMinutes": 20, "tasks": [] },
-    "speaking": { "totalTimeMinutes": 15, "prepTimeMinutes": 0, "parts": [] }
+    "listening": {
+      "totalTimeMinutes": 20,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Sie hören drei kurze Gespräche. Zu jedem Gespräch gibt es eine Aufgabe. Kreuzen Sie die richtige Antwort an: a, b oder c. Sie hören jeden Text zweimal.",
+          "instructionsTranslation": "You will hear three short conversations. For each conversation there is one task. Mark the correct answer: a, b, or c. You will hear each text twice.",
+          "audioFile": "assets/audio/A1/mock06/listening_part1.mp3",
+          "playCount": 2,
+          "questions": [
+            {
+              "id": "A1_m06_L1_q1",
+              "type": "mcq",
+              "questionText": "Wann beginnt Herr Meyers Arbeit heute?",
+              "questionImage": "assets/images/A1/mock06/L1_q1.png",
+              "options": [
+                "a) Um 7:00 Uhr",
+                "b) Um 8:30 Uhr",
+                "c) Um 9:00 Uhr"
+              ],
+              "correctAnswer": "b",
+              "explanation": "Im Audio Herr Meyer sagt: 'Ich fange heute um halb neun an' — 'halb neun' is 8:30 Uhr.",
+              "audioTimestamp": 18
+            },
+            {
+              "id": "A1_m06_L1_q2",
+              "type": "mcq",
+              "questionText": "Was kauft die Frau im Supermarkt für das Büro?",
+              "questionImage": "assets/images/A1/mock06/L1_q2.png",
+              "options": [
+                "a) Kaffee und Zucker",
+                "b) Milch und Brot",
+                "c) Wasser und Tee"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Die Frau sagt 'Ich kaufe Kaffee und Zucker für das Büro' when asked what she is getting from the supermarket.",
+              "audioTimestamp": 52
+            },
+            {
+              "id": "A1_m06_L1_q3",
+              "type": "mcq",
+              "questionText": "Wo arbeitet Frau Klein?",
+              "questionImage": "assets/images/A1/mock06/L1_q3.png",
+              "options": [
+                "a) In einer Schule",
+                "b) In einem Krankenhaus",
+                "c) In einem Büro"
+              ],
+              "correctAnswer": "c",
+              "explanation": "Frau Klein sagt 'Ich arbeite in einem Büro in der Stadtmitte' — she works in an office in the city centre.",
+              "audioTimestamp": 88
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Sie hören ein Gespräch. Zu dem Gespräch gibt es fünf Aufgaben. Kreuzen Sie an: Richtig oder Falsch. Sie hören den Text zweimal.",
+          "instructionsTranslation": "You will hear one conversation. There are five tasks. Mark: Correct or Incorrect. You will hear the text twice.",
+          "audioFile": "assets/audio/A1/mock06/listening_part2.mp3",
+          "playCount": 2,
+          "questions": [
+            {
+              "id": "A1_m06_L2_q1",
+              "type": "true_false",
+              "questionText": "Peter arbeitet seit drei Jahren in der Firma.",
+              "correctAnswer": "falsch",
+              "explanation": "Peter sagt 'Ich arbeite seit zwei Jahren hier' — he has been at the company for two years, nicht three.",
+              "audioTimestamp": 12
+            },
+            {
+              "id": "A1_m06_L2_q2",
+              "type": "true_false",
+              "questionText": "Das Büro hat von Montag bis Freitag geöffnet.",
+              "correctAnswer": "richtig",
+              "explanation": "Die Rezeptionistin bestätigt 'Das Büro ist von Montag bis Freitag von 8 bis 17 Uhr geöffnet.'",
+              "audioTimestamp": 35
+            },
+            {
+              "id": "A1_m06_L2_q3",
+              "type": "true_false",
+              "questionText": "Der Chef ist heute krank und kommt nicht ins Büro.",
+              "correctAnswer": "richtig",
+              "explanation": "Der Kollege sagt: \"Der Chef ist heute krank. Er kommt nicht ins Büro.\" Der Chef ist also krank. Die Aussage ist richtig.",
+              "audioTimestamp": 58
+            },
+            {
+              "id": "A1_m06_L2_q4",
+              "type": "true_false",
+              "questionText": "Das Mittagessen beginnt um 13:00 Uhr.",
+              "correctAnswer": "falsch",
+              "explanation": "Peter sagt the lunch break starts 'um halb eins' — at 12:30, nicht 13:00.",
+              "audioTimestamp": 74
+            },
+            {
+              "id": "A1_m06_L2_q5",
+              "type": "true_false",
+              "questionText": "Peter kommt morgen früher zur Arbeit.",
+              "correctAnswer": "richtig",
+              "explanation": "Peter sagt 'Morgen komme ich früher, um 7 Uhr' at the end of the conversation.",
+              "audioTimestamp": 98
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Sie hören drei kurze Gespräche. Zu jedem Gespräch gibt es eine Aufgabe. Kreuzen Sie die richtige Antwort an: a, b oder c. Sie hören jeden Text einmal.",
+          "instructionsTranslation": "You will hear three short conversations. For each conversation there is one task. Mark the correct answer: a, b, or c. You will hear each text once.",
+          "audioFile": "assets/audio/A1/mock06/listening_part3.mp3",
+          "playCount": 1,
+          "questions": [
+            {
+              "id": "A1_m06_L3_q1",
+              "type": "mcq",
+              "questionText": "Was ist das Problem mit dem Drucker?",
+              "options": [
+                "a) Der Drucker hat kein Papier.",
+                "b) Der Drucker ist kaputt.",
+                "c) Der Drucker ist aus."
+              ],
+              "correctAnswer": "a",
+              "explanation": "Der Kollege sagt: \"Der Drucker druckt nicht — er hat kein Papier mehr.\" Das Problem ist das fehlende Papier. Die Antwort ist a.",
+              "audioTimestamp": 14
+            },
+            {
+              "id": "A1_m06_L3_q2",
+              "type": "mcq",
+              "questionText": "Wann hat Frau Hoffmann heute einen Termin?",
+              "options": [
+                "a) Um 10:00 Uhr",
+                "b) Um 14:00 Uhr",
+                "c) Um 15:30 Uhr"
+              ],
+              "correctAnswer": "b",
+              "explanation": "Frau Hoffmann's assistant sagt her appointment is 'um 14 Uhr nachmittags' — at 2 p.m.",
+              "audioTimestamp": 48
+            },
+            {
+              "id": "A1_m06_L3_q3",
+              "type": "mcq",
+              "questionText": "Warum ruft der Mann an?",
+              "options": [
+                "a) Er möchte einen Job.",
+                "b) Er hat eine Frage zur Stelle.",
+                "c) Er möchte seine Adresse ändern."
+              ],
+              "correctAnswer": "b",
+              "explanation": "Der Mann sagt 'Ich habe eine Frage zu der Stelle, die Sie ausgeschrieben haben' — he has a question about the advertised position.",
+              "audioTimestamp": 82
+            }
+          ]
+        }
+      ]
+    },
+    "reading": {
+      "totalTimeMinutes": 25,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Lesen Sie die Texte und die Aufgaben. Kreuzen Sie an: Richtig oder Falsch.",
+          "instructionsTranslation": "Read the texts and the tasks. Mark: Correct or Incorrect.",
+          "texts": [
+            {
+              "id": "A1_m06_R1_text1",
+              "type": "email",
+              "content": "Von: anna.berger@buromax.de\nAn: team@buromax.de\nBetreff: Neue Arbeitszeiten\n\nLiebe Kolleginnen und Kollegen,\n\nab nächsten Montag beginnt unsere Arbeitszeit um 8:00 Uhr (früher: 9:00 Uhr). Das Büro schließt dann um 17:00 Uhr. Die Mittagspause ist von 12:00 bis 13:00 Uhr.\n\nBitte kommen Sie pünktlich. Bei Fragen wenden Sie sich an mich.\n\nViele Grüße\nAnna Berger\nPersonalabteilung",
+              "source": "Büromax GmbH – interne E-Mail"
+            },
+            {
+              "id": "A1_m06_R1_text2",
+              "type": "ad",
+              "content": "STELLENANZEIGE\n\nWir suchen ab sofort:\n\nBürokaufmann / Bürokauffrau (Vollzeit)\n\nIhre Aufgaben:\n– Telefon und E-Mails bearbeiten\n– Termine organisieren\n– Dokumente ablegen\n\nWir bieten:\n– 30 Tage Urlaub\n– Gutes Gehalt\n– Freundliches Team\n\nBitte senden Sie Ihre Bewerbung an:\njobs@stadtwerke-nord.de\n\nStadtwerke Nord GmbH",
+              "source": "Stellenanzeige – Stadtwerke Nord GmbH"
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m06_R1_q1",
+              "type": "true_false",
+              "questionText": "Die neue Arbeitszeit beginnt um 8:00 Uhr.",
+              "relatedTextId": "A1_m06_R1_text1",
+              "correctAnswer": "richtig",
+              "explanation": "In der E-Mail steht: \"Ab nächsten Montag beginnt unsere Arbeitszeit um 8:00 Uhr.\" Die neue Arbeitszeit beginnt also am Montag. Die Aussage ist richtig."
+            },
+            {
+              "id": "A1_m06_R1_q2",
+              "type": "true_false",
+              "questionText": "Das Büro schließt jetzt um 18:00 Uhr.",
+              "relatedTextId": "A1_m06_R1_text1",
+              "correctAnswer": "falsch",
+              "explanation": "In der E-Mail steht: \"Das Büro ist von 8:00 bis 17:00 Uhr geöffnet.\" Das Büro schließt um 17:00 Uhr, nicht um 18:00 Uhr. Die Aussage ist falsch."
+            },
+            {
+              "id": "A1_m06_R1_q3",
+              "type": "true_false",
+              "questionText": "Die Mittagspause dauert eine Stunde.",
+              "relatedTextId": "A1_m06_R1_text1",
+              "correctAnswer": "richtig",
+              "explanation": "In der E-Mail steht: \"Die Mittagspause ist von 12:00 bis 13:00 Uhr.\" Das ist eine Stunde. Die Aussage ist richtig."
+            },
+            {
+              "id": "A1_m06_R1_q4",
+              "type": "true_false",
+              "questionText": "Die Stelle bei Stadtwerke Nord ist für Teilzeit.",
+              "relatedTextId": "A1_m06_R1_text2",
+              "correctAnswer": "falsch",
+              "explanation": "In der Stellenanzeige steht \"Vollzeit\" — das bedeutet eine Vollzeitstelle, keine Teilzeitstelle. Die Aussage ist falsch."
+            },
+            {
+              "id": "A1_m06_R1_q5",
+              "type": "true_false",
+              "questionText": "Bewerber sollen eine E-Mail schicken.",
+              "relatedTextId": "A1_m06_R1_text2",
+              "correctAnswer": "richtig",
+              "explanation": "Die Anzeige sagt 'Bitte senden Sie Ihre Bewerbung an: jobs@stadtwerke-nord.de' — applicants should send an email."
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Lesen Sie die Anzeigen a–h und die Situationen 1–5. Welche Anzeige passt zu welcher Situation? Für eine Situation gibt es keine passende Anzeige. Schreiben Sie dann den Buchstaben oder ein X.",
+          "instructionsTranslation": "Read the ads a–h and situations 1–5. Which ad matches which situation? For one situation there is no matching ad. Write the letter or X.",
+          "texts": [
+            {
+              "id": "A1_m06_R2_ad_a",
+              "type": "ad",
+              "content": "JOBBÖRSE ONLINE\nTelefonist/-in gesucht\nTeilzeit, 20 Std./Woche\nGute Deutschkenntnisse nötig\nBewerbung: jobs@callcenter-berlin.de"
+            },
+            {
+              "id": "A1_m06_R2_ad_b",
+              "type": "ad",
+              "content": "Sprachkurs Deutsch A1\nAbende: Mo, Mi, Fr — 18:00–19:30 Uhr\nKleingruppenunterricht (max. 8 Personen)\nAnmeldung: vhs-mitte.de"
+            },
+            {
+              "id": "A1_m06_R2_ad_c",
+              "type": "ad",
+              "content": "LAGERHELFER (m/w/d)\nSofort! Vollzeit\nKeine Berufserfahrung nötig\nAnruf: 030 / 44 55 66 77\nLogistik Müller GmbH"
+            },
+            {
+              "id": "A1_m06_R2_ad_d",
+              "type": "ad",
+              "content": "Bürostuhl & Schreibtisch zu verkaufen\nGut erhalten, zusammen 80 €\nAbholung in Prenzlauer Berg\nTel.: 0177 / 123 456 78"
+            },
+            {
+              "id": "A1_m06_R2_ad_e",
+              "type": "ad",
+              "content": "BABYSITTER GESUCHT\nFür 2 Kinder (3 und 6 Jahre)\nDienstag & Donnerstag, 16–19 Uhr\nGute Bezahlung\nbabysitter@familiemayer.de"
+            },
+            {
+              "id": "A1_m06_R2_ad_f",
+              "type": "ad",
+              "content": "Kostenloser Computerkurs\nGrundlagen: Word & Excel\nSamstags 10:00–12:00 Uhr\nAnmeldung: bildung@gemeinde-nord.de"
+            },
+            {
+              "id": "A1_m06_R2_ad_g",
+              "type": "ad",
+              "content": "REINIGUNGSKRAFT (m/w/d)\nBüroreinigung, Mo–Fr morgens\nErfahrung erwünscht\nBewerbung an: info@cleanpro.de"
+            },
+            {
+              "id": "A1_m06_R2_ad_h",
+              "type": "ad",
+              "content": "Mitfahrgelegenheit\nBerlin → Hamburg, jeden Montag\nAbfahrt 6:30 Uhr, Kosten: 20 €\nKontakt: fahrer@mitfahrclub.de"
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m06_R2_q1",
+              "type": "matching",
+              "questionText": "Maria spricht wenig Deutsch. Sie möchte einen Deutschkurs am Abend machen.",
+              "matchingSources": [
+                {
+                  "id": "A1_m06_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m06_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m06_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m06_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m06_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m06_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m06_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m06_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "b",
+              "explanation": "Ad b bietet a German A1 course in the evenings (Monday, Wednesday, Friday 18:00–19:30), which passt zu Maria's need."
+            },
+            {
+              "id": "A1_m06_R2_q2",
+              "type": "matching",
+              "questionText": "Thomas sucht einen Job. Er hat keine Berufserfahrung und kann sofort anfangen.",
+              "matchingSources": [
+                {
+                  "id": "A1_m06_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m06_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m06_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m06_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m06_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m06_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m06_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m06_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "c",
+              "explanation": "Ad c is for a warehouse helper (Lagerhelfer), available immediately and requires no prior work experience."
+            },
+            {
+              "id": "A1_m06_R2_q3",
+              "type": "matching",
+              "questionText": "Familie Bauer braucht jemanden, der zwei Nachmittage pro Woche auf ihre Kinder aufpasst.",
+              "matchingSources": [
+                {
+                  "id": "A1_m06_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m06_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m06_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m06_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m06_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m06_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m06_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m06_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "e",
+              "explanation": "Ad e is looking for a babysitter for 2 children on Tuesday and Thursday afternoons — two afternoons per week."
+            },
+            {
+              "id": "A1_m06_R2_q4",
+              "type": "matching",
+              "questionText": "Lena möchte lernen, wie man Word und Excel am Computer benutzt. Sie hat am Samstag Zeit.",
+              "matchingSources": [
+                {
+                  "id": "A1_m06_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m06_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m06_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m06_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m06_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m06_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m06_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m06_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "f",
+              "explanation": "Ad f bietet a free computer course covering Word and Excel basics on Saturdays from 10:00–12:00."
+            },
+            {
+              "id": "A1_m06_R2_q5",
+              "type": "matching",
+              "questionText": "Herr Vogel sucht ein günstiges Ticket für einen Zug von Berlin nach Hamburg.",
+              "matchingSources": [
+                {
+                  "id": "A1_m06_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m06_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m06_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m06_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m06_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m06_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m06_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m06_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "x",
+              "explanation": "Ad h bietet a carpooling ride (Mitfahrgelegenheit) Berlin–Hamburg, but Herr Vogel wants a train ticket. No ad passt zu a train ticket specifically."
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Lesen Sie die Texte und die Aufgaben. Kreuzen Sie an: Richtig oder Falsch.",
+          "instructionsTranslation": "Read the texts and the tasks. Mark: Correct or Incorrect.",
+          "texts": [
+            {
+              "id": "A1_m06_R3_text1",
+              "type": "notice",
+              "content": "AUSHANG\n\nDas Büro ist am Freitag, den 14. Juni, ab 15:00 Uhr geschlossen.\nWir sind ab Montag wieder für Sie da.\n\nDanke für Ihr Verständnis!\n– Die Geschäftsleitung"
+            },
+            {
+              "id": "A1_m06_R3_text2",
+              "type": "notice",
+              "content": "ACHTUNG!\n\nDer Aufzug ist kaputt.\nBitte benutzen Sie die Treppe.\nWir reparieren den Aufzug am Dienstag.\n\n– Hausmeister"
+            },
+            {
+              "id": "A1_m06_R3_text3",
+              "type": "notice",
+              "content": "Liebe Mitarbeiterinnen und Mitarbeiter,\n\nbitte stellen Sie keine privaten Sachen in der Büroküche ab. Die Küche ist nur für die Mittagspause.\n\nDienstag und Donnerstag gibt es frischen Kaffee.\n\n– Anna, Verwaltung"
+            },
+            {
+              "id": "A1_m06_R3_text4",
+              "type": "notice",
+              "content": "PARKPLATZ-INFORMATION\n\nMitarbeiter können Platz 1–10 benutzen.\nBitte fahren Sie langsam auf dem Parkplatz (max. 10 km/h).\nBesucher parken bitte auf Platz 11–15."
+            },
+            {
+              "id": "A1_m06_R3_text5",
+              "type": "notice",
+              "content": "Teambesprechung\nMittwoch, 11. Juni — 10:00 Uhr\nKonferenzraum 2 (3. Etage)\n\nThemen: Neue Projekte, Urlaubsplanung\n\nBitte alle pünktlich kommen!"
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m06_R3_q1",
+              "type": "true_false",
+              "questionText": "Das Büro ist am Freitagnachmittag zu.",
+              "relatedTextId": "A1_m06_R3_text1",
+              "correctAnswer": "richtig",
+              "explanation": "Das Schild sagt the office is closed on Friday from 15:00 — so it closes in the afternoon."
+            },
+            {
+              "id": "A1_m06_R3_q2",
+              "type": "true_false",
+              "questionText": "Der Aufzug funktioniert heute nicht.",
+              "relatedTextId": "A1_m06_R3_text2",
+              "correctAnswer": "richtig",
+              "explanation": "Das Schild sagt 'Der Aufzug ist kaputt' — the elevator is broken and nicht working."
+            },
+            {
+              "id": "A1_m06_R3_q3",
+              "type": "true_false",
+              "questionText": "In der Büroküche darf man persönliche Sachen lagern.",
+              "relatedTextId": "A1_m06_R3_text3",
+              "correctAnswer": "falsch",
+              "explanation": "Das Schild sagt 'bitte stellen Sie keine privaten Sachen in der Büroküche ab' — personal items are nicht allowed in the kitchen."
+            },
+            {
+              "id": "A1_m06_R3_q4",
+              "type": "true_false",
+              "questionText": "Besucher können die Parkplätze 1–10 benutzen.",
+              "relatedTextId": "A1_m06_R3_text4",
+              "correctAnswer": "falsch",
+              "explanation": "Places 1–10 are for employees (Mitarbeiter). Visitors (Besucher) use places 11–15."
+            },
+            {
+              "id": "A1_m06_R3_q5",
+              "type": "true_false",
+              "questionText": "Die Teambesprechung ist im dritten Stock.",
+              "relatedTextId": "A1_m06_R3_text5",
+              "correctAnswer": "richtig",
+              "explanation": "Das Schild sagt the meeting is in 'Konferenzraum 2 (3. Etage)' — 3. Etage means the third floor."
+            }
+          ]
+        }
+      ]
+    },
+    "writing": {
+      "totalTimeMinutes": 20,
+      "tasks": [
+        {
+          "taskNumber": 1,
+          "type": "form_fill",
+          "instructions": "Füllen Sie das Formular aus. Lesen Sie zuerst das Beispiel.",
+          "instructionsTranslation": "Fill in the form. Read the example first.",
+          "formFields": [
+            {
+              "label": "Vorname",
+              "correctAnswer": "Sara",
+              "hint": "Schreiben Sie Ihren Vornamen."
+            },
+            {
+              "label": "Familienname",
+              "correctAnswer": "Yilmaz",
+              "hint": "Schreiben Sie Ihren Familiennamen."
+            },
+            {
+              "label": "Beruf",
+              "correctAnswer": "Bürokauffrau",
+              "hint": "Was ist Ihr Beruf? (z. B. Verkäufer, Kellner, Bürokaufmann)"
+            },
+            {
+              "label": "Arbeitszeit",
+              "correctAnswer": "Vollzeit",
+              "hint": "Möchten Sie Vollzeit oder Teilzeit arbeiten?"
+            },
+            {
+              "label": "Telefonnummer",
+              "correctAnswer": "0176 / 98 76 54 32",
+              "hint": "Schreiben Sie Ihre Handynummer oder Festnetznummer."
+            }
+          ],
+          "sampleAnswer": "Vorname: Sara | Familienname: Yilmaz | Beruf: Bürokauffrau | Arbeitszeit: Vollzeit | Telefonnummer: 0176 / 98 76 54 32",
+          "scoringCriteria": [
+            {
+              "criterion": "Vollständigkeit",
+              "maxPoints": 5,
+              "description": "Alle fünf Felder sind ausgefüllt. Pro fehlendem Feld wird ein Punkt abgezogen."
+            },
+            {
+              "criterion": "Korrektheit",
+              "maxPoints": 5,
+              "description": "Die Angaben sind sprachlich korrekt und dem Feld entsprechend (z. B. kein Satz statt eines Namens)."
+            }
+          ]
+        },
+        {
+          "taskNumber": 2,
+          "type": "short_message",
+          "instructions": "Sie sind krank und können heute nicht zur Arbeit kommen. Schreiben Sie eine Nachricht an Ihren Kollegen Jonas. Schreiben Sie 30–40 Wörter. Schreiben Sie zu allen drei Punkten.",
+          "instructionsTranslation": "You are sick and cannot come to work today. Write a message to your colleague Jonas. Write 30–40 words. Write about all three points.",
+          "prompt": "– Warum schreiben Sie?\n– Wann kommen Sie wieder?\n– Was soll Jonas für Sie machen?",
+          "promptTranslation": "– Why are you writing?\n– When will you come back?\n– What should Jonas do for you?",
+          "requiredPoints": [
+            "Begründung (Sie sind krank / können nicht kommen)",
+            "Rückkehr (z. B. morgen oder übermorgen)",
+            "Bitte an Jonas (z. B. Termin absagen, E-Mails lesen)"
+          ],
+          "wordCountMin": 30,
+          "wordCountMax": 40,
+          "sampleAnswer": "Hallo Jonas,\n\nleider bin ich heute krank und kann nicht zur Arbeit kommen. Ich komme wahrscheinlich morgen wieder. Kannst du bitte den Termin mit Frau Schulz um 14 Uhr absagen? Danke!\n\nViele Grüße,\nSara",
+          "scoringCriteria": [
+            {
+              "criterion": "Aufgabenerfüllung",
+              "maxPoints": 4,
+              "description": "Alle drei Punkte sind angesprochen. Für jeden fehlenden Punkt werden Punkte abgezogen."
+            },
+            {
+              "criterion": "Kommunikative Gestaltung",
+              "maxPoints": 4,
+              "description": "Die Nachricht ist verständlich, hat eine Anrede und einen Abschluss. Der Text ist zusammenhängend."
+            },
+            {
+              "criterion": "Formale Richtigkeit",
+              "maxPoints": 4,
+              "description": "Rechtschreibung, Grammatik und Wortschatz sind überwiegend korrekt für das Niveau A1."
+            }
+          ]
+        }
+      ]
+    },
+    "speaking": {
+      "totalTimeMinutes": 15,
+      "prepTimeMinutes": 0,
+      "parts": [
+        {
+          "partNumber": 1,
+          "type": "introduce",
+          "instructions": "Stellen Sie sich vor. Sprechen Sie über: Name, Herkunft, Wohnort, Beruf und Sprachen.",
+          "instructionsTranslation": "Introduce yourself. Talk about: name, origin, place of residence, job and languages.",
+          "prompt": "Mein Name ist ... Ich komme aus ... Ich wohne in ... Ich bin ... (Beruf). Ich spreche ...",
+          "sampleResponse": "Mein Name ist Kerim Demir. Ich komme aus der Türkei, aber ich wohne jetzt in Hamburg. Ich bin Bürokaufmann. Ich spreche Türkisch und etwas Deutsch.",
+          "sampleAudioFile": "assets/audio/A1/mock06/speaking_part1_sample.mp3",
+          "evaluationTips": [
+            "Sprechen Sie laut und deutlich.",
+            "Nennen Sie alle fünf Punkte: Name, Herkunft, Wohnort, Beruf, Sprachen.",
+            "Machen Sie kurze, einfache Sätze.",
+            "Schauen Sie den Prüfer an, wenn möglich."
+          ],
+          "keyPhrases": [
+            "Mein Name ist ...",
+            "Ich komme aus ...",
+            "Ich wohne in ...",
+            "Ich bin ... (Beruf).",
+            "Ich spreche ...",
+            "Ich lerne Deutsch."
+          ]
+        },
+        {
+          "partNumber": 2,
+          "type": "picture_cards",
+          "instructions": "Sie bekommen drei Karten. Auf jeder Karte ist ein Bild und ein Wort. Sagen Sie, was Sie auf den Bildern sehen. Machen Sie einen Satz zu jedem Bild.",
+          "instructionsTranslation": "You receive three cards. Each card has a picture and a word. Say what you see in the pictures. Make one sentence for each picture.",
+          "prompt": "Karte 1: der Computer\nKarte 2: das Telefon\nKarte 3: der Schreibtisch",
+          "promptImage": "assets/images/A1/mock06/speaking_part2_cards.png",
+          "sampleResponse": "Karte 1: Das ist ein Computer. Der Computer ist im Büro.\nKarte 2: Das ist ein Telefon. Das Telefon ist schwarz.\nKarte 3: Das ist ein Schreibtisch. Der Schreibtisch ist groß.",
+          "sampleAudioFile": "assets/audio/A1/mock06/speaking_part2_sample.mp3",
+          "evaluationTips": [
+            "Sagen Sie das Wort auf der Karte: 'Das ist ein/eine ...'",
+            "Fügen Sie eine weitere Information hinzu (Farbe, Ort, Größe).",
+            "Benutzen Sie den richtigen Artikel: der, die oder das.",
+            "Sprechen Sie ruhig — es ist kein Problem, kurz nachzudenken."
+          ],
+          "keyPhrases": [
+            "Das ist ein/eine ...",
+            "Der/Die/Das ... ist ...",
+            "Ich sehe ...",
+            "Das benutzt man im Büro.",
+            "Das ist groß / klein / neu.",
+            "Man schreibt damit."
+          ]
+        },
+        {
+          "partNumber": 3,
+          "type": "und_du",
+          "instructions": "Sie bekommen drei Wortkarten zu einem Thema. Sie stellen Ihrem Partner eine Frage. Ihr Partner antwortet und fragt zurück: 'Und du?' Dann antworten Sie.",
+          "instructionsTranslation": "You receive three word cards on a topic. You ask your partner a question. Your partner answers and asks back: 'And you?' Then you answer.",
+          "prompt": "Thema: Arbeit\nWortkarte 1: Arbeitszeit\nWortkarte 2: Kollegen\nWortkarte 3: Pause",
+          "sampleResponse": "Wortkarte 1 — Arbeitszeit:\nA: 'Wann arbeitest du?' B: 'Ich arbeite von 8 bis 17 Uhr. Und du?' A: 'Ich arbeite von 9 bis 18 Uhr.'\n\nWortkarte 2 — Kollegen:\nA: 'Hast du nette Kollegen?' B: 'Ja, meine Kollegen sind sehr freundlich. Und du?' A: 'Meine Kollegen sind auch nett.'\n\nWortkarte 3 — Pause:\nA: 'Wann machst du Pause?' B: 'Ich mache um 12 Uhr Pause. Und du?' A: 'Ich mache um halb eins Pause.'",
+          "sampleAudioFile": "assets/audio/A1/mock06/speaking_part3_sample.mp3",
+          "evaluationTips": [
+            "Stellen Sie eine klare Frage mit 'Wann', 'Wo', 'Wie' oder 'Hast du ...'.",
+            "Antworten Sie in einem vollständigen Satz.",
+            "Vergessen Sie nicht 'Und du?' nach Ihrer Antwort.",
+            "Benutzen Sie einfache Sätze — kurz und klar ist gut."
+          ],
+          "keyPhrases": [
+            "Wann arbeitest du?",
+            "Ich arbeite von ... bis ...",
+            "Hast du nette Kollegen?",
+            "Meine Kollegen sind ...",
+            "Wann machst du Pause?",
+            "Und du?"
+          ]
+        }
+      ]
+    }
   }
 }

--- a/assets/content/A1/mock_07.json
+++ b/assets/content/A1/mock_07.json
@@ -2,12 +2,719 @@
   "id": "A1_mock_07",
   "level": "A1",
   "title": "Übungstest 7",
-  "version": 0,
-  "_stub": true,
+  "version": 1,
   "sections": {
-    "listening": { "totalTimeMinutes": 20, "parts": [] },
-    "reading": { "totalTimeMinutes": 25, "parts": [] },
-    "writing": { "totalTimeMinutes": 20, "tasks": [] },
-    "speaking": { "totalTimeMinutes": 15, "prepTimeMinutes": 0, "parts": [] }
+    "listening": {
+      "totalTimeMinutes": 20,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Sie hören drei kurze Gespräche. Zu jedem Gespräch gibt es eine Aufgabe. Kreuzen Sie die richtige Antwort an: a, b oder c. Sie hören jeden Text zweimal.",
+          "instructionsTranslation": "You will hear three short conversations. There is one task per conversation. Mark the correct answer: a, b or c. You will hear each text twice.",
+          "audioFile": "assets/audio/A1/mock07/listening_part1.mp3",
+          "playCount": 2,
+          "questions": [
+            {
+              "id": "A1_m07_L1_q1",
+              "type": "mcq",
+              "questionText": "Wohin geht die Frau am Samstag?",
+              "questionImage": "assets/images/A1/mock07/L1_q1.png",
+              "options": [
+                "a) ins Schwimmbad",
+                "b) in den Park",
+                "c) ins Kino"
+              ],
+              "correctAnswer": "c",
+              "explanation": "Die Frau sagt im Gespräch: 'Am Samstag gehe ich mit meiner Freundin ins Kino. Der neue Film läuft schon seit einer Woche.' Park und Schwimmbad werden nicht erwähnt.",
+              "audioTimestamp": 14
+            },
+            {
+              "id": "A1_m07_L1_q2",
+              "type": "mcq",
+              "questionText": "Was macht der Mann in seiner Freizeit?",
+              "questionImage": "assets/images/A1/mock07/L1_q2.png",
+              "options": [
+                "a) Er spielt Fußball.",
+                "b) Er fährt Fahrrad.",
+                "c) Er spielt Tennis."
+              ],
+              "correctAnswer": "b",
+              "explanation": "Der Mann sagt: 'Ich fahre jeden Sonntag Fahrrad, meistens zwei Stunden im Stadtpark.' Fußball und Tennis werden im Gespräch nicht genannt.",
+              "audioTimestamp": 47
+            },
+            {
+              "id": "A1_m07_L1_q3",
+              "type": "mcq",
+              "questionText": "Wann beginnt das Konzert?",
+              "questionImage": "assets/images/A1/mock07/L1_q3.png",
+              "options": [
+                "a) um 19 Uhr",
+                "b) um 20 Uhr",
+                "c) um 21 Uhr"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Die Frau fragt: 'Wann fängt das Konzert an?' und der Mann antwortet: 'Um 19 Uhr. Aber wir sollten um 18:30 Uhr dort sein.' 20 Uhr und 21 Uhr sind falsch.",
+              "audioTimestamp": 82
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Sie hören einen Text. Lesen Sie die Aufgaben 1 bis 5. Kreuzen Sie an: richtig oder falsch. Sie hören den Text zweimal.",
+          "instructionsTranslation": "You will hear a text. Read tasks 1 to 5. Mark: correct or incorrect. You will hear the text twice.",
+          "audioFile": "assets/audio/A1/mock07/listening_part2.mp3",
+          "playCount": 2,
+          "questions": [
+            {
+              "id": "A1_m07_L2_q1",
+              "type": "true_false",
+              "questionText": "Der Sportverein hat am Montag geschlossen.",
+              "correctAnswer": "falsch",
+              "explanation": "Im Text heißt es: 'Der Sportverein Stadtmitte ist montags bis freitags von 9 bis 21 Uhr geöffnet.' Er ist also montags geöffnet, nicht geschlossen.",
+              "audioTimestamp": 18
+            },
+            {
+              "id": "A1_m07_L2_q2",
+              "type": "true_false",
+              "questionText": "Kinder bis 12 Jahre bezahlen keinen Eintritt.",
+              "correctAnswer": "richtig",
+              "explanation": "Der Sprecher sagt ausdrücklich: 'Kinder bis zwölf Jahre können kostenlos mitmachen.' Das bestätigt die Aussage.",
+              "audioTimestamp": 34
+            },
+            {
+              "id": "A1_m07_L2_q3",
+              "type": "true_false",
+              "questionText": "Das Schwimmbad ist am Wochenende bis 22 Uhr geöffnet.",
+              "correctAnswer": "falsch",
+              "explanation": "Im Text wird gesagt: 'Am Samstag und Sonntag ist das Hallenbad von 8 bis 20 Uhr geöffnet.' 22 Uhr ist falsch — es schließt um 20 Uhr.",
+              "audioTimestamp": 52
+            },
+            {
+              "id": "A1_m07_L2_q4",
+              "type": "true_false",
+              "questionText": "Es gibt einen Yogakurs für Anfänger.",
+              "correctAnswer": "richtig",
+              "explanation": "Der Sprecher erwähnt: 'Wir bieten auch Yoga für Anfänger an — dienstags und donnerstags um 18 Uhr.' Die Aussage ist korrekt.",
+              "audioTimestamp": 68
+            },
+            {
+              "id": "A1_m07_L2_q5",
+              "type": "true_false",
+              "questionText": "Man kann sich beim Verein nur online anmelden.",
+              "correctAnswer": "falsch",
+              "explanation": "Im Text heißt es: 'Sie können sich online oder persönlich an unserer Rezeption anmelden.' Es ist also auch eine persönliche Anmeldung möglich.",
+              "audioTimestamp": 85
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Sie hören drei Gespräche. Zu jedem Gespräch gibt es eine Aufgabe. Kreuzen Sie die richtige Antwort an: a, b oder c. Sie hören jeden Text einmal.",
+          "instructionsTranslation": "You will hear three conversations. There is one task per conversation. Mark the correct answer: a, b or c. You will hear each text once.",
+          "audioFile": "assets/audio/A1/mock07/listening_part3.mp3",
+          "playCount": 1,
+          "questions": [
+            {
+              "id": "A1_m07_L3_q1",
+              "type": "mcq",
+              "questionText": "Was kauft die Frau im Sportgeschäft?",
+              "options": [
+                "a) Sportschuhe",
+                "b) eine Schwimmbrille",
+                "c) ein Trikot"
+              ],
+              "correctAnswer": "b",
+              "explanation": "Die Frau fragt den Verkäufer: 'Haben Sie Schwimmbrillen? Ich brauche eine für das Training.' Sie kauft schließlich eine Schwimmbrille. Schuhe und Trikots werden nicht gekauft.",
+              "audioTimestamp": 12
+            },
+            {
+              "id": "A1_m07_L3_q2",
+              "type": "mcq",
+              "questionText": "Wie oft trainiert Lukas pro Woche?",
+              "options": [
+                "a) einmal",
+                "b) zweimal",
+                "c) dreimal"
+              ],
+              "correctAnswer": "c",
+              "explanation": "Lukas sagt: 'Ich trainiere dreimal pro Woche: Montag, Mittwoch und Freitag.' Er nennt konkret drei Termine pro Woche.",
+              "audioTimestamp": 51
+            },
+            {
+              "id": "A1_m07_L3_q3",
+              "type": "mcq",
+              "questionText": "Wo treffen sich die Freunde am Sonntag?",
+              "options": [
+                "a) im Café",
+                "b) am Bahnhof",
+                "c) im Park"
+              ],
+              "correctAnswer": "c",
+              "explanation": "Im Gespräch sagt Anna: 'Treffen wir uns im Park, am Haupteingang um 11 Uhr?' und Tobias antwortet: 'Ja, gerne!' Café und Bahnhof werden nicht als Treffpunkt genannt.",
+              "audioTimestamp": 88
+            }
+          ]
+        }
+      ]
+    },
+    "reading": {
+      "totalTimeMinutes": 25,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Lesen Sie die Texte und die Aufgaben 1 bis 5. Kreuzen Sie an: richtig oder falsch.",
+          "instructionsTranslation": "Read the texts and tasks 1 to 5. Mark: correct or incorrect.",
+          "texts": [
+            {
+              "id": "A1_m07_R1_text1",
+              "type": "notice",
+              "content": "SMS von Mia:\nHallo Jana! Ich gehe heute Nachmittag um 15 Uhr in den Stadtpark zum Joggen. Kommst du mit? Wir können danach zusammen einen Kaffee trinken. Bitte schreib mir schnell!",
+              "source": "SMS-Nachricht"
+            },
+            {
+              "id": "A1_m07_R1_text2",
+              "type": "notice",
+              "content": "STADTFEST GRÜNTAL\nSamstag, 14. Juni – 11:00 bis 22:00 Uhr\nGroßer Festplatz am Stadtpark\n\nProgramm:\n- Kinderturnier (Fußball) ab 11 Uhr\n- Live-Musik ab 15 Uhr\n- Feuerwerk um 21:30 Uhr\n\nEintritt frei! Für Essen und Getränke sind Festmarken erhältlich.\nInformationen: www.stadtfest-gruental.de",
+              "source": "Veranstaltungsflyer"
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m07_R1_q1",
+              "type": "true_false",
+              "questionText": "Mia möchte heute Nachmittag joggen gehen.",
+              "relatedTextId": "A1_m07_R1_text1",
+              "correctAnswer": "richtig",
+              "explanation": "In der SMS schreibt Mia: 'Ich gehe heute Nachmittag um 15 Uhr in den Stadtpark zum Joggen.' Das stimmt mit der Aussage überein."
+            },
+            {
+              "id": "A1_m07_R1_q2",
+              "type": "true_false",
+              "questionText": "Jana und Mia wollen nach dem Sport Kaffee trinken.",
+              "relatedTextId": "A1_m07_R1_text1",
+              "correctAnswer": "richtig",
+              "explanation": "Mia schlägt vor: 'Wir können danach zusammen einen Kaffee trinken.' Das stimmt genau."
+            },
+            {
+              "id": "A1_m07_R1_q3",
+              "type": "true_false",
+              "questionText": "Das Stadtfest beginnt um 10 Uhr.",
+              "relatedTextId": "A1_m07_R1_text2",
+              "correctAnswer": "falsch",
+              "explanation": "Laut Flyer beginnt das Stadtfest Grüntal um 11:00 Uhr, nicht um 10 Uhr."
+            },
+            {
+              "id": "A1_m07_R1_q4",
+              "type": "true_false",
+              "questionText": "Der Eintritt zum Stadtfest ist kostenlos.",
+              "relatedTextId": "A1_m07_R1_text2",
+              "correctAnswer": "richtig",
+              "explanation": "Der Flyer sagt klar: 'Eintritt frei!' Das bedeutet kostenlos."
+            },
+            {
+              "id": "A1_m07_R1_q5",
+              "type": "true_false",
+              "questionText": "Es gibt beim Stadtfest ein Feuerwerk um Mitternacht.",
+              "relatedTextId": "A1_m07_R1_text2",
+              "correctAnswer": "falsch",
+              "explanation": "Das Feuerwerk ist laut Programm um 21:30 Uhr geplant, nicht um Mitternacht."
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Lesen Sie die Anzeigen a bis h und die Aufgaben 1 bis 5. Welche Anzeige passt zu welcher Person? Für eine Aufgabe gibt es keine Anzeige. Schreiben Sie dann den Buchstaben oder X.",
+          "instructionsTranslation": "Read ads a to h and tasks 1 to 5. Which ad matches which person? For one task there is no ad. Write the letter or X.",
+          "texts": [
+            {
+              "id": "A1_m07_R2_ad_a",
+              "type": "ad",
+              "content": "FITNESSSTUDIO AKTIV\nMitgliedschaft ab 29 Euro/Monat\nModerne Geräte, Kurse und Sauna\nNeue Mitglieder erhalten den ersten Monat gratis!\nInfo: 0221 345678"
+            },
+            {
+              "id": "A1_m07_R2_ad_b",
+              "type": "ad",
+              "content": "KINO PALACE – DIESE WOCHE\n'Sommertage in Rom' – romantische Komödie\nTäglich 17:30 und 20:00 Uhr\nStudenten zahlen nur 7 Euro\nOnline-Tickets: www.kinopalace.de"
+            },
+            {
+              "id": "A1_m07_R2_ad_c",
+              "type": "ad",
+              "content": "SPORTSHOP LAUFSTARK\nLaufschuhe für alle Distanzen\nFachberatung kostenlos\nSonderangebot: 20% auf alle Laufschuhe diese Woche!\nÖffnungszeiten: Mo–Sa 9–20 Uhr"
+            },
+            {
+              "id": "A1_m07_R2_ad_d",
+              "type": "ad",
+              "content": "SCHWIMMKURS FÜR ERWACHSENE\nAnfänger und Fortgeschrittene\nKursbeginn: 3. März, montags 19–20 Uhr\nAnmeldung bis 28. Februar\nStadtbad Mitte – Tel. 0221 987654"
+            },
+            {
+              "id": "A1_m07_R2_ad_e",
+              "type": "ad",
+              "content": "PARKFEST IM ROSENGARTEN\nSonntag, 20. Juli\nFlohmarkt, Kinderkarussell und Livemusik\nEintritt: Erwachsene 3 Euro, Kinder frei\nWir freuen uns auf Sie!"
+            },
+            {
+              "id": "A1_m07_R2_ad_f",
+              "type": "ad",
+              "content": "TANZSCHULE RHYTHMUS\nSalsa, Tango und Standard\nSchnupperkurs Samstag, 10 Uhr\nKeine Vorkenntnisse nötig!\nAnmeldung: info@tanzschule-rhythmus.de"
+            },
+            {
+              "id": "A1_m07_R2_ad_g",
+              "type": "ad",
+              "content": "FAHRRAD MIETEN – STADTPARK\nStundenmiete ab 4 Euro\nTagesmiete ab 15 Euro\nHelm und Schloss inklusive\nVerleihaus: Parkeingang Nord, täglich 8–18 Uhr"
+            },
+            {
+              "id": "A1_m07_R2_ad_h",
+              "type": "ad",
+              "content": "TENNIS-CLUB STADTMITTE\nSchnupperstunde gratis für Neumitglieder\nPlätze frei, auch abends\nTrainer mit Lizenz\nTel. 0221 112233 – www.tc-stadtmitte.de"
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m07_R2_q1",
+              "type": "matching",
+              "questionText": "Petra möchte Schwimmen lernen. Sie hat montags abends Zeit.",
+              "matchingSources": [
+                {
+                  "id": "A1_m07_R2_ad_a",
+                  "label": "a) Fitnessstudio Aktiv"
+                },
+                {
+                  "id": "A1_m07_R2_ad_b",
+                  "label": "b) Kino Palace"
+                },
+                {
+                  "id": "A1_m07_R2_ad_c",
+                  "label": "c) Sportshop Laufstark"
+                },
+                {
+                  "id": "A1_m07_R2_ad_d",
+                  "label": "d) Schwimmkurs für Erwachsene"
+                },
+                {
+                  "id": "A1_m07_R2_ad_e",
+                  "label": "e) Parkfest im Rosengarten"
+                },
+                {
+                  "id": "A1_m07_R2_ad_f",
+                  "label": "f) Tanzschule Rhythmus"
+                },
+                {
+                  "id": "A1_m07_R2_ad_g",
+                  "label": "g) Fahrrad mieten – Stadtpark"
+                },
+                {
+                  "id": "A1_m07_R2_ad_h",
+                  "label": "h) Tennis-Club Stadtmitte"
+                }
+              ],
+              "correctAnswer": "d",
+              "explanation": "Anzeige d bietet einen Schwimmkurs für Erwachsene und Anfänger montags von 19–20 Uhr an — das passt genau zu Petras Wunsch und ihrer freien Zeit."
+            },
+            {
+              "id": "A1_m07_R2_q2",
+              "type": "matching",
+              "questionText": "Marco ist Student und möchte einen Film sehen. Er sucht ein günstiges Angebot.",
+              "matchingSources": [
+                {
+                  "id": "A1_m07_R2_ad_a",
+                  "label": "a) Fitnessstudio Aktiv"
+                },
+                {
+                  "id": "A1_m07_R2_ad_b",
+                  "label": "b) Kino Palace"
+                },
+                {
+                  "id": "A1_m07_R2_ad_c",
+                  "label": "c) Sportshop Laufstark"
+                },
+                {
+                  "id": "A1_m07_R2_ad_d",
+                  "label": "d) Schwimmkurs für Erwachsene"
+                },
+                {
+                  "id": "A1_m07_R2_ad_e",
+                  "label": "e) Parkfest im Rosengarten"
+                },
+                {
+                  "id": "A1_m07_R2_ad_f",
+                  "label": "f) Tanzschule Rhythmus"
+                },
+                {
+                  "id": "A1_m07_R2_ad_g",
+                  "label": "g) Fahrrad mieten – Stadtpark"
+                },
+                {
+                  "id": "A1_m07_R2_ad_h",
+                  "label": "h) Tennis-Club Stadtmitte"
+                }
+              ],
+              "correctAnswer": "b",
+              "explanation": "Anzeige b ist das Kino Palace mit einem Studentenrabatt von 7 Euro. Marco ist Student, sucht einen Film, und das ist das günstigste passende Angebot."
+            },
+            {
+              "id": "A1_m07_R2_q3",
+              "type": "matching",
+              "questionText": "Sabine möchte am Wochenende mit ihrer Familie in den Park. Sie sucht eine Veranstaltung mit Musik und Aktivitäten für Kinder.",
+              "matchingSources": [
+                {
+                  "id": "A1_m07_R2_ad_a",
+                  "label": "a) Fitnessstudio Aktiv"
+                },
+                {
+                  "id": "A1_m07_R2_ad_b",
+                  "label": "b) Kino Palace"
+                },
+                {
+                  "id": "A1_m07_R2_ad_c",
+                  "label": "c) Sportshop Laufstark"
+                },
+                {
+                  "id": "A1_m07_R2_ad_d",
+                  "label": "d) Schwimmkurs für Erwachsene"
+                },
+                {
+                  "id": "A1_m07_R2_ad_e",
+                  "label": "e) Parkfest im Rosengarten"
+                },
+                {
+                  "id": "A1_m07_R2_ad_f",
+                  "label": "f) Tanzschule Rhythmus"
+                },
+                {
+                  "id": "A1_m07_R2_ad_g",
+                  "label": "g) Fahrrad mieten – Stadtpark"
+                },
+                {
+                  "id": "A1_m07_R2_ad_h",
+                  "label": "h) Tennis-Club Stadtmitte"
+                }
+              ],
+              "correctAnswer": "e",
+              "explanation": "Anzeige e (Parkfest im Rosengarten) bietet Livemusik und ein Kinderkarussell — ideal für eine Familie mit Kindern an einem Sonntag im Park."
+            },
+            {
+              "id": "A1_m07_R2_q4",
+              "type": "matching",
+              "questionText": "Thomas läuft gern und möchte neue Laufschuhe kaufen. Er sucht Fachberatung.",
+              "matchingSources": [
+                {
+                  "id": "A1_m07_R2_ad_a",
+                  "label": "a) Fitnessstudio Aktiv"
+                },
+                {
+                  "id": "A1_m07_R2_ad_b",
+                  "label": "b) Kino Palace"
+                },
+                {
+                  "id": "A1_m07_R2_ad_c",
+                  "label": "c) Sportshop Laufstark"
+                },
+                {
+                  "id": "A1_m07_R2_ad_d",
+                  "label": "d) Schwimmkurs für Erwachsene"
+                },
+                {
+                  "id": "A1_m07_R2_ad_e",
+                  "label": "e) Parkfest im Rosengarten"
+                },
+                {
+                  "id": "A1_m07_R2_ad_f",
+                  "label": "f) Tanzschule Rhythmus"
+                },
+                {
+                  "id": "A1_m07_R2_ad_g",
+                  "label": "g) Fahrrad mieten – Stadtpark"
+                },
+                {
+                  "id": "A1_m07_R2_ad_h",
+                  "label": "h) Tennis-Club Stadtmitte"
+                }
+              ],
+              "correctAnswer": "c",
+              "explanation": "Anzeige c (Sportshop Laufstark) bietet kostenlose Fachberatung und 20% Rabatt auf Laufschuhe — genau das, was Thomas sucht."
+            },
+            {
+              "id": "A1_m07_R2_q5",
+              "type": "matching",
+              "questionText": "Lena möchte eine neue Sportart ausprobieren. Sie interessiert sich für Kampfsport.",
+              "matchingSources": [
+                {
+                  "id": "A1_m07_R2_ad_a",
+                  "label": "a) Fitnessstudio Aktiv"
+                },
+                {
+                  "id": "A1_m07_R2_ad_b",
+                  "label": "b) Kino Palace"
+                },
+                {
+                  "id": "A1_m07_R2_ad_c",
+                  "label": "c) Sportshop Laufstark"
+                },
+                {
+                  "id": "A1_m07_R2_ad_d",
+                  "label": "d) Schwimmkurs für Erwachsene"
+                },
+                {
+                  "id": "A1_m07_R2_ad_e",
+                  "label": "e) Parkfest im Rosengarten"
+                },
+                {
+                  "id": "A1_m07_R2_ad_f",
+                  "label": "f) Tanzschule Rhythmus"
+                },
+                {
+                  "id": "A1_m07_R2_ad_g",
+                  "label": "g) Fahrrad mieten – Stadtpark"
+                },
+                {
+                  "id": "A1_m07_R2_ad_h",
+                  "label": "h) Tennis-Club Stadtmitte"
+                }
+              ],
+              "correctAnswer": "x",
+              "explanation": "Keine der Anzeigen a bis h bietet Kampfsport an. Anzeige f ist Tanzen, nicht Kampfsport. Lena findet kein passendes Angebot."
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Lesen Sie die fünf Texte. Zu jedem Text gibt es eine Aufgabe. Kreuzen Sie an: richtig oder falsch.",
+          "instructionsTranslation": "Read the five texts. There is one task per text. Mark: correct or incorrect.",
+          "texts": [
+            {
+              "id": "A1_m07_R3_text1",
+              "type": "notice",
+              "content": "HALLENBAD GESCHLOSSEN\nWegen Wartungsarbeiten bleibt das Hallenbad am Dienstag, 18. März, ganztägig geschlossen. Ab Mittwoch wieder normal geöffnet.",
+              "source": "Aushang am Eingang"
+            },
+            {
+              "id": "A1_m07_R3_text2",
+              "type": "notice",
+              "content": "Fußballtraining heute Abend findet NICHT statt. Der Trainer ist krank. Nächstes Training: Donnerstag, 18 Uhr, wie gewohnt. – FC Blau-Weiß",
+              "source": "Gruppeninfo"
+            },
+            {
+              "id": "A1_m07_R3_text3",
+              "type": "notice",
+              "content": "FAHRRÄDER ABSTELLEN VERBOTEN!\nBitte Fahrräder nur im Fahrradkeller abstellen. Fahrräder im Hausflur werden entfernt.",
+              "source": "Hinweisschild im Eingangsbereich"
+            },
+            {
+              "id": "A1_m07_R3_text4",
+              "type": "notice",
+              "content": "Yoga im Park – kostenlos!\nJeden Samstag, 9 Uhr, Stadtpark Pavillon\nAlle Levels willkommen. Bitte Matte mitbringen.\nBei schlechtem Wetter fällt der Kurs aus.",
+              "source": "Plakat"
+            },
+            {
+              "id": "A1_m07_R3_text5",
+              "type": "notice",
+              "content": "Lieber Mieter,\nbitte beachten Sie: Der Aufzug ist diese Woche außer Betrieb. Wir bitten um Entschuldigung für die Unannehmlichkeiten.\n– Die Hausverwaltung",
+              "source": "Brief"
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m07_R3_q1",
+              "type": "true_false",
+              "questionText": "Das Hallenbad öffnet am Mittwoch wieder.",
+              "relatedTextId": "A1_m07_R3_text1",
+              "correctAnswer": "richtig",
+              "explanation": "Der Aushang sagt: 'Ab Mittwoch wieder normal geöffnet.' Die Aussage stimmt."
+            },
+            {
+              "id": "A1_m07_R3_q2",
+              "type": "true_false",
+              "questionText": "Das Fußballtraining findet heute statt.",
+              "relatedTextId": "A1_m07_R3_text2",
+              "correctAnswer": "falsch",
+              "explanation": "Die Nachricht sagt ausdrücklich: 'Fußballtraining heute Abend findet NICHT statt.' Es fällt also aus."
+            },
+            {
+              "id": "A1_m07_R3_q3",
+              "type": "true_false",
+              "questionText": "Man darf das Fahrrad im Hausflur abstellen.",
+              "relatedTextId": "A1_m07_R3_text3",
+              "correctAnswer": "falsch",
+              "explanation": "Das Schild sagt: 'Fahrräder im Hausflur werden entfernt' und 'Abstellen verboten'. Es ist also nicht erlaubt, Fahrräder dort abzustellen."
+            },
+            {
+              "id": "A1_m07_R3_q4",
+              "type": "true_false",
+              "questionText": "Der Yogakurs im Park kostet Geld.",
+              "relatedTextId": "A1_m07_R3_text4",
+              "correctAnswer": "falsch",
+              "explanation": "Das Plakat sagt klar: 'Yoga im Park – kostenlos!' Der Kurs ist gratis."
+            },
+            {
+              "id": "A1_m07_R3_q5",
+              "type": "true_false",
+              "questionText": "Der Aufzug funktioniert diese Woche nicht.",
+              "relatedTextId": "A1_m07_R3_text5",
+              "correctAnswer": "richtig",
+              "explanation": "Der Brief sagt: 'Der Aufzug ist diese Woche außer Betrieb.' Das bedeutet, er funktioniert nicht."
+            }
+          ]
+        }
+      ]
+    },
+    "writing": {
+      "totalTimeMinutes": 20,
+      "tasks": [
+        {
+          "taskNumber": 1,
+          "type": "form_fill",
+          "instructions": "Sie möchten Mitglied in einem Sportverein werden. Füllen Sie das Anmeldeformular aus.",
+          "instructionsTranslation": "You would like to become a member of a sports club. Fill in the registration form.",
+          "formFields": [
+            {
+              "label": "Vorname und Nachname",
+              "correctAnswer": "z. B. Julia Hoffmann",
+              "hint": "Schreiben Sie Ihren vollen Namen."
+            },
+            {
+              "label": "Geburtsdatum",
+              "correctAnswer": "z. B. 12.05.1990",
+              "hint": "Schreiben Sie Tag, Monat und Jahr."
+            },
+            {
+              "label": "Gewünschte Sportart",
+              "correctAnswer": "z. B. Schwimmen",
+              "hint": "Welchen Sport möchten Sie machen? (z. B. Fußball, Tennis, Schwimmen)"
+            },
+            {
+              "label": "Telefonnummer",
+              "correctAnswer": "z. B. 0176 1234567",
+              "hint": "Schreiben Sie Ihre Handynummer oder Festnetznummer."
+            },
+            {
+              "label": "Wann haben Sie Zeit? (Tag und Uhrzeit)",
+              "correctAnswer": "z. B. Dienstag und Donnerstag, 18 Uhr",
+              "hint": "Nennen Sie einen oder zwei Tage und eine Uhrzeit."
+            }
+          ],
+          "sampleAnswer": "Vorname und Nachname: Julia Hoffmann\nGeburtsdatum: 12.05.1990\nGewünschte Sportart: Schwimmen\nTelefonnummer: 0176 1234567\nWann haben Sie Zeit?: Dienstag und Donnerstag, 18 Uhr",
+          "scoringCriteria": [
+            {
+              "criterion": "Vollständigkeit",
+              "maxPoints": 5,
+              "description": "Alle fünf Felder sind ausgefüllt. Für jedes ausgefüllte Feld gibt es einen Punkt."
+            },
+            {
+              "criterion": "Korrektheit",
+              "maxPoints": 5,
+              "description": "Die Angaben sind sprachlich korrekt und verständlich. Kleine Rechtschreibfehler werden nicht bestraft, wenn die Information klar ist."
+            }
+          ]
+        },
+        {
+          "taskNumber": 2,
+          "type": "short_message",
+          "instructions": "Sie möchten Ihren Freund / Ihre Freundin zu einer Freizeitaktivität einladen. Schreiben Sie eine Nachricht (30–40 Wörter). Schreiben Sie zu allen drei Punkten.",
+          "instructionsTranslation": "You would like to invite your friend to a leisure activity. Write a message (30–40 words). Write about all three points.",
+          "prompt": "- Was machen Sie? (Aktivität)\n- Wann und wo?\n- Was soll Ihr Freund / Ihre Freundin mitbringen?",
+          "promptTranslation": "- What are you doing? (activity)\n- When and where?\n- What should your friend bring?",
+          "requiredPoints": [
+            "Art der Aktivität nennen (z. B. Fahrradtour, Schwimmen, Kino)",
+            "Zeit und Ort angeben",
+            "Etwas zum Mitbringen erwähnen"
+          ],
+          "wordCountMin": 30,
+          "wordCountMax": 40,
+          "sampleAnswer": "Hallo Katrin!\n\nIch mache am Samstag um 10 Uhr eine Fahrradtour im Stadtpark. Kommst du mit? Wir treffen uns am Parkeingang Nord. Bitte bring dein Fahrrad und eine Wasserflasche mit. Bis Samstag!\n\nDeine Julia",
+          "scoringCriteria": [
+            {
+              "criterion": "Aufgabenerfüllung",
+              "maxPoints": 4,
+              "description": "Alle drei Punkte (Aktivität, Zeit/Ort, Mitbringen) sind vollständig und verständlich bearbeitet."
+            },
+            {
+              "criterion": "Kommunikative Gestaltung",
+              "maxPoints": 4,
+              "description": "Die Nachricht ist klar strukturiert, hat eine Anrede und einen Abschluss, und liest sich natürlich."
+            },
+            {
+              "criterion": "Formale Richtigkeit",
+              "maxPoints": 4,
+              "description": "Grammatik, Rechtschreibung und Zeichensetzung sind weitgehend korrekt. Kleinere Fehler sind akzeptabel, wenn der Text verständlich bleibt."
+            }
+          ]
+        }
+      ]
+    },
+    "speaking": {
+      "totalTimeMinutes": 15,
+      "prepTimeMinutes": 0,
+      "parts": [
+        {
+          "partNumber": 1,
+          "type": "introduce",
+          "instructions": "Stellen Sie sich vor. Sprechen Sie über Ihre Hobbys und Ihre Freizeit.",
+          "instructionsTranslation": "Introduce yourself. Talk about your hobbies and your free time.",
+          "prompt": "Sagen Sie etwas über:\n- Ihren Namen und Ihre Herkunft\n- Ihre Hobbys und Freizeitaktivitäten\n- Ihren Lieblingssport oder Ihre Lieblingsfreizeitaktivität\n- Wann und wie oft Sie Sport machen",
+          "sampleResponse": "Hallo, mein Name ist Luisa Becker. Ich komme aus Köln. In meiner Freizeit mache ich gern Sport. Mein Hobby ist Schwimmen. Ich schwimme zweimal pro Woche im Hallenbad. Am Wochenende gehe ich auch manchmal joggen. Ich liebe Sport, weil er Spaß macht und gesund ist.",
+          "sampleAudioFile": "assets/audio/A1/mock07/speaking_part1_sample.mp3",
+          "evaluationTips": [
+            "Sprechen Sie laut und deutlich — der Prüfer muss Sie gut verstehen.",
+            "Benutzen Sie einfache, vollständige Sätze auf Deutsch.",
+            "Nennen Sie konkrete Hobbys mit Häufigkeit (z. B. 'zweimal pro Woche').",
+            "Machen Sie eine kurze Pause zwischen den Themen — das wirkt strukturiert."
+          ],
+          "keyPhrases": [
+            "Mein Name ist ...",
+            "Ich komme aus ...",
+            "In meiner Freizeit ...",
+            "Mein Hobby ist ...",
+            "Ich mache gern ...",
+            "Ich mache das ... mal pro Woche."
+          ]
+        },
+        {
+          "partNumber": 2,
+          "type": "picture_cards",
+          "instructions": "Sie sehen drei Bildkarten mit Freizeitgegenständen. Bitte sprechen Sie über die Gegenstände auf den Karten.",
+          "instructionsTranslation": "You see three picture cards showing leisure items. Please talk about the items on the cards.",
+          "prompt": "Was sehen Sie auf den Bildern? Sagen Sie, was es ist, welche Farbe es hat, oder was man damit macht.",
+          "promptImage": "assets/images/A1/mock07/speaking_part2_cards.png",
+          "sampleResponse": "Auf dem ersten Bild sehe ich einen Fußball. Er ist schwarz und weiß. Man spielt Fußball auf einem Fußballplatz. Auf dem zweiten Bild ist ein Fahrrad. Das Fahrrad ist blau. Man fährt Fahrrad im Park oder auf der Straße. Auf dem dritten Bild sehe ich eine Schwimmbrille. Die Schwimmbrille ist rot. Man benutzt sie im Schwimmbad.",
+          "sampleAudioFile": "assets/audio/A1/mock07/speaking_part2_sample.mp3",
+          "evaluationTips": [
+            "Beschreiben Sie jedes Bild mit mindestens einem vollständigen Satz.",
+            "Nennen Sie den Artikel (der, die, das) — das gehört zur Bewertung.",
+            "Sie dürfen auch sagen, was man mit dem Gegenstand macht.",
+            "Wenn Sie ein Wort nicht wissen, beschreiben Sie den Gegenstand auf Deutsch."
+          ],
+          "keyPhrases": [
+            "Auf dem Bild sehe ich ...",
+            "Das ist ein/eine ...",
+            "Es ist / Er ist / Sie ist ...",
+            "Man benutzt das für ...",
+            "Man spielt / fährt / schwimmt ...",
+            "Die Farbe ist ..."
+          ]
+        },
+        {
+          "partNumber": 3,
+          "type": "und_du",
+          "instructions": "Ihr Gesprächspartner nennt ein Thema. Stellen Sie eine Frage dazu und antworten Sie auch selbst. Themen: Sport, Musik, Urlaub.",
+          "instructionsTranslation": "Your conversation partner names a topic. Ask a question about it and also answer yourself. Topics: Sport, Musik, Urlaub.",
+          "prompt": "Thema 1: Sport\nThema 2: Musik\nThema 3: Urlaub",
+          "sampleResponse": "Prüfer: Sport. Und du?\nKandidat: Machst du gern Sport?\nPrüfer: Ja, ich spiele Tennis. Und du?\nKandidat: Ich schwimme gern, zweimal pro Woche.\n\nPrüfer: Musik. Und du?\nKandidat: Hörst du gern Musik?\nPrüfer: Ja, ich höre gern Pop. Und du?\nKandidat: Ich höre auch gern Musik. Am liebsten höre ich Rock.\n\nPrüfer: Urlaub. Und du?\nKandidat: Fährst du gern in den Urlaub?\nPrüfer: Ja, ich fahre gern ans Meer. Und du?\nKandidat: Ich fahre gern in die Berge. Das macht mir sehr viel Spaß.",
+          "sampleAudioFile": "assets/audio/A1/mock07/speaking_part3_sample.mp3",
+          "evaluationTips": [
+            "Stellen Sie immer eine Frage zum genannten Thema — das ist Pflicht in diesem Teil.",
+            "Antworten Sie auch selbst auf das Thema, nicht nur mit 'Ja' oder 'Nein'.",
+            "Benutzen Sie 'Und du?' oder 'Und Sie?' um das Gespräch weiterzuführen.",
+            "Bleiben Sie beim Thema und sprechen Sie in ganzen Sätzen."
+          ],
+          "keyPhrases": [
+            "Machst du gern ...?",
+            "Spielst du ...?",
+            "Hörst du gern ...?",
+            "Fährst du gern ...?",
+            "Ich ... gern ...",
+            "Das macht mir Spaß."
+          ]
+        }
+      ]
+    }
   }
 }

--- a/assets/content/A1/mock_08.json
+++ b/assets/content/A1/mock_08.json
@@ -2,12 +2,719 @@
   "id": "A1_mock_08",
   "level": "A1",
   "title": "Übungstest 8",
-  "version": 0,
-  "_stub": true,
+  "version": 1,
   "sections": {
-    "listening": { "totalTimeMinutes": 20, "parts": [] },
-    "reading": { "totalTimeMinutes": 25, "parts": [] },
-    "writing": { "totalTimeMinutes": 20, "tasks": [] },
-    "speaking": { "totalTimeMinutes": 15, "prepTimeMinutes": 0, "parts": [] }
+    "listening": {
+      "totalTimeMinutes": 20,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Sie hören drei kurze Texte. Zu jedem Text gibt es eine Aufgabe. Kreuzen Sie die richtige Antwort an: a, b oder c. Sie hören jeden Text zweimal.",
+          "instructionsTranslation": "You will hear three short texts. There is one task for each text. Mark the correct answer: a, b or c. You will hear each text twice.",
+          "audioFile": "assets/audio/A1/mock08/listening_part1.mp3",
+          "playCount": 2,
+          "questions": [
+            {
+              "id": "A1_m08_L1_q1",
+              "type": "mcq",
+              "questionText": "Was hat die Frau?",
+              "questionImage": "assets/images/A1/mock08/L1_q1.png",
+              "options": [
+                "a) Kopfschmerzen",
+                "b) Bauchschmerzen",
+                "c) Halsschmerzen"
+              ],
+              "correctAnswer": "b",
+              "explanation": "Die Frau sagt: 'Ich habe seit gestern Bauchschmerzen und kann nichts essen.' Kopfschmerzen und Halsschmerzen werden nicht erwähnt.",
+              "audioTimestamp": 8
+            },
+            {
+              "id": "A1_m08_L1_q2",
+              "type": "mcq",
+              "questionText": "Wann hat die Arztpraxis geöffnet?",
+              "questionImage": "assets/images/A1/mock08/L1_q2.png",
+              "options": [
+                "a) Montag bis Freitag, 8 bis 18 Uhr",
+                "b) Montag bis Freitag, 8 bis 12 Uhr und 14 bis 17 Uhr",
+                "c) Montag bis Samstag, 9 bis 12 Uhr"
+              ],
+              "correctAnswer": "b",
+              "explanation": "Die Ansage sagt: 'Unsere Sprechzeiten sind Montag bis Freitag von 8 bis 12 Uhr und von 14 bis 17 Uhr.' Samstag und Abendstunden sind falsch.",
+              "audioTimestamp": 12
+            },
+            {
+              "id": "A1_m08_L1_q3",
+              "type": "mcq",
+              "questionText": "Was kauft der Mann in der Apotheke?",
+              "questionImage": "assets/images/A1/mock08/L1_q3.png",
+              "options": [
+                "a) Ein Pflaster und eine Creme",
+                "b) Tabletten gegen Fieber",
+                "c) Hustensaft und Nasentropfen"
+              ],
+              "correctAnswer": "c",
+              "explanation": "Der Apotheker sagt: 'Hier sind Ihr Hustensaft und die Nasentropfen.' Tabletten werden nicht gekauft, und ein Pflaster wird nicht erwähnt.",
+              "audioTimestamp": 15
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Sie hören einen Text. Zu dem Text gibt es fünf Aufgaben. Kreuzen Sie an: richtig oder falsch. Sie hören den Text zweimal.",
+          "instructionsTranslation": "You will hear one text. There are five tasks for the text. Mark: correct or incorrect. You will hear the text twice.",
+          "audioFile": "assets/audio/A1/mock08/listening_part2.mp3",
+          "playCount": 2,
+          "questions": [
+            {
+              "id": "A1_m08_L2_q1",
+              "type": "true_false",
+              "questionText": "Der Arzt hat am Donnerstag keine Sprechstunde.",
+              "correctAnswer": "richtig",
+              "explanation": "Die Rezeptionistin sagt: 'Donnerstag ist Herr Dr. Meier nicht da. Er hat nur montags, dienstags, mittwochs und freitags Sprechstunde.'",
+              "audioTimestamp": 18
+            },
+            {
+              "id": "A1_m08_L2_q2",
+              "type": "true_false",
+              "questionText": "Frau Hoffmann hat einen Termin um 10:30 Uhr.",
+              "correctAnswer": "falsch",
+              "explanation": "Frau Hoffmann bekommt einen Termin um 14:00 Uhr, nicht um 10:30 Uhr. Die Rezeptionistin sagt: 'Ich habe noch etwas frei um 14 Uhr.'",
+              "audioTimestamp": 32
+            },
+            {
+              "id": "A1_m08_L2_q3",
+              "type": "true_false",
+              "questionText": "Frau Hoffmann soll ihre Krankenkassenkarte mitbringen.",
+              "correctAnswer": "richtig",
+              "explanation": "Die Rezeptionistin sagt am Ende: 'Bringen Sie bitte Ihre Krankenkassenkarte mit.' Das ist eine Standard-Anforderung beim Arztbesuch.",
+              "audioTimestamp": 48
+            },
+            {
+              "id": "A1_m08_L2_q4",
+              "type": "true_false",
+              "questionText": "Frau Hoffmann hat seit drei Tagen Fieber.",
+              "correctAnswer": "falsch",
+              "explanation": "Frau Hoffmann sagt: 'Ich habe seit gestern Abend Fieber' — das ist seit einem Tag, nicht seit drei Tagen.",
+              "audioTimestamp": 22
+            },
+            {
+              "id": "A1_m08_L2_q5",
+              "type": "true_false",
+              "questionText": "Die Arztpraxis ist in der Berliner Straße.",
+              "correctAnswer": "richtig",
+              "explanation": "Die Rezeptionistin bestätigt die Adresse: 'Wir sind in der Berliner Straße 12, zweites Obergeschoss.' Das stimmt überein.",
+              "audioTimestamp": 55
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Sie hören drei Gespräche. Zu jedem Gespräch gibt es eine Aufgabe. Kreuzen Sie die richtige Antwort an: a, b oder c. Sie hören jeden Text einmal.",
+          "instructionsTranslation": "You will hear three conversations. There is one task for each conversation. Mark the correct answer: a, b or c. You will hear each text once.",
+          "audioFile": "assets/audio/A1/mock08/listening_part3.mp3",
+          "playCount": 1,
+          "questions": [
+            {
+              "id": "A1_m08_L3_q1",
+              "type": "mcq",
+              "questionText": "Was soll Tobias essen?",
+              "options": [
+                "a) Viel Obst und Gemüse",
+                "b) Nur Suppe und Brot",
+                "c) Nichts, er soll fasten"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Der Arzt empfiehlt: 'Essen Sie viel Obst und Gemüse, trinken Sie viel Wasser, und vermeiden Sie Fett.' Fasten und nur Suppe werden nicht gesagt.",
+              "audioTimestamp": 8
+            },
+            {
+              "id": "A1_m08_L3_q2",
+              "type": "mcq",
+              "questionText": "Was macht die Frau mit den Tabletten?",
+              "options": [
+                "a) Sie nimmt zwei Tabletten dreimal täglich.",
+                "b) Sie nimmt eine Tablette morgens und eine abends.",
+                "c) Sie nimmt drei Tabletten einmal täglich."
+              ],
+              "correctAnswer": "b",
+              "explanation": "Der Apotheker erklärt: 'Nehmen Sie morgens eine Tablette und abends eine Tablette — also insgesamt zweimal täglich eine Tablette.'",
+              "audioTimestamp": 22
+            },
+            {
+              "id": "A1_m08_L3_q3",
+              "type": "mcq",
+              "questionText": "Wohin geht Lena nach der Arbeit?",
+              "options": [
+                "a) Zum Fitnessstudio",
+                "b) Zur Apotheke",
+                "c) Nach Hause zum Schlafen"
+              ],
+              "correctAnswer": "b",
+              "explanation": "Lena sagt: 'Ich muss noch schnell zur Apotheke — das Rezept vom Arzt.' Sie geht nicht ins Fitnessstudio oder direkt nach Hause.",
+              "audioTimestamp": 15
+            }
+          ]
+        }
+      ]
+    },
+    "reading": {
+      "totalTimeMinutes": 25,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Lesen Sie die zwei Texte. Zu jedem Text gibt es Aussagen. Kreuzen Sie an: richtig oder falsch.",
+          "instructionsTranslation": "Read the two texts. There are statements about each text. Cross: correct or incorrect.",
+          "texts": [
+            {
+              "id": "A1_m08_R1_text1",
+              "type": "email",
+              "content": "Betreff: Ihr Termin bei Dr. Schäfer\n\nSehr geehrte Frau Bauer,\n\nIch bestätige Ihren Termin bei Dr. Schäfer am Dienstag, den 15. März, um 9:30 Uhr. Bitte bringen Sie Ihre Krankenkassenkarte und alle Medikamente mit, die Sie regelmäßig nehmen. Die Praxis ist in der Gartenstraße 7, Erdgeschoss. Bitte kommen Sie fünf Minuten früher.\n\nBei Fragen rufen Sie uns an: 0421 / 88 55 33.\n\nMit freundlichen Grüßen\nDas Team der Praxis Dr. Schäfer",
+              "source": "E-Mail einer Arztpraxis"
+            },
+            {
+              "id": "A1_m08_R1_text2",
+              "type": "notice",
+              "content": "GESUNDHEITS-TIPP DES MONATS\n\nTrinken Sie jeden Tag mindestens 1,5 Liter Wasser!\n\nWasser ist sehr wichtig für den Körper. Es hilft bei Kopfschmerzen und macht die Haut schön. Viele Menschen trinken zu wenig. Kaffee und Alkohol zählen nicht — trinken Sie lieber Wasser, Tee oder Saft.\n\nIhr Apothekenteam der Stadt-Apotheke, Marktplatz 3",
+              "source": "Aushang einer Apotheke"
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m08_R1_q1",
+              "type": "true_false",
+              "questionText": "Der Termin bei Dr. Schäfer ist um 9:30 Uhr.",
+              "relatedTextId": "A1_m08_R1_text1",
+              "correctAnswer": "richtig",
+              "explanation": "Die E-Mail sagt direkt: '…am Dienstag, den 15. März, um 9:30 Uhr.' Die Uhrzeit ist eindeutig angegeben."
+            },
+            {
+              "id": "A1_m08_R1_q2",
+              "type": "true_false",
+              "questionText": "Die Praxis ist im zweiten Obergeschoss.",
+              "relatedTextId": "A1_m08_R1_text1",
+              "correctAnswer": "falsch",
+              "explanation": "Die E-Mail sagt: '…Erdgeschoss.' Zweites Obergeschoss ist falsch — die Praxis liegt im Erdgeschoss."
+            },
+            {
+              "id": "A1_m08_R1_q3",
+              "type": "true_false",
+              "questionText": "Frau Bauer soll ihre Medikamente mitbringen.",
+              "relatedTextId": "A1_m08_R1_text1",
+              "correctAnswer": "richtig",
+              "explanation": "Die E-Mail sagt: 'Bitte bringen Sie … alle Medikamente mit, die Sie regelmäßig nehmen.' Das stimmt."
+            },
+            {
+              "id": "A1_m08_R1_q4",
+              "type": "true_false",
+              "questionText": "Man soll täglich mindestens zwei Liter Wasser trinken.",
+              "relatedTextId": "A1_m08_R1_text2",
+              "correctAnswer": "falsch",
+              "explanation": "Der Text empfiehlt 'mindestens 1,5 Liter', nicht zwei Liter. Die Zahl ist im Text klar angegeben."
+            },
+            {
+              "id": "A1_m08_R1_q5",
+              "type": "true_false",
+              "questionText": "Kaffee zählt nicht als Wasser für den täglichen Bedarf.",
+              "relatedTextId": "A1_m08_R1_text2",
+              "correctAnswer": "richtig",
+              "explanation": "Der Text sagt ausdrücklich: 'Kaffee und Alkohol zählen nicht.' Man soll lieber Wasser, Tee oder Saft trinken."
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Lesen Sie die Anzeigen a bis h. Welche Anzeige passt zu welcher Situation? Für eine Situation gibt es keine passende Anzeige. Schreiben Sie dann den Buchstaben x.",
+          "instructionsTranslation": "Read advertisements a to h. Which advertisement matches which situation? For one situation there is no matching advertisement. Write the letter x.",
+          "texts": [
+            {
+              "id": "A1_m08_R2_ad_a",
+              "type": "ad",
+              "content": "STADTAPOTHEKE\nMarktplatz 3 · Tel. 0421 / 55 44 33\nGeöffnet: Mo–Fr 8–19 Uhr, Sa 9–13 Uhr\nWir beraten Sie gerne zu Medikamenten, Vitaminen und Nahrungsergänzungsmitteln.\nKostenlose Blutdruckmessung jeden Dienstag!"
+            },
+            {
+              "id": "A1_m08_R2_ad_b",
+              "type": "ad",
+              "content": "DR. MED. PETRA LANGE\nAllgemeinmedizin & Vorsorge\nNeupatientensprechstunde: Montag 10–12 Uhr\nTermine: 0421 / 33 22 11\nGartenstraße 14 · Wir sprechen auch Englisch und Türkisch."
+            },
+            {
+              "id": "A1_m08_R2_ad_c",
+              "type": "ad",
+              "content": "FIT & GESUND SPORTKURS\nBewegung für Rücken und Gelenke\nDienstags und Donnerstags 18:30 Uhr\nStadthalle Raum 5 · Kursgebühr: 8 € pro Einheit\nAnmeldung: sportverein-city.de"
+            },
+            {
+              "id": "A1_m08_R2_ad_d",
+              "type": "ad",
+              "content": "ERNÄHRUNGSBERATUNG\nSie möchten gesünder essen und abnehmen?\nIndividuelle Beratung mit Ernährungsplan\nDipl.-Ernährungswissenschaftlerin Maria Vogt\nTermine: 0176 / 44 55 66 · vogt-ernaehrung.de"
+            },
+            {
+              "id": "A1_m08_R2_ad_e",
+              "type": "ad",
+              "content": "KINDERARZTPRAXIS DR. BAUER\nPädiatrie & Vorsorgeuntersuchungen\nMontag–Freitag 8–12 Uhr\nNachmittag nach Vereinbarung\nRosenweg 9 · Tel. 0421 / 77 88 99"
+            },
+            {
+              "id": "A1_m08_R2_ad_f",
+              "type": "ad",
+              "content": "MASSAGE & WELLNESS\nKlassische Massage, Rückenmassage, Aromatherapie\nTermin nach Vereinbarung\nPreise ab 35 € / 45 Minuten\nWohlfühlzentrum Mitte, Hauptstraße 22 · Tel. 0421 / 11 22 33"
+            },
+            {
+              "id": "A1_m08_R2_ad_g",
+              "type": "ad",
+              "content": "ZAHNARZTPRAXIS DR. KLEIN\nZahnreinigung, Füllungen, Zahnspangen\nMo, Mi, Fr: 8–17 Uhr · Di, Do: 10–19 Uhr\nNachsorge und Schmerzbehandlung möglich\nBahnhofstraße 5 · 0421 / 66 77 88"
+            },
+            {
+              "id": "A1_m08_R2_ad_h",
+              "type": "ad",
+              "content": "ERSTE-HILFE-KURS\nFür Führerscheinbewerber und Interessierte\nJeden Samstag 9–13 Uhr\nDRK-Zentrum, Schillerstraße 3\nAnmeldung: 0421 / 99 00 11 · Kurs: 35 €"
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m08_R2_q1",
+              "type": "matching",
+              "questionText": "Mia ist sieben Jahre alt und hat Ohrenschmerzen. Ihre Mutter sucht einen Arzt für Kinder.",
+              "matchingSources": [
+                {
+                  "id": "A1_m08_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m08_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m08_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m08_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m08_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m08_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m08_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m08_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "e",
+              "explanation": "Anzeige e ist die 'Kinderarztpraxis Dr. Bauer' — speziell für Kinder (Pädiatrie). Mia braucht einen Kinderarzt, keinen Allgemeinmediziner oder Zahnarzt."
+            },
+            {
+              "id": "A1_m08_R2_q2",
+              "type": "matching",
+              "questionText": "Karl hat starke Rückenschmerzen und möchte Sport machen, um fit zu bleiben.",
+              "matchingSources": [
+                {
+                  "id": "A1_m08_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m08_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m08_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m08_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m08_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m08_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m08_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m08_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "c",
+              "explanation": "Anzeige c bietet einen 'Sportkurs' speziell für 'Rücken und Gelenke'. Das passt direkt zu Karls Rückenschmerzen und dem Wunsch, Sport zu treiben."
+            },
+            {
+              "id": "A1_m08_R2_q3",
+              "type": "matching",
+              "questionText": "Sandra möchte gesünder essen. Sie braucht professionelle Hilfe und einen persönlichen Ernährungsplan.",
+              "matchingSources": [
+                {
+                  "id": "A1_m08_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m08_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m08_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m08_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m08_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m08_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m08_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m08_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "d",
+              "explanation": "Anzeige d bietet 'Ernährungsberatung' mit 'individuellem Ernährungsplan' — genau das, was Sandra sucht. Die anderen Anzeigen bieten keine Ernährungsberatung."
+            },
+            {
+              "id": "A1_m08_R2_q4",
+              "type": "matching",
+              "questionText": "Herr Weber braucht eine neue Brille. Er sucht einen Optiker in der Nähe.",
+              "matchingSources": [
+                {
+                  "id": "A1_m08_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m08_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m08_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m08_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m08_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m08_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m08_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m08_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "x",
+              "explanation": "Keine der acht Anzeigen ist von einem Optiker. Es gibt eine Apotheke (a), einen Arzt (b), Sportkurse (c), Ernährungsberatung (d), Kinderarzt (e), Massage (f), Zahnarzt (g) und Erste-Hilfe-Kurs (h) — aber keinen Optiker. Die Antwort ist x."
+            },
+            {
+              "id": "A1_m08_R2_q5",
+              "type": "matching",
+              "questionText": "Nina möchte einen Erste-Hilfe-Kurs besuchen. Sie braucht ihn für den Führerschein.",
+              "matchingSources": [
+                {
+                  "id": "A1_m08_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m08_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m08_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m08_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m08_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m08_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m08_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m08_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "h",
+              "explanation": "Anzeige h ist der 'Erste-Hilfe-Kurs', der explizit 'für Führerscheinbewerber' angeboten wird — ein direkter Treffer für Ninas Situation."
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Lesen Sie die fünf Texte. Zu jedem Text gibt es eine Aussage. Kreuzen Sie an: richtig oder falsch.",
+          "instructionsTranslation": "Read the five texts. There is one statement about each text. Cross: correct or incorrect.",
+          "texts": [
+            {
+              "id": "A1_m08_R3_notice1",
+              "type": "notice",
+              "content": "APOTHEKE GEÖFFNET\nMontag–Freitag: 8:00–19:00 Uhr\nSamstag: 9:00–14:00 Uhr\nNotdienst: Telefon 0421 / 11 22 33",
+              "source": "Schild an einer Apotheke"
+            },
+            {
+              "id": "A1_m08_R3_notice2",
+              "type": "notice",
+              "content": "BITTE BEACHTEN!\nIn diesem Wartezimmer gilt ein striktes Handyverbot.\nBitte schalten Sie Ihr Handy aus oder auf lautlos.\nVielen Dank für Ihr Verständnis.",
+              "source": "Aushang in einer Arztpraxis"
+            },
+            {
+              "id": "A1_m08_R3_notice3",
+              "type": "notice",
+              "content": "ACHTUNG: KÜHLPFLICHTIG!\nDiese Medikamente müssen im Kühlschrank aufbewahrt werden (2–8 °C).\nNicht einfrieren!\nNach dem Öffnen innerhalb von 28 Tagen verwenden.",
+              "source": "Aufkleber auf einer Medikamentenschachtel"
+            },
+            {
+              "id": "A1_m08_R3_notice4",
+              "type": "notice",
+              "content": "KRANKMELDUNG\nWenn Sie krank sind und nicht zur Arbeit können:\n1. Rufen Sie so früh wie möglich an.\n2. Bringen Sie ab dem 3. Krankheitstag ein Attest vom Arzt.",
+              "source": "Hinweisschild in einem Büro"
+            },
+            {
+              "id": "A1_m08_R3_notice5",
+              "type": "notice",
+              "content": "FITNESSKURS FÜR SENIOREN\nSanfte Bewegung für mehr Lebensfreude!\nJeden Mittwoch, 10:00–11:00 Uhr\nKosten: 5 € pro Stunde\nAnmeldung im Büro, Zimmer 3",
+              "source": "Aushang im Seniorenzentrum"
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m08_R3_q1",
+              "type": "true_false",
+              "questionText": "Die Apotheke ist samstags bis 14 Uhr geöffnet.",
+              "relatedTextId": "A1_m08_R3_notice1",
+              "correctAnswer": "richtig",
+              "explanation": "Das Schild zeigt klar: 'Samstag: 9:00–14:00 Uhr'. Die Aussage stimmt exakt überein."
+            },
+            {
+              "id": "A1_m08_R3_q2",
+              "type": "true_false",
+              "questionText": "Im Wartezimmer kann man telefonieren.",
+              "relatedTextId": "A1_m08_R3_notice2",
+              "correctAnswer": "falsch",
+              "explanation": "Der Aushang sagt 'striktes Handyverbot' — man soll das Handy ausschalten oder auf lautlos stellen. Telefonieren ist ausdrücklich verboten."
+            },
+            {
+              "id": "A1_m08_R3_q3",
+              "type": "true_false",
+              "questionText": "Man darf die Medikamente einfrieren.",
+              "relatedTextId": "A1_m08_R3_notice3",
+              "correctAnswer": "falsch",
+              "explanation": "Der Aufkleber sagt ausdrücklich 'Nicht einfrieren!' Einfrieren ist verboten — das Medikament muss bei 2–8 °C im Kühlschrank aufbewahrt werden."
+            },
+            {
+              "id": "A1_m08_R3_q4",
+              "type": "true_false",
+              "questionText": "Ab dem dritten Krankheitstag braucht man ein Attest vom Arzt.",
+              "relatedTextId": "A1_m08_R3_notice4",
+              "correctAnswer": "richtig",
+              "explanation": "Das Schild sagt: 'Bringen Sie ab dem 3. Krankheitstag ein Attest vom Arzt.' Das stimmt mit der Aussage überein."
+            },
+            {
+              "id": "A1_m08_R3_q5",
+              "type": "true_false",
+              "questionText": "Der Fitnesskurs für Senioren findet zweimal pro Woche statt.",
+              "relatedTextId": "A1_m08_R3_notice5",
+              "correctAnswer": "falsch",
+              "explanation": "Der Aushang sagt 'Jeden Mittwoch' — also einmal pro Woche, nicht zweimal. Die Aussage ist falsch."
+            }
+          ]
+        }
+      ]
+    },
+    "writing": {
+      "totalTimeMinutes": 20,
+      "tasks": [
+        {
+          "taskNumber": 1,
+          "type": "form_fill",
+          "instructions": "Sie möchten sich in einer neuen Arztpraxis anmelden. Füllen Sie das Anmeldeformular aus.",
+          "instructionsTranslation": "You would like to register at a new doctor's surgery. Fill in the registration form.",
+          "formFields": [
+            {
+              "label": "Vorname und Nachname",
+              "correctAnswer": "Anna Müller",
+              "hint": "Schreiben Sie Ihren vollständigen Namen (Vorname + Nachname)."
+            },
+            {
+              "label": "Geburtsdatum",
+              "correctAnswer": "12.05.1990",
+              "hint": "Format: TT.MM.JJJJ (z.B. 01.03.1985)"
+            },
+            {
+              "label": "Krankenkasse",
+              "correctAnswer": "AOK Bayern",
+              "hint": "Name Ihrer Krankenkasse (z.B. TK, AOK, Barmer)"
+            },
+            {
+              "label": "Telefonnummer",
+              "correctAnswer": "0176 / 12 34 56 78",
+              "hint": "Ihre Handynummer oder Festnetznummer"
+            },
+            {
+              "label": "Grund des Besuchs",
+              "correctAnswer": "Halsweh und Husten seit drei Tagen",
+              "hint": "Beschreiben Sie kurz Ihre Beschwerden (z.B. Fieber, Bauchschmerzen)."
+            }
+          ],
+          "sampleAnswer": "Vorname und Nachname: Anna Müller\nGeburtsdatum: 12.05.1990\nKrankenkasse: AOK Bayern\nTelefonnummer: 0176 / 12 34 56 78\nGrund des Besuchs: Halsweh und Husten seit drei Tagen",
+          "scoringCriteria": [
+            {
+              "criterion": "Vollständigkeit",
+              "maxPoints": 5,
+              "description": "Alle fünf Felder sind ausgefüllt. Pro fehlendem Feld wird ein Punkt abgezogen."
+            },
+            {
+              "criterion": "Korrektheit",
+              "maxPoints": 5,
+              "description": "Die Angaben sind sachlich korrekt und im richtigen Format (z.B. Datumsformat, vollständiger Name). Pro fehlerhaftem Feld wird ein Punkt abgezogen."
+            }
+          ]
+        },
+        {
+          "taskNumber": 2,
+          "type": "short_message",
+          "instructions": "Schreiben Sie eine kurze Nachricht an Ihren Freund Jonas. Schreiben Sie 30–40 Wörter. Schreiben Sie zu diesen drei Punkten:",
+          "instructionsTranslation": "Write a short message to your friend Jonas. Write 30–40 words. Write about these three points:",
+          "prompt": "Sie waren beim Arzt. Schreiben Sie Jonas eine Nachricht.\n\n• Was hat der Arzt gesagt?\n• Was sollen Sie tun?\n• Können Sie am Wochenende kommen?",
+          "promptTranslation": "You have been to the doctor. Write Jonas a message.\n\n• What did the doctor say?\n• What should you do?\n• Can you come at the weekend?",
+          "requiredPoints": [
+            "Was der Arzt gesagt hat",
+            "Was Sie tun sollen (Medikamente/Ruhe etc.)",
+            "Information über das Wochenende"
+          ],
+          "wordCountMin": 30,
+          "wordCountMax": 40,
+          "sampleAnswer": "Hallo Jonas,\n\nich war heute beim Arzt. Er sagt, ich habe eine Erkältung. Ich soll viel schlafen und Tee trinken. Am Wochenende kann ich leider nicht kommen — ich muss zu Hause bleiben.\n\nLiebe Grüße,\nMaria",
+          "scoringCriteria": [
+            {
+              "criterion": "Aufgabenerfüllung",
+              "maxPoints": 4,
+              "description": "Alle drei Punkte werden angesprochen: Krankheitsgrund, Dauer der Abwesenheit und Bitte an einen Kollegen. Pro fehlendem Punkt wird ein Punkt abgezogen."
+            },
+            {
+              "criterion": "Kommunikative Gestaltung",
+              "maxPoints": 4,
+              "description": "Die Nachricht hat eine Anrede und einen Abschluss. Der Text ist kohärent und verständlich. Einfache Verbindungswörter werden benutzt (leider, und, aber)."
+            },
+            {
+              "criterion": "Formale Richtigkeit",
+              "maxPoints": 4,
+              "description": "Grammatik, Wortschatz und Orthografie auf A1-Niveau sind weitgehend korrekt. Kleine Fehler, die das Verständnis nicht behindern, werden toleriert."
+            }
+          ]
+        }
+      ]
+    },
+    "speaking": {
+      "totalTimeMinutes": 15,
+      "prepTimeMinutes": 0,
+      "parts": [
+        {
+          "partNumber": 1,
+          "type": "introduce",
+          "instructions": "Stellen Sie sich vor. Sprechen Sie über: Name, Alter, Land, Wohnort, Sprachen, Beruf oder Schule, Hobby.",
+          "instructionsTranslation": "Introduce yourself. Talk about: name, age, country, place of residence, languages, job or school, hobby.",
+          "prompt": "Hallo! Stellen Sie sich bitte vor. Wie heißen Sie? Woher kommen Sie? Wo wohnen Sie? Was machen Sie? Was ist Ihr Hobby?",
+          "sampleResponse": "Hallo! Ich heiße Ana Rodrigues. Ich komme aus Portugal, aber ich wohne jetzt in München. Ich bin 28 Jahre alt. Ich arbeite als Krankenpflegerin in einem Krankenhaus. In meiner Freizeit mache ich gerne Sport — ich gehe laufen und schwimmen. Ich lerne auch Deutsch, weil ich hier leben möchte.",
+          "sampleAudioFile": "assets/audio/A1/mock08/speaking_part1_sample.mp3",
+          "evaluationTips": [
+            "Sprechen Sie alle sieben Punkte an: Name, Alter, Land, Wohnort, Sprachen, Beruf und Hobby.",
+            "Sprechen Sie in vollständigen Sätzen — nicht nur einzelne Wörter.",
+            "Nutzen Sie einfache Verben: heißen, kommen aus, wohnen in, arbeiten als, machen.",
+            "Wenn Sie ein Wort nicht wissen, beschreiben Sie es einfach auf Deutsch."
+          ],
+          "keyPhrases": [
+            "Ich heiße …",
+            "Ich komme aus …",
+            "Ich wohne in …",
+            "Ich bin … Jahre alt.",
+            "Ich arbeite als … / Ich bin … von Beruf.",
+            "Mein Hobby ist … / Ich mache gerne …"
+          ]
+        },
+        {
+          "partNumber": 2,
+          "type": "picture_cards",
+          "instructions": "Sie bekommen drei Karten mit Bildern. Sagen Sie, was Sie sehen. Was ist das? Was macht man damit? Wo kauft man das?",
+          "instructionsTranslation": "You receive three cards with pictures. Say what you see. What is it? What do you use it for? Where do you buy it?",
+          "prompt": "Schauen Sie auf die drei Bilder. Sagen Sie: Was sehen Sie? Was ist das? Was macht man damit?",
+          "promptImage": "assets/images/A1/mock08/speaking_part2_cards.png",
+          "sampleResponse": "Das erste Bild zeigt Tabletten. Man nimmt Tabletten, wenn man krank ist — zum Beispiel bei Fieber oder Kopfschmerzen. Man kauft sie in der Apotheke. Das zweite Bild zeigt ein Thermometer. Man benutzt ein Thermometer, um die Temperatur zu messen — wenn man Fieber hat. Das dritte Bild zeigt einen Arztkoffer. Den Arztkoffer hat der Arzt. Er bringt ihn mit, wenn er zum Patienten nach Hause kommt.",
+          "sampleAudioFile": "assets/audio/A1/mock08/speaking_part2_sample.mp3",
+          "evaluationTips": [
+            "Benennen Sie das Objekt auf jedem Bild direkt — 'Das ist ein/eine …'",
+            "Erklären Sie kurz, wozu man es benutzt — 'Man benutzt das für …' oder 'Das ist gut gegen …'",
+            "Nennen Sie den Artikel: die Tablette, das Thermometer, der Arztkoffer.",
+            "Sprechen Sie in kurzen, klaren Sätzen — komplizierte Sätze sind nicht nötig."
+          ],
+          "keyPhrases": [
+            "Das ist ein/eine …",
+            "Man benutzt das für …",
+            "Das kauft man in der Apotheke.",
+            "Das braucht man, wenn man krank ist.",
+            "Damit kann man … messen / nehmen / behandeln.",
+            "Das hat der Arzt / die Apothekerin."
+          ]
+        },
+        {
+          "partNumber": 3,
+          "type": "und_du",
+          "instructions": "Sie bekommen drei Themenkarten. Für jede Karte stellt Ihnen Ihr Partner / Ihre Partnerin eine Frage. Antworten Sie und fragen Sie zurück.",
+          "instructionsTranslation": "You receive three topic cards. For each card your partner asks you a question. Answer and ask back.",
+          "prompt": "Karte 1: GESUNDHEIT — Wie oft sind Sie krank?\nKarte 2: ARZT — Gehen Sie oft zum Arzt?\nKarte 3: ESSEN — Was essen Sie, wenn Sie krank sind?",
+          "sampleResponse": "Karte 1 — Gesundheit:\nPrüfer: 'Wie oft sind Sie krank?'\nKandidat: 'Ich bin etwa zwei- oder dreimal im Jahr krank — meistens im Winter. Ich bekomme dann Erkältungen oder Grippe. Und Sie? Sind Sie oft krank?'\nPrüfer: 'Nein, ich bin selten krank.'\n\nKarte 2 — Arzt:\nPrüfer: 'Gehen Sie oft zum Arzt?'\nKandidat: 'Nicht so oft — nur wenn ich wirklich krank bin. Einmal im Jahr gehe ich zur Vorsorgeuntersuchung. Und Sie? Haben Sie einen Hausarzt hier?'\nPrüfer: 'Ja, ich gehe einmal im Jahr zum Check-up.'\n\nKarte 3 — Essen:\nPrüfer: 'Was essen Sie, wenn Sie krank sind?'\nKandidat: 'Wenn ich krank bin, esse ich Hühnersuppe — meine Mutter sagt, das hilft. Ich trinke auch viel Tee mit Honig. Und Sie? Was essen Sie, wenn Sie krank sind?'\nPrüfer: 'Ich esse auch Suppe und trinke viel Wasser.'",
+          "sampleAudioFile": "assets/audio/A1/mock08/speaking_part3_sample.mp3",
+          "evaluationTips": [
+            "Antworten Sie in vollständigen Sätzen — mindestens zwei bis drei Sätze pro Karte.",
+            "Fragen Sie immer zurück — das zeigt kommunikative Kompetenz und ist Teil der Aufgabe.",
+            "Benutzen Sie einfache Zeitangaben: oft, manchmal, selten, einmal im Jahr, im Winter.",
+            "Wenn Sie das Wort nicht kennen, beschreiben Sie die Situation: 'Ich bin krank — Kopf tut weh, Nase läuft.'"
+          ],
+          "keyPhrases": [
+            "Ich bin … (oft / manchmal / selten) krank.",
+            "Ich gehe zum Arzt, wenn … / nur wenn …",
+            "Einmal im Jahr gehe ich zur Vorsorge.",
+            "Wenn ich krank bin, esse / trinke ich …",
+            "Und Sie? / Und du?",
+            "Das hilft mir / Das ist gut gegen …"
+          ]
+        }
+      ]
+    }
   }
 }

--- a/assets/content/A1/mock_09.json
+++ b/assets/content/A1/mock_09.json
@@ -2,12 +2,714 @@
   "id": "A1_mock_09",
   "level": "A1",
   "title": "Übungstest 9",
-  "version": 0,
-  "_stub": true,
+  "version": 1,
   "sections": {
-    "listening": { "totalTimeMinutes": 20, "parts": [] },
-    "reading": { "totalTimeMinutes": 25, "parts": [] },
-    "writing": { "totalTimeMinutes": 20, "tasks": [] },
-    "speaking": { "totalTimeMinutes": 15, "prepTimeMinutes": 0, "parts": [] }
+    "listening": {
+      "totalTimeMinutes": 20,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Sie hören drei kurze Texte. Zu jedem Text gibt es eine Aufgabe. Welches Bild passt? Kreuzen Sie an: a, b oder c. Sie hören jeden Text zweimal.",
+          "instructionsTranslation": "You will hear three short recordings. For each recording there is one task. Which picture matches? Mark: a, b, or c. You will hear each recording twice.",
+          "audioFile": "assets/audio/A1/mock09/listening_part1.mp3",
+          "playCount": 2,
+          "questions": [
+            {
+              "id": "A1_m09_L1_q1",
+              "type": "mcq",
+              "questionText": "Wohin fährt der nächste Zug?",
+              "questionImage": "assets/images/A1/mock09/L1_q1.png",
+              "options": [
+                "a) nach Berlin",
+                "b) nach München",
+                "c) nach Hamburg"
+              ],
+              "correctAnswer": "b",
+              "explanation": "Die Durchsage am Bahnhof sagt: 'Achtung auf Gleis 3. Der Intercity 582 fährt jetzt ab — Fahrziel München Hauptbahnhof.' Der Zug fährt nach München. Berlin und Hamburg werden in dieser Durchsage nicht erwähnt.",
+              "audioTimestamp": 6
+            },
+            {
+              "id": "A1_m09_L1_q2",
+              "type": "mcq",
+              "questionText": "Was kauft Herr Patel am Schalter?",
+              "questionImage": "assets/images/A1/mock09/L1_q2.png",
+              "options": [
+                "a) eine Monatskarte",
+                "b) eine Einzelfahrkarte",
+                "c) eine Tageskarte"
+              ],
+              "correctAnswer": "c",
+              "explanation": "Im Gespräch am Fahrkartenschalter fragt der Mitarbeiter: 'Einzel- oder Tageskarte?' und Herr Patel antwortet: 'Eine Tageskarte, bitte — ich fahre heute mehrmals.' Er kauft also eine Tageskarte. Eine Monatskarte oder Einzelfahrkarte kauft er nicht.",
+              "audioTimestamp": 9
+            },
+            {
+              "id": "A1_m09_L1_q3",
+              "type": "mcq",
+              "questionText": "Von welchem Steig fährt der Bus ab?",
+              "questionImage": "assets/images/A1/mock09/L1_q3.png",
+              "options": [
+                "a) von Steig 2",
+                "b) von Steig 5",
+                "c) von Steig 7"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Die Ansage im Busbahnhof sagt: 'Der Bus Linie 38 nach Flughafen fährt heute von Steig 2 ab — bitte beachten Sie die Änderung.' Der Bus fährt von Steig 2. Steig 5 und Steig 7 werden nicht für diesen Bus genannt.",
+              "audioTimestamp": 11
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Sie hören fünf kurze Texte. Zu jedem Text gibt es eine Aufgabe. Kreuzen Sie an: richtig oder falsch. Sie hören jeden Text zweimal.",
+          "instructionsTranslation": "You will hear five short recordings. For each recording there is one task. Mark: correct or incorrect. You will hear each recording twice.",
+          "audioFile": "assets/audio/A1/mock09/listening_part2.mp3",
+          "playCount": 2,
+          "questions": [
+            {
+              "id": "A1_m09_L2_q1",
+              "type": "true_false",
+              "questionText": "Das Hotel liegt direkt am Bahnhof.",
+              "correctAnswer": "richtig",
+              "explanation": "Im Telefonat sagt die Rezeptionistin: 'Unser Hotel ist sehr leicht zu finden — wir liegen direkt neben dem Hauptbahnhof, Ausgang Süd.' Das Hotel liegt also direkt am Bahnhof. Die Aussage ist richtig.",
+              "audioTimestamp": 7
+            },
+            {
+              "id": "A1_m09_L2_q2",
+              "type": "true_false",
+              "questionText": "Der Flug nach Wien startet pünktlich.",
+              "correctAnswer": "falsch",
+              "explanation": "Die Durchsage am Flughafen sagt: 'Achtung für Passagiere des Fluges OS 231 nach Wien — dieser Flug verspätet sich um 45 Minuten. Der neue Abflug ist um 16:15 Uhr.' Der Flug startet also nicht pünktlich. Die Aussage ist falsch.",
+              "audioTimestamp": 5
+            },
+            {
+              "id": "A1_m09_L2_q3",
+              "type": "true_false",
+              "questionText": "Die Touristeninformation ist am Samstag geöffnet.",
+              "correctAnswer": "richtig",
+              "explanation": "Die Nachricht auf dem Anrufbeantworter der Touristeninformation sagt: 'Unsere Öffnungszeiten: Montag bis Freitag 9 bis 18 Uhr, Samstag 10 bis 14 Uhr.' Am Samstag ist die Touristeninformation von 10 bis 14 Uhr geöffnet. Die Aussage ist richtig.",
+              "audioTimestamp": 9
+            },
+            {
+              "id": "A1_m09_L2_q4",
+              "type": "true_false",
+              "questionText": "Das Taxi kostet mehr als 20 Euro.",
+              "correctAnswer": "falsch",
+              "explanation": "Im Gespräch mit dem Taxifahrer sagt er: 'Das macht 17 Euro 50, bitte.' Die Fahrt kostet 17,50 Euro — also weniger als 20 Euro. Die Aussage ist falsch.",
+              "audioTimestamp": 6
+            },
+            {
+              "id": "A1_m09_L2_q5",
+              "type": "true_false",
+              "questionText": "Man braucht für die U-Bahn kein Ticket.",
+              "correctAnswer": "falsch",
+              "explanation": "Der Kontrolleur sagt: 'Bitte zeigen Sie mir Ihr Ticket.' Die Frau antwortet: 'Oh, ich habe vergessen, ein Ticket zu kaufen.' In der U-Bahn braucht man also ein Ticket. Die Aussage ist falsch.",
+              "audioTimestamp": 8
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Sie hören drei Gespräche. Zu jedem Gespräch gibt es eine Aufgabe. Was ist richtig? Kreuzen Sie an: a, b oder c. Sie hören jeden Text einmal.",
+          "instructionsTranslation": "You will hear three short conversations. For each conversation there is one task. What is correct? Mark: a, b, or c. You will hear each recording once.",
+          "audioFile": "assets/audio/A1/mock09/listening_part3.mp3",
+          "playCount": 1,
+          "questions": [
+            {
+              "id": "A1_m09_L3_q1",
+              "type": "mcq",
+              "questionText": "Wann kommt Anna in Frankfurt an?",
+              "options": [
+                "a) um 13:20 Uhr",
+                "b) um 14:05 Uhr",
+                "c) um 15:30 Uhr"
+              ],
+              "correctAnswer": "b",
+              "explanation": "Im Gespräch sagt Anna zu ihrer Mutter: 'Mein Zug kommt um 14:05 Uhr in Frankfurt an.' Die Mutter fragt: 'Also um fünf nach zwei?' und Anna bestätigt. 13:20 Uhr ist die Abfahrtszeit in Berlin, 15:30 Uhr wurde nicht genannt.",
+              "audioTimestamp": 12
+            },
+            {
+              "id": "A1_m09_L3_q2",
+              "type": "mcq",
+              "questionText": "Wie kommt Herr Weber zum Flughafen?",
+              "options": [
+                "a) mit dem Taxi",
+                "b) mit dem Bus",
+                "c) mit der S-Bahn"
+              ],
+              "correctAnswer": "c",
+              "explanation": "Im Gespräch mit dem Kollegen sagt Herr Weber: 'Ich nehme die S-Bahn — sie fährt direkt vom Hauptbahnhof zum Terminal 1, ohne Umsteigen.' Das Taxi war sein erster Gedanke, aber er entscheidet sich für die S-Bahn. Der Bus wird nicht erwähnt.",
+              "audioTimestamp": 15
+            },
+            {
+              "id": "A1_m09_L3_q3",
+              "type": "mcq",
+              "questionText": "Was möchte die Frau im Hotel?",
+              "options": [
+                "a) ein Zimmer für zwei Nächte",
+                "b) ein Zimmer für eine Nacht",
+                "c) ein Zimmer für drei Nächte"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Im Gespräch an der Hotelrezeption sagt die Frau: 'Ich möchte ein Zimmer reservieren, bitte — von Freitag bis Sonntag, also zwei Nächte.' Der Rezeptionist bestätigt: 'Zwei Nächte, sehr gern.' Eine oder drei Nächte werden nicht gebucht.",
+              "audioTimestamp": 10
+            }
+          ]
+        }
+      ]
+    },
+    "reading": {
+      "totalTimeMinutes": 25,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Lesen Sie die zwei Texte. Zu den Texten gibt es fünf Aufgaben. Kreuzen Sie an: richtig oder falsch.",
+          "instructionsTranslation": "Read the two texts. There are five tasks about the texts. Mark: correct or incorrect.",
+          "texts": [
+            {
+              "id": "A1_m09_R1_text1",
+              "type": "email",
+              "content": "Von: petra.hoffmann@email.de\nAn: lukas.braun@email.de\nBetreff: Unser Ausflug nach Köln\n\nHallo Lukas,\n\nich freue mich schon auf unseren Ausflug nach Köln! Ich habe die Zugtickets schon gekauft. Wir fahren am Samstag, den 22. April, um 9:15 Uhr vom Berliner Hauptbahnhof ab. In Köln kommen wir um 12:40 Uhr an.\n\nDas Hotel heißt Stadthotel am Dom und liegt direkt neben dem Kölner Dom. Ich habe zwei Einzelzimmer reserviert — sie kosten 65 Euro pro Nacht. Wir bleiben zwei Nächte.\n\nBitte bring deinen Reisepass oder Personalausweis mit — man braucht ihn für das Hotel.\n\nBis Samstag!\nPetra",
+              "source": "Persönliche E-Mail"
+            },
+            {
+              "id": "A1_m09_R1_text2",
+              "type": "notice",
+              "content": "BAHNHOF INFORMATION — KÖLN HAUPTBAHNHOF\n\nWillkommen in Köln!\n\nLinien in der Nähe:\n• U-Bahn: Linien 1, 7, 9 — Haltestelle Dom/Hauptbahnhof\n• Bus: Linie 132 zum Flughafen Köln/Bonn (ca. 30 Minuten)\n\nGepäckaufbewahrung: Öffnungszeiten 6:00 – 22:00 Uhr\nTouristinformation: Erdgeschoss, Ausgang West\nFahrradverleih: Vor dem Haupteingang",
+              "source": "Informationstafel Köln Hauptbahnhof"
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m09_R1_q1",
+              "type": "true_false",
+              "questionText": "Petra und Lukas fahren am Samstag nach Köln.",
+              "relatedTextId": "A1_m09_R1_text1",
+              "correctAnswer": "richtig",
+              "explanation": "In der E-Mail schreibt Petra: 'Wir fahren am Samstag, den 22. April, um 9:15 Uhr vom Berliner Hauptbahnhof ab.' Die Fahrt ist also am Samstag. Die Aussage ist richtig."
+            },
+            {
+              "id": "A1_m09_R1_q2",
+              "type": "true_false",
+              "questionText": "Das Hotelzimmer kostet 65 Euro pro Nacht.",
+              "relatedTextId": "A1_m09_R1_text1",
+              "correctAnswer": "richtig",
+              "explanation": "Petra schreibt: 'Ich habe zwei Einzelzimmer reserviert — sie kosten 65 Euro pro Nacht.' Der Preis pro Zimmer und Nacht beträgt 65 Euro. Die Aussage ist richtig."
+            },
+            {
+              "id": "A1_m09_R1_q3",
+              "type": "true_false",
+              "questionText": "Lukas soll seinen Personalausweis zu Hause lassen.",
+              "relatedTextId": "A1_m09_R1_text1",
+              "correctAnswer": "falsch",
+              "explanation": "Petra schreibt das Gegenteil: 'Bitte bring deinen Reisepass oder Personalausweis mit — man braucht ihn für das Hotel.' Lukas soll das Dokument mitbringen, nicht zu Hause lassen. Die Aussage ist falsch."
+            },
+            {
+              "id": "A1_m09_R1_q4",
+              "type": "true_false",
+              "questionText": "Die Gepäckaufbewahrung am Kölner Hauptbahnhof ist rund um die Uhr geöffnet.",
+              "relatedTextId": "A1_m09_R1_text2",
+              "correctAnswer": "falsch",
+              "explanation": "Das Informationsschild sagt: 'Gepäckaufbewahrung: Öffnungszeiten 6:00 – 22:00 Uhr.' Die Gepäckaufbewahrung ist nur von 6 bis 22 Uhr geöffnet, nicht 24 Stunden. Die Aussage ist falsch."
+            },
+            {
+              "id": "A1_m09_R1_q5",
+              "type": "true_false",
+              "questionText": "Man kann am Kölner Hauptbahnhof ein Fahrrad ausleihen.",
+              "relatedTextId": "A1_m09_R1_text2",
+              "correctAnswer": "richtig",
+              "explanation": "Das Informationsschild am Bahnhof sagt: 'Fahrradverleih: Vor dem Haupteingang.' Man kann also am Bahnhof ein Fahrrad mieten. Die Aussage ist richtig."
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Lesen Sie die Anzeigen a–h und die Situationen 1–5. Welche Anzeige passt zu welcher Situation? Für eine Situation gibt es keine passende Anzeige. Schreiben Sie den richtigen Buchstaben (a–h).",
+          "instructionsTranslation": "Read the advertisements a–h and situations 1–5. Which advertisement matches which situation? For one situation there is no matching advertisement. Write the correct letter (a–h).",
+          "texts": [
+            {
+              "id": "A1_m09_R2_ad_a",
+              "type": "ad",
+              "content": "REISEBUS MÜNCHEN–WIEN\nTäglich 8:00 und 14:00 Uhr\nEinfache Fahrt: 29 €\nHin- und Rückfahrt: 49 €\nOnline buchen: busreise-mv.de"
+            },
+            {
+              "id": "A1_m09_R2_ad_b",
+              "type": "ad",
+              "content": "HOTEL GARNI SEEBLICK\nZimmer ab 55 € / Nacht\nFrühstück inklusive\nParkplatz kostenlos\nTel.: 08821 / 44 77 00\nwww.hotel-seeblick.de"
+            },
+            {
+              "id": "A1_m09_R2_ad_c",
+              "type": "ad",
+              "content": "TOURISTINFORMATION HEIDELBERG\nStadtrundgänge täglich 10 und 14 Uhr\nKarten und Broschüren kostenlos\nMarkusplatz 3, Mo–Sa 9–18 Uhr\ninfo@heidelberg-tourismus.de"
+            },
+            {
+              "id": "A1_m09_R2_ad_d",
+              "type": "ad",
+              "content": "TAXI SCHNELL & GÜNSTIG\n24 Stunden, 7 Tage die Woche\nFlughafen-Transfer ab 28 €\nGruppen-Taxen verfügbar\nRuf an: 0800 / 111 22 33"
+            },
+            {
+              "id": "A1_m09_R2_ad_e",
+              "type": "ad",
+              "content": "FAHRRADVERLEIH STADTMITTE\nStadträder und E-Bikes\nAb 8 € pro Tag\nHelmverleih kostenlos\nHauptstraße 14, täglich 8–20 Uhr"
+            },
+            {
+              "id": "A1_m09_R2_ad_f",
+              "type": "ad",
+              "content": "AUTOVERMIETUNG KAISER\nKleinwagen ab 39 € / Tag\nKeine Kilometerkosten\nFührerschein + Kreditkarte nötig\nFlughafenterminal 2, Ankunftshalle"
+            },
+            {
+              "id": "A1_m09_R2_ad_g",
+              "type": "ad",
+              "content": "GEPÄCKSERVICE REISEKLAR\nKofferaufbewahrung und -transport\nAbholung vom Hotel möglich\nGeöffnet 6:00–22:00 Uhr\nBahnhof Südseite, Raum 12"
+            },
+            {
+              "id": "A1_m09_R2_ad_h",
+              "type": "ad",
+              "content": "STADTFÜHRUNG PER BOOT\nRheinrundfahrt — 90 Minuten\nAbfahrt täglich 11:00 und 15:00 Uhr\nErwachsene 14 €, Kinder 7 €\nAnlegestelle am Alten Hafen"
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m09_R2_q1",
+              "type": "matching",
+              "questionText": "Frau Kim ist Touristin in Heidelberg und möchte Informationen über die Stadt und kostenlose Stadtpläne.",
+              "matchingSources": [
+                {
+                  "id": "A1_m09_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m09_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m09_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m09_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m09_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m09_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m09_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m09_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "c",
+              "explanation": "Anzeige c ist die Touristinformation Heidelberg. Sie bietet Karten und Broschüren kostenlos an und ist Montag bis Samstag geöffnet. Das passt genau zu Frau Kims Wunsch nach Stadtinformationen und kostenlosen Stadtplänen."
+            },
+            {
+              "id": "A1_m09_R2_q2",
+              "type": "matching",
+              "questionText": "Familie Bauer braucht nachts um 23 Uhr ein Fahrzeug zum Flughafen. Sie haben kein Auto.",
+              "matchingSources": [
+                {
+                  "id": "A1_m09_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m09_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m09_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m09_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m09_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m09_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m09_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m09_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "d",
+              "explanation": "Anzeige d ist der Taxidienst, der 24 Stunden an 7 Tagen die Woche verfügbar ist und Flughafen-Transfer anbietet. Der Bus (a) fährt nur tagsüber. Das Taxi ist die einzige Option, die nachts und zum Flughafen fährt."
+            },
+            {
+              "id": "A1_m09_R2_q3",
+              "type": "matching",
+              "questionText": "Herr Schulz möchte von München nach Wien fahren. Er sucht eine günstige Busverbindung.",
+              "matchingSources": [
+                {
+                  "id": "A1_m09_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m09_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m09_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m09_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m09_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m09_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m09_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m09_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "a",
+              "explanation": "Anzeige a ist der Reisebus München–Wien, der täglich zweimal fährt und eine einfache Fahrt für 29 Euro anbietet. Das ist eine günstige Busverbindung genau für diese Strecke. Das passt perfekt zu Herrn Schulz."
+            },
+            {
+              "id": "A1_m09_R2_q4",
+              "type": "matching",
+              "questionText": "Lena möchte ihre Koffer nicht mit ins Museum nehmen. Sie sucht jemanden, der sie kurz aufbewahrt.",
+              "matchingSources": [
+                {
+                  "id": "A1_m09_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m09_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m09_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m09_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m09_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m09_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m09_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m09_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "g",
+              "explanation": "Anzeige g ist der Gepäckservice Reiseklar mit Kofferaufbewahrung, geöffnet von 6 bis 22 Uhr am Bahnhof. Das ist genau das, was Lena braucht — jemanden, der ihre Koffer kurz aufbewahrt, während sie ins Museum geht."
+            },
+            {
+              "id": "A1_m09_R2_q5",
+              "type": "matching",
+              "questionText": "Tobias möchte sein altes Fahrrad verkaufen. Er sucht einen Käufer.",
+              "matchingSources": [
+                {
+                  "id": "A1_m09_R2_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "A1_m09_R2_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "A1_m09_R2_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "A1_m09_R2_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "A1_m09_R2_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "A1_m09_R2_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "A1_m09_R2_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "A1_m09_R2_ad_h",
+                  "label": "h"
+                }
+              ],
+              "correctAnswer": "x",
+              "explanation": "Keine der acht Anzeigen bietet den Ankauf von Fahrrädern oder einen Verkaufsmarkt an. Anzeige e ist ein Fahrradverleih (Leihservice), kein Ankauf. Die Antwort ist x."
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Lesen Sie die Texte und die Aufgaben 1–5. Kreuzen Sie an: richtig oder falsch.",
+          "instructionsTranslation": "Read the texts and tasks 1–5. Mark: correct or incorrect.",
+          "texts": [
+            {
+              "id": "A1_m09_R3_notice1",
+              "type": "notice",
+              "content": "BAHNSTEIG 6 GESPERRT\nUmbauarbeiten bis 30. Juni.\nBitte benutzen Sie Bahnsteig 7.\nIhr Zug fährt planmäßig."
+            },
+            {
+              "id": "A1_m09_R3_notice2",
+              "type": "notice",
+              "content": "FLUGHAFEN-EXPRESS\nAbfahrt: Jede 20 Minuten\nReisezeit: ca. 25 Minuten\nTicket: 4,20 € (Einzelfahrt)\nKeine Reservierung nötig."
+            },
+            {
+              "id": "A1_m09_R3_notice3",
+              "type": "notice",
+              "content": "ACHTUNG!\nFahrräder im Bus nur außerhalb der Hauptverkehrszeiten erlaubt.\nHauptverkehrszeiten: Mo–Fr 7:00–9:00 und 16:00–18:30 Uhr"
+            },
+            {
+              "id": "A1_m09_R3_notice4",
+              "type": "notice",
+              "content": "HOTEL-SHUTTLE\nKostenloser Transfer vom Flughafen zum Hotel\nAbfahrt: 9:00, 12:00, 15:00, 18:00 Uhr\nAnmeldung an der Rezeption oder unter: 0511 / 882 30 00"
+            },
+            {
+              "id": "A1_m09_R3_notice5",
+              "type": "notice",
+              "content": "GEPÄCK AUFGEBEN\nMax. 2 Koffer pro Person\nMax. 23 kg pro Koffer\nHandgepäck: max. 8 kg\nBitte 90 Minuten vor Abflug am Schalter sein."
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m09_R3_q1",
+              "type": "true_false",
+              "questionText": "Züge fahren auch während der Umbauarbeiten ab.",
+              "relatedTextId": "A1_m09_R3_notice1",
+              "correctAnswer": "richtig",
+              "explanation": "Das Schild sagt: 'Bitte benutzen Sie Bahnsteig 7. Ihr Zug fährt planmäßig.' Die Züge fahren weiterhin ab — nur von einem anderen Bahnsteig. Die Aussage ist richtig."
+            },
+            {
+              "id": "A1_m09_R3_q2",
+              "type": "true_false",
+              "questionText": "Man muss einen Platz im Flughafen-Express reservieren.",
+              "relatedTextId": "A1_m09_R3_notice2",
+              "correctAnswer": "falsch",
+              "explanation": "Das Schild sagt ausdrücklich: 'Keine Reservierung nötig.' Man kann einfach einsteigen und ein Ticket kaufen. Eine Reservierung ist nicht erforderlich. Die Aussage ist falsch."
+            },
+            {
+              "id": "A1_m09_R3_q3",
+              "type": "true_false",
+              "questionText": "Man kann samstags um 8 Uhr morgens sein Fahrrad in den Bus mitnehmen.",
+              "relatedTextId": "A1_m09_R3_notice3",
+              "correctAnswer": "richtig",
+              "explanation": "Das Schild zeigt, dass Fahrräder außerhalb der Hauptverkehrszeiten erlaubt sind. Die Hauptverkehrszeiten gelten nur Montag bis Freitag (Mo–Fr). Samstag ist kein Werktag, daher gilt die Einschränkung samstags nicht. Das Fahrrad ist erlaubt. Die Aussage ist richtig."
+            },
+            {
+              "id": "A1_m09_R3_q4",
+              "type": "true_false",
+              "questionText": "Der Hotel-Shuttle kostet Geld.",
+              "relatedTextId": "A1_m09_R3_notice4",
+              "correctAnswer": "falsch",
+              "explanation": "Das Schild sagt: 'Kostenloser Transfer vom Flughafen zum Hotel.' Der Shuttle-Service ist kostenlos. Die Aussage ist falsch."
+            },
+            {
+              "id": "A1_m09_R3_q5",
+              "type": "true_false",
+              "questionText": "Ein Koffer darf mehr als 23 Kilogramm wiegen.",
+              "relatedTextId": "A1_m09_R3_notice5",
+              "correctAnswer": "falsch",
+              "explanation": "Das Schild sagt: 'Max. 23 kg pro Koffer.' Das Maximum sind 23 Kilogramm — mehr ist nicht erlaubt. Ein Koffer darf also nicht mehr als 23 kg wiegen. Die Aussage ist falsch."
+            }
+          ]
+        }
+      ]
+    },
+    "writing": {
+      "totalTimeMinutes": 20,
+      "tasks": [
+        {
+          "taskNumber": 1,
+          "type": "form_fill",
+          "instructions": "Herr Ibrahim möchte ein Hotelzimmer reservieren. Lesen Sie das Formular und füllen Sie die fünf Lücken aus. Benutzen Sie die Informationen unten.\n\nAngaben: Vorname: Karim | Nachname: Ibrahim | Anreise: 15. Mai | Abreise: 18. Mai | Zimmerwunsch: Einzelzimmer, Nichtraucher | Telefon: 0162 / 778 44 55",
+          "instructionsTranslation": "Mr Ibrahim wants to reserve a hotel room. Read the form and fill in the five gaps using the information below.\n\nDetails: First name: Karim | Surname: Ibrahim | Arrival: 15 May | Departure: 18 May | Room preference: single room, non-smoking | Phone: 0162 / 778 44 55",
+          "formFields": [
+            {
+              "label": "Vorname",
+              "correctAnswer": "Karim",
+              "hint": "Erster Vorname des Gastes"
+            },
+            {
+              "label": "Nachname",
+              "correctAnswer": "Ibrahim",
+              "hint": "Familienname des Gastes"
+            },
+            {
+              "label": "Anreisedatum",
+              "correctAnswer": "15. Mai",
+              "hint": "Wann kommt der Gast an?"
+            },
+            {
+              "label": "Abreisedatum",
+              "correctAnswer": "18. Mai",
+              "hint": "Wann reist der Gast ab?"
+            },
+            {
+              "label": "Zimmerwunsch",
+              "correctAnswer": "Einzelzimmer, Nichtraucher",
+              "hint": "Welche Art Zimmer möchte der Gast?"
+            }
+          ],
+          "sampleAnswer": "Vorname: Karim\nNachname: Ibrahim\nAnreisedatum: 15. Mai\nAbreisedatum: 18. Mai\nZimmerwunsch: Einzelzimmer, Nichtraucher",
+          "scoringCriteria": [
+            {
+              "criterion": "Vollständigkeit",
+              "maxPoints": 5,
+              "description": "Alle fünf Felder sind ausgefüllt. Pro korrekt ausgefülltem Feld einen Punkt."
+            },
+            {
+              "criterion": "Korrektheit",
+              "maxPoints": 5,
+              "description": "Die Informationen entsprechen den Angaben aus der Aufgabenstellung. Daten sind plausibel und vollständig (Tag + Monat), der Zimmerwunsch ist klar benannt."
+            }
+          ]
+        },
+        {
+          "taskNumber": 2,
+          "type": "short_message",
+          "instructions": "Schreiben Sie eine kurze Nachricht an Ihre Freundin Sara. Schreiben Sie 30–40 Wörter. Schreiben Sie zu diesen drei Punkten:",
+          "instructionsTranslation": "Write a short message to your friend Sara. Write 30–40 words. Write about these three points:",
+          "prompt": "Schreiben Sie Sara eine Nachricht.\n\n• Wohin fahren Sie?\n• Wie fahren Sie dorthin?\n• Wann kommen Sie an?",
+          "promptTranslation": "Write Sara a message.\n\n• Where are you travelling to?\n• How are you travelling there?\n• When do you arrive?",
+          "requiredPoints": [
+            "Reiseziel — wohin fahren Sie?",
+            "Verkehrsmittel — wie fahren Sie? (z.B. Zug, Bus, Auto, Flugzeug)",
+            "Ankunftszeit — wann kommen Sie an?"
+          ],
+          "wordCountMin": 30,
+          "wordCountMax": 40,
+          "sampleAnswer": "Hallo Sara,\n\nIch fahre am Donnerstag nach Hamburg! Ich nehme den Zug um 10:30 Uhr vom Kölner Hauptbahnhof. Ich komme um 14:05 Uhr in Hamburg an. Können wir uns am Bahnhof treffen?\n\nLiebe Grüße,\nMaria",
+          "scoringCriteria": [
+            {
+              "criterion": "Aufgabenerfüllung",
+              "maxPoints": 4,
+              "description": "Alle drei Inhaltspunkte (Reiseziel, Verkehrsmittel, Ankunftszeit) sind angesprochen. Je vollständiger und klarer, desto mehr Punkte."
+            },
+            {
+              "criterion": "Kommunikative Gestaltung",
+              "maxPoints": 4,
+              "description": "Die Nachricht hat eine Anrede (z.B. 'Hallo Sara') und einen Abschluss (z.B. 'Liebe Grüße'). Der Text ist verständlich und fließt zusammen."
+            },
+            {
+              "criterion": "Formale Richtigkeit",
+              "maxPoints": 4,
+              "description": "Auf A1-Niveau werden einfache Fehler toleriert, solange der Text verständlich bleibt. Grundlegende Satzstruktur (Subjekt + Verb + Objekt) soll erkennbar sein."
+            }
+          ]
+        }
+      ]
+    },
+    "speaking": {
+      "totalTimeMinutes": 15,
+      "prepTimeMinutes": 0,
+      "parts": [
+        {
+          "partNumber": 1,
+          "type": "introduce",
+          "instructions": "Stellen Sie sich vor. Sagen Sie etwas über: Name, Alter, Herkunft, Beruf oder Hobby.",
+          "instructionsTranslation": "Introduce yourself. Say something about: name, age, where you are from, job or hobby.",
+          "prompt": "Guten Tag, mein Name ist ... Ich komme aus ... Ich bin ... Jahre alt. Ich arbeite als ... / Mein Hobby ist ...",
+          "sampleResponse": "Guten Tag, mein Name ist Yuna Park. Ich komme aus Südkorea, aus Seoul. Ich bin 26 Jahre alt. Ich studiere Architektur hier in Deutschland. In meiner Freizeit reise ich sehr gern — ich war schon in zehn europäischen Ländern.",
+          "sampleAudioFile": "assets/audio/A1/mock09/speaking_part1_sample.mp3",
+          "evaluationTips": [
+            "Nennen Sie alle vier Punkte: Name, Alter, Herkunft und Beruf oder Hobby. Fehlende Punkte reduzieren die Bewertung.",
+            "Sprechen Sie in vollständigen Sätzen — 'Ich heiße Yuna' ist besser als nur Ihren Namen zu sagen.",
+            "Kleine Grammatikfehler auf A1-Niveau sind normal. Verständlichkeit zählt mehr als Fehlerfreiheit.",
+            "Schauen Sie den Prüfer an und sprechen Sie laut und deutlich."
+          ],
+          "keyPhrases": [
+            "Mein Name ist ... / Ich heiße ...",
+            "Ich komme aus ...",
+            "Ich bin ... Jahre alt.",
+            "Ich studiere / arbeite als ...",
+            "Mein Hobby ist ...",
+            "In meiner Freizeit reise ich gern."
+          ]
+        },
+        {
+          "partNumber": 2,
+          "type": "picture_cards",
+          "instructions": "Sie bekommen eine Bildkarte. Sagen Sie das Wort auf Deutsch. Der Prüfer fragt dann: 'Haben Sie das auch?' oder 'Fahren Sie damit?' Antworten Sie mit Ja oder Nein und einem kurzen Satz.",
+          "instructionsTranslation": "You receive a picture card. Say the word in German. The examiner then asks: 'Do you have that too?' or 'Do you travel by that?' Answer with yes or no and a short sentence.",
+          "prompt": "Bildkarte 1: Ein Koffer\nBildkarte 2: Ein Zug\nBildkarte 3: Eine Karte / ein Stadtplan\n\nDer Prüfer fragt nach jeder Karte:\n'Haben Sie einen Koffer?' / 'Fahren Sie oft mit dem Zug?' / 'Haben Sie einen Stadtplan?'",
+          "promptImage": "assets/images/A1/mock09/speaking_part2_cards.png",
+          "sampleResponse": "Karte 1: 'Das ist ein Koffer. Ja, ich habe einen Koffer. Er ist blau und sehr groß.'\nKarte 2: 'Das ist ein Zug. Ja, ich fahre oft mit dem Zug — ich habe eine Bahncard.'\nKarte 3: 'Das ist ein Stadtplan. Nein, ich habe keinen Stadtplan. Ich benutze mein Handy.'",
+          "sampleAudioFile": "assets/audio/A1/mock09/speaking_part2_sample.mp3",
+          "evaluationTips": [
+            "Nennen Sie das Objekt mit dem richtigen Artikel: 'Das ist ein Koffer.' Der Artikel ist ein wichtiger Teil des deutschen Nomens.",
+            "Antworten Sie auf die Prüferfrage mit einem vollständigen Satz, nicht nur 'Ja' oder 'Nein'.",
+            "Wenn Sie den genauen Artikel nicht wissen, sagen Sie trotzdem das Wort — eine Antwort ist besser als Schweigen.",
+            "Fügen Sie eine kurze Zusatzinformation hinzu ('Er ist neu.', 'Ich fahre oft damit.') — das zeigt sprachliche Initiative."
+          ],
+          "keyPhrases": [
+            "Das ist ein / eine ...",
+            "Ja, ich habe einen / eine / ein ...",
+            "Nein, ich habe keinen / keine / kein ...",
+            "Er / Sie / Es ist ...",
+            "Ich fahre oft mit dem Zug / Bus / Flugzeug.",
+            "Ich benutze mein Handy / die App."
+          ]
+        },
+        {
+          "partNumber": 3,
+          "type": "und_du",
+          "instructions": "Sie bekommen eine Wortkarte mit einem Thema. Stellen Sie dem Prüfer eine Frage zu diesem Thema. Der Prüfer antwortet und fragt dann: 'Und du?' Antworten Sie auch.",
+          "instructionsTranslation": "You receive a word card with a topic. Ask the examiner a question on this topic. The examiner answers and then asks: 'And you?' Answer too.",
+          "prompt": "Wortkarte 1: Urlaub\nWortkarte 2: Verkehr\nWortkarte 3: Lieblingsstadt\n\nFormulieren Sie für jede Karte eine Frage an den Prüfer.",
+          "sampleResponse": "Karte 1 — Urlaub:\nKandidat: 'Wohin fahren Sie im Urlaub?'\nPrüfer: 'Ich fahre dieses Jahr nach Spanien. Und du?'\nKandidat: 'Ich fahre nach Italien — nach Rom. Ich möchte das Kolosseum sehen.'\n\nKarte 2 — Verkehr:\nKandidat: 'Wie fahren Sie zur Arbeit?'\nPrüfer: 'Ich fahre mit der U-Bahn. Und du?'\nKandidat: 'Ich fahre mit dem Fahrrad. Es ist schnell und günstig.'\n\nKarte 3 — Lieblingsstadt:\nKandidat: 'Was ist Ihre Lieblingsstadt?'\nPrüfer: 'Meine Lieblingsstadt ist Wien. Und du?'\nKandidat: 'Meine Lieblingsstadt ist Barcelona — das Wetter ist warm und die Stadt ist sehr schön.'",
+          "sampleAudioFile": "assets/audio/A1/mock09/speaking_part3_sample.mp3",
+          "evaluationTips": [
+            "Lesen Sie das Thema auf der Karte und formulieren Sie eine W-Frage: 'Urlaub' wird zu 'Wohin fahren Sie im Urlaub?'",
+            "Wenn der Prüfer zurückfragt ('Und du?'), antworten Sie mit einem vollständigen Satz und gern mit einer kurzen Begründung.",
+            "Verwenden Sie 'Sie' (formell) für den Prüfer, solange nicht anders gesagt.",
+            "Es ist normal, kurz nachzudenken. 'Moment, bitte...' ist kein Fehler und wirkt ruhig und kompetent."
+          ],
+          "keyPhrases": [
+            "Wohin fahren Sie im Urlaub?",
+            "Wie kommen Sie zur Arbeit / zum Bahnhof?",
+            "Was ist Ihre Lieblingsstadt?",
+            "Ich fahre nach ... / Ich fliege nach ...",
+            "Ich fahre mit dem Zug / Bus / Fahrrad / Auto.",
+            "Meine Lieblingsstadt ist ..."
+          ]
+        }
+      ]
+    }
   }
 }

--- a/assets/content/A1/mock_10.json
+++ b/assets/content/A1/mock_10.json
@@ -2,12 +2,714 @@
   "id": "A1_mock_10",
   "level": "A1",
   "title": "Übungstest 10",
-  "version": 0,
-  "_stub": true,
+  "version": 1,
   "sections": {
-    "listening": { "totalTimeMinutes": 20, "parts": [] },
-    "reading": { "totalTimeMinutes": 25, "parts": [] },
-    "writing": { "totalTimeMinutes": 20, "tasks": [] },
-    "speaking": { "totalTimeMinutes": 15, "prepTimeMinutes": 0, "parts": [] }
+    "listening": {
+      "totalTimeMinutes": 20,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Sie hören drei kurze Texte. Zu jedem Text gibt es eine Aufgabe. Kreuzen Sie die richtige Antwort an: a, b oder c. Sie hören jeden Text zweimal.",
+          "instructionsTranslation": "You will hear three short texts. There is one task for each text. Mark the correct answer: a, b or c. You will hear each text twice.",
+          "audioFile": "assets/audio/A1/mock10/listening_part1.mp3",
+          "playCount": 2,
+          "questions": [
+            {
+              "id": "A1_m10_L1_q1",
+              "type": "mcq",
+              "questionText": "Was kauft die Frau im Supermarkt?",
+              "questionImage": "assets/images/A1/mock10/L1_q1.png",
+              "options": [
+                "a) Brot und Milch",
+                "b) Äpfel und Käse",
+                "c) Fleisch und Kartoffeln"
+              ],
+              "correctAnswer": "b",
+              "explanation": "Die Frau sagt im Dialog: 'Ich brauche Äpfel und Käse. Brot haben wir noch.' Sie kauft also Äpfel und Käse.",
+              "audioTimestamp": 18
+            },
+            {
+              "id": "A1_m10_L1_q2",
+              "type": "mcq",
+              "questionText": "Wie viel kostet das Kilo Tomaten?",
+              "questionImage": "assets/images/A1/mock10/L1_q2.png",
+              "options": [
+                "a) 1,20 Euro",
+                "b) 1,99 Euro",
+                "c) 2,50 Euro"
+              ],
+              "correctAnswer": "b",
+              "explanation": "Der Verkäufer sagt: 'Das Kilo Tomaten kostet heute ein Euro neunundneunzig.' Die richtige Antwort ist 1,99 Euro.",
+              "audioTimestamp": 42
+            },
+            {
+              "id": "A1_m10_L1_q3",
+              "type": "mcq",
+              "questionText": "Wo ist der Wochenmarkt?",
+              "questionImage": "assets/images/A1/mock10/L1_q3.png",
+              "options": [
+                "a) Vor dem Rathaus",
+                "b) Neben dem Bahnhof",
+                "c) Auf dem Marktplatz"
+              ],
+              "correctAnswer": "c",
+              "explanation": "In der Durchsage heißt es: 'Der Wochenmarkt findet jeden Samstag auf dem Marktplatz statt.' Die richtige Antwort ist also auf dem Marktplatz.",
+              "audioTimestamp": 67
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Sie hören einen Text. Lesen Sie die Aufgaben 1 bis 5. Kreuzen Sie an: richtig oder falsch. Sie hören den Text zweimal.",
+          "instructionsTranslation": "You will hear a text. Read tasks 1 to 5. Mark: correct or incorrect. You will hear the text twice.",
+          "audioFile": "assets/audio/A1/mock10/listening_part2.mp3",
+          "playCount": 2,
+          "questions": [
+            {
+              "id": "A1_m10_L2_q1",
+              "type": "true_false",
+              "questionText": "Die Wohnung hat zwei Schlafzimmer.",
+              "correctAnswer": "falsch",
+              "explanation": "Die Vermieterin sagt: 'Die Wohnung hat ein Schlafzimmer, ein Wohnzimmer, eine Küche und ein Bad.' Es gibt also nur ein Schlafzimmer.",
+              "audioTimestamp": 12
+            },
+            {
+              "id": "A1_m10_L2_q2",
+              "type": "true_false",
+              "questionText": "Die Miete kostet 650 Euro im Monat.",
+              "correctAnswer": "richtig",
+              "explanation": "Die Vermieterin erklärt: 'Die Kaltmiete beträgt sechshundertfünfzig Euro pro Monat.' Das sind 650 Euro — richtig.",
+              "audioTimestamp": 28
+            },
+            {
+              "id": "A1_m10_L2_q3",
+              "type": "true_false",
+              "questionText": "In der Wohnung gibt es eine Einbauküche.",
+              "correctAnswer": "richtig",
+              "explanation": "Die Vermieterin sagt ausdrücklich: 'Die Küche ist eine Einbauküche mit Herd und Kühlschrank.' Das ist richtig.",
+              "audioTimestamp": 41
+            },
+            {
+              "id": "A1_m10_L2_q4",
+              "type": "true_false",
+              "questionText": "Die Wohnung ist im dritten Stock.",
+              "correctAnswer": "falsch",
+              "explanation": "Die Vermieterin sagt: 'Die Wohnung liegt im zweiten Stock.' Sie ist also nicht im dritten, sondern im zweiten Stock.",
+              "audioTimestamp": 55
+            },
+            {
+              "id": "A1_m10_L2_q5",
+              "type": "true_false",
+              "questionText": "Es gibt einen Parkplatz für das Auto.",
+              "correctAnswer": "richtig",
+              "explanation": "Am Ende sagt die Vermieterin: 'Im Hof gibt es einen Parkplatz, den Sie mitbenutzen können.' Das ist richtig.",
+              "audioTimestamp": 70
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Sie hören drei Gespräche. Zu jedem Gespräch gibt es eine Aufgabe. Kreuzen Sie die richtige Antwort an: a, b oder c. Sie hören jeden Text einmal.",
+          "instructionsTranslation": "You will hear three conversations. There is one task for each conversation. Mark the correct answer: a, b or c. You will hear each text once.",
+          "audioFile": "assets/audio/A1/mock10/listening_part3.mp3",
+          "playCount": 1,
+          "questions": [
+            {
+              "id": "A1_m10_L3_q1",
+              "type": "mcq",
+              "questionText": "Was braucht der Mann für seine neue Wohnung noch?",
+              "options": [
+                "a) Einen Schrank",
+                "b) Ein Bett",
+                "c) Einen Tisch"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Der Mann sagt seiner Freundin: 'Bett und Tisch habe ich schon, aber ich brauche noch einen Schrank.' Die richtige Antwort ist einen Schrank.",
+              "audioTimestamp": 8
+            },
+            {
+              "id": "A1_m10_L3_q2",
+              "type": "mcq",
+              "questionText": "Wann ist das Möbelgeschäft geöffnet?",
+              "options": [
+                "a) Von Montag bis Samstag, 9 bis 19 Uhr",
+                "b) Von Montag bis Freitag, 10 bis 18 Uhr",
+                "c) Jeden Tag von 8 bis 20 Uhr"
+              ],
+              "correctAnswer": "a",
+              "explanation": "In der telefonischen Ansage heißt es: 'Unser Geschäft ist Montag bis Samstag von neun bis neunzehn Uhr für Sie geöffnet.' Antwort a ist richtig.",
+              "audioTimestamp": 38
+            },
+            {
+              "id": "A1_m10_L3_q3",
+              "type": "mcq",
+              "questionText": "Warum geht die Frau nicht auf den Markt?",
+              "options": [
+                "a) Der Markt ist geschlossen.",
+                "b) Sie hat kein Geld dabei.",
+                "c) Sie hat keine Zeit."
+              ],
+              "correctAnswer": "c",
+              "explanation": "Die Frau sagt: 'Ich würde gerne auf den Markt gehen, aber heute habe ich wirklich keine Zeit.' Die richtige Antwort ist c.",
+              "audioTimestamp": 64
+            }
+          ]
+        }
+      ]
+    },
+    "reading": {
+      "totalTimeMinutes": 25,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Lesen Sie die Texte und die Aufgaben 1 bis 5. Kreuzen Sie an: richtig oder falsch.",
+          "instructionsTranslation": "Read the texts and tasks 1 to 5. Mark: correct or incorrect.",
+          "texts": [
+            {
+              "id": "A1_m10_R1_text1",
+              "type": "email",
+              "content": "Betreff: Wohnung gesucht\n\nLiebe Frau Hartmann,\n\nich heiße Jana Müller und suche eine Wohnung in Mainz. Ich bin 28 Jahre alt und arbeite als Lehrerin. Ich brauche eine ruhige Wohnung mit mindestens zwei Zimmern, weil ich auch zu Hause arbeite. Eine Küche und ein Bad sind natürlich wichtig. Ein Balkon wäre schön, aber er ist nicht unbedingt nötig. Meine maximale Miete ist 700 Euro warm. Ich habe keine Haustiere und rauche nicht. Ich bin eine zuverlässige Mieterin.\n\nKönnen Sie mir helfen? Bitte schreiben Sie mir zurück.\n\nMit freundlichen Grüßen\nJana Müller",
+              "source": "Wohnungssuche per E-Mail"
+            },
+            {
+              "id": "A1_m10_R1_text2",
+              "type": "ad",
+              "content": "WOHNUNG ZU VERMIETEN\n\n3-Zimmer-Wohnung in Mainz-Mitte\nWohnfläche: 72 m²\nErdgeschoss\nModerne Einbauküche, Bad mit Dusche\nKein Balkon\nKaltmiete: 620 Euro + 80 Euro Nebenkosten\nHaustiere auf Anfrage\nNichtraucher bevorzugt\n\nKontakt: Hartmann Immobilien, Tel. 06131-445566",
+              "source": "Wohnungsanzeige Mainzer Zeitung"
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m10_R1_q1",
+              "type": "true_false",
+              "questionText": "Jana Müller sucht eine Wohnung in Mainz.",
+              "relatedTextId": "A1_m10_R1_text1",
+              "correctAnswer": "richtig",
+              "explanation": "Im ersten Satz der E-Mail steht: 'ich suche eine Wohnung in Mainz.' Das ist richtig."
+            },
+            {
+              "id": "A1_m10_R1_q2",
+              "type": "true_false",
+              "questionText": "Jana Müller möchte maximal 650 Euro Miete zahlen.",
+              "relatedTextId": "A1_m10_R1_text1",
+              "correctAnswer": "falsch",
+              "explanation": "Im Text steht: 'Meine maximale Miete ist 700 Euro warm.' Sie kann bis zu 700 Euro zahlen, nicht nur 650 Euro."
+            },
+            {
+              "id": "A1_m10_R1_q3",
+              "type": "true_false",
+              "questionText": "Die angebotene Wohnung hat einen Balkon.",
+              "relatedTextId": "A1_m10_R1_text2",
+              "correctAnswer": "falsch",
+              "explanation": "In der Anzeige steht explizit: 'Kein Balkon.' Die Wohnung hat also keinen Balkon."
+            },
+            {
+              "id": "A1_m10_R1_q4",
+              "type": "true_false",
+              "questionText": "Die Gesamtmiete der angebotenen Wohnung beträgt 700 Euro.",
+              "relatedTextId": "A1_m10_R1_text2",
+              "correctAnswer": "richtig",
+              "explanation": "Kaltmiete 620 Euro plus 80 Euro Nebenkosten ergibt zusammen 700 Euro Warmmiete. Das ist richtig."
+            },
+            {
+              "id": "A1_m10_R1_q5",
+              "type": "true_false",
+              "questionText": "Jana Müller hat eine Katze.",
+              "relatedTextId": "A1_m10_R1_text1",
+              "correctAnswer": "falsch",
+              "explanation": "Im Text schreibt Jana: 'Ich habe keine Haustiere und rauche nicht.' Sie hat also keine Katze."
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Lesen Sie die Anzeigen a bis h und die Aufgaben 1 bis 5. Welche Anzeige passt zu welcher Aufgabe? Für eine Aufgabe gibt es keine passende Anzeige. Schreiben Sie dann: x.",
+          "instructionsTranslation": "Read the ads a to h and tasks 1 to 5. Which ad matches which task? For one task there is no matching ad. Write then: x.",
+          "texts": [
+            {
+              "id": "A1_m10_R2_ad_a",
+              "type": "ad",
+              "content": "ALDI SÜD — Wochenangebote\nBananen 1 kg: 0,89 €\nYogurt (500 g): 0,49 €\nHähnchen (ganz, 1,5 kg): 3,99 €\nNur gültig Mo–Sa diese Woche!\nALDI SÜD, Berliner Str. 12"
+            },
+            {
+              "id": "A1_m10_R2_ad_b",
+              "type": "ad",
+              "content": "MÖBELHAUS KAISER\nGroßer Sommerschlussverkauf!\nBis zu 40% auf alle Sofas und Sessel\nAuch Betten und Schränke reduziert\nKostenlose Lieferung ab 500 € Einkauf\nGeöffnet: Mo–Sa 9–20 Uhr\nKaiserstr. 88"
+            },
+            {
+              "id": "A1_m10_R2_ad_c",
+              "type": "ad",
+              "content": "WOHNGEMEINSCHAFT GESUCHT\nWir sind 2 Studenten (25, 27) und suchen eine dritte Person für unser WG-Zimmer (14 m²).\nMiete: 380 Euro alles inklusive\nRuhige Lage, Nähe Universität\nKontakt: wg-suche@mail.de"
+            },
+            {
+              "id": "A1_m10_R2_ad_d",
+              "type": "ad",
+              "content": "WOCHENMARKT BORNHEIM\nFrisches Obst und Gemüse direkt vom Bauern\nJeden Dienstag und Freitag 7–13 Uhr\nMarktplatz Bornheim\nAuch Käse, Eier und Honig aus der Region"
+            },
+            {
+              "id": "A1_m10_R2_ad_e",
+              "type": "ad",
+              "content": "SECOND-HAND-MÖBEL\nFlohmarkt & Gebrauchtmöbel\nTisch, Stühle, Regale, Lampen — alles günstig!\nSamstag 8–14 Uhr, Parkplatz Industriestr. 5\nFür Käufer und Verkäufer offen"
+            },
+            {
+              "id": "A1_m10_R2_ad_f",
+              "type": "ad",
+              "content": "1-ZIMMER-WOHNUNG FREI\nZentral gelegen, 35 m², 4. Etage, Aufzug\nBad mit Badewanne, Küchenzeile\nKaltmiete 490 Euro, NK 60 Euro\nFrei ab 1. Juli\nTel. 069-778899"
+            },
+            {
+              "id": "A1_m10_R2_ad_g",
+              "type": "ad",
+              "content": "BIO-SUPERMARKT GRÜNWELT\nNeueröffnung! Diese Woche: 10% auf alles\nBio-Gemüse, Vollkornbrot, Naturkosmetik\nKostenloser Parkplatz\nHauptstr. 33, Mo–Sa 8–20 Uhr"
+            },
+            {
+              "id": "A1_m10_R2_ad_h",
+              "type": "ad",
+              "content": "UMZUGSHELFER GESUCHT\nWir suchen 2 kräftige Helfer für Umzug am Samstag, 15. Juni\nVon 9–15 Uhr, Frankfurt Innenstadt\nBezahlung: 12 Euro pro Stunde + Essen und Trinken\nBitte melden: 0176-12345678"
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m10_R2_q1",
+              "type": "matching",
+              "questionText": "Herr Novak möchte günstig ein gebrauchtes Regal kaufen.",
+              "matchingSources": [
+                {
+                  "id": "A1_m10_R2_ad_a",
+                  "label": "a) ALDI SÜD Wochenangebote"
+                },
+                {
+                  "id": "A1_m10_R2_ad_b",
+                  "label": "b) Möbelhaus Kaiser Schlussverkauf"
+                },
+                {
+                  "id": "A1_m10_R2_ad_c",
+                  "label": "c) WG-Zimmer gesucht"
+                },
+                {
+                  "id": "A1_m10_R2_ad_d",
+                  "label": "d) Wochenmarkt Bornheim"
+                },
+                {
+                  "id": "A1_m10_R2_ad_e",
+                  "label": "e) Second-Hand-Möbel Flohmarkt"
+                },
+                {
+                  "id": "A1_m10_R2_ad_f",
+                  "label": "f) 1-Zimmer-Wohnung frei"
+                },
+                {
+                  "id": "A1_m10_R2_ad_g",
+                  "label": "g) Bio-Supermarkt Grünwelt"
+                },
+                {
+                  "id": "A1_m10_R2_ad_h",
+                  "label": "h) Umzugshelfer gesucht"
+                }
+              ],
+              "correctAnswer": "e",
+              "explanation": "Anzeige e ist der Second-Hand-Möbel Flohmarkt, wo man günstig gebrauchte Möbel und Regale kaufen kann. Das passt zu Herrn Novaks Wunsch."
+            },
+            {
+              "id": "A1_m10_R2_q2",
+              "type": "matching",
+              "questionText": "Frau Becker sucht frisches Gemüse und Eier direkt vom Bauern.",
+              "matchingSources": [
+                {
+                  "id": "A1_m10_R2_ad_a",
+                  "label": "a) ALDI SÜD Wochenangebote"
+                },
+                {
+                  "id": "A1_m10_R2_ad_b",
+                  "label": "b) Möbelhaus Kaiser Schlussverkauf"
+                },
+                {
+                  "id": "A1_m10_R2_ad_c",
+                  "label": "c) WG-Zimmer gesucht"
+                },
+                {
+                  "id": "A1_m10_R2_ad_d",
+                  "label": "d) Wochenmarkt Bornheim"
+                },
+                {
+                  "id": "A1_m10_R2_ad_e",
+                  "label": "e) Second-Hand-Möbel Flohmarkt"
+                },
+                {
+                  "id": "A1_m10_R2_ad_f",
+                  "label": "f) 1-Zimmer-Wohnung frei"
+                },
+                {
+                  "id": "A1_m10_R2_ad_g",
+                  "label": "g) Bio-Supermarkt Grünwelt"
+                },
+                {
+                  "id": "A1_m10_R2_ad_h",
+                  "label": "h) Umzugshelfer gesucht"
+                }
+              ],
+              "correctAnswer": "d",
+              "explanation": "Anzeige d ist der Wochenmarkt Bornheim mit frischem Obst und Gemüse direkt vom Bauern sowie Käse und Eiern aus der Region. Das passt perfekt."
+            },
+            {
+              "id": "A1_m10_R2_q3",
+              "type": "matching",
+              "questionText": "Student Ali sucht ein günstiges Zimmer mit anderen Leuten zusammen.",
+              "matchingSources": [
+                {
+                  "id": "A1_m10_R2_ad_a",
+                  "label": "a) ALDI SÜD Wochenangebote"
+                },
+                {
+                  "id": "A1_m10_R2_ad_b",
+                  "label": "b) Möbelhaus Kaiser Schlussverkauf"
+                },
+                {
+                  "id": "A1_m10_R2_ad_c",
+                  "label": "c) WG-Zimmer gesucht"
+                },
+                {
+                  "id": "A1_m10_R2_ad_d",
+                  "label": "d) Wochenmarkt Bornheim"
+                },
+                {
+                  "id": "A1_m10_R2_ad_e",
+                  "label": "e) Second-Hand-Möbel Flohmarkt"
+                },
+                {
+                  "id": "A1_m10_R2_ad_f",
+                  "label": "f) 1-Zimmer-Wohnung frei"
+                },
+                {
+                  "id": "A1_m10_R2_ad_g",
+                  "label": "g) Bio-Supermarkt Grünwelt"
+                },
+                {
+                  "id": "A1_m10_R2_ad_h",
+                  "label": "h) Umzugshelfer gesucht"
+                }
+              ],
+              "correctAnswer": "c",
+              "explanation": "Anzeige c ist eine Wohngemeinschaft mit freiem WG-Zimmer für 380 Euro inklusive. Das ist ideal für Student Ali, der günstig mit anderen wohnen möchte."
+            },
+            {
+              "id": "A1_m10_R2_q4",
+              "type": "matching",
+              "questionText": "Familie Weber möchte ihr neues Sofa aus dem Möbelhaus liefern lassen.",
+              "matchingSources": [
+                {
+                  "id": "A1_m10_R2_ad_a",
+                  "label": "a) ALDI SÜD Wochenangebote"
+                },
+                {
+                  "id": "A1_m10_R2_ad_b",
+                  "label": "b) Möbelhaus Kaiser Schlussverkauf"
+                },
+                {
+                  "id": "A1_m10_R2_ad_c",
+                  "label": "c) WG-Zimmer gesucht"
+                },
+                {
+                  "id": "A1_m10_R2_ad_d",
+                  "label": "d) Wochenmarkt Bornheim"
+                },
+                {
+                  "id": "A1_m10_R2_ad_e",
+                  "label": "e) Second-Hand-Möbel Flohmarkt"
+                },
+                {
+                  "id": "A1_m10_R2_ad_f",
+                  "label": "f) 1-Zimmer-Wohnung frei"
+                },
+                {
+                  "id": "A1_m10_R2_ad_g",
+                  "label": "g) Bio-Supermarkt Grünwelt"
+                },
+                {
+                  "id": "A1_m10_R2_ad_h",
+                  "label": "h) Umzugshelfer gesucht"
+                }
+              ],
+              "correctAnswer": "b",
+              "explanation": "Anzeige b ist das Möbelhaus Kaiser mit Sofas und Sesseln im Angebot sowie kostenloser Lieferung ab 500 Euro Einkauf. Das passt zu Familie Weber."
+            },
+            {
+              "id": "A1_m10_R2_q5",
+              "type": "matching",
+              "questionText": "Herr Lange möchte seine alte Wohnung verkaufen.",
+              "matchingSources": [
+                {
+                  "id": "A1_m10_R2_ad_a",
+                  "label": "a) ALDI SÜD Wochenangebote"
+                },
+                {
+                  "id": "A1_m10_R2_ad_b",
+                  "label": "b) Möbelhaus Kaiser Schlussverkauf"
+                },
+                {
+                  "id": "A1_m10_R2_ad_c",
+                  "label": "c) WG-Zimmer gesucht"
+                },
+                {
+                  "id": "A1_m10_R2_ad_d",
+                  "label": "d) Wochenmarkt Bornheim"
+                },
+                {
+                  "id": "A1_m10_R2_ad_e",
+                  "label": "e) Second-Hand-Möbel Flohmarkt"
+                },
+                {
+                  "id": "A1_m10_R2_ad_f",
+                  "label": "f) 1-Zimmer-Wohnung frei"
+                },
+                {
+                  "id": "A1_m10_R2_ad_g",
+                  "label": "g) Bio-Supermarkt Grünwelt"
+                },
+                {
+                  "id": "A1_m10_R2_ad_h",
+                  "label": "h) Umzugshelfer gesucht"
+                }
+              ],
+              "correctAnswer": "x",
+              "explanation": "Keine der Anzeigen handelt vom Verkauf einer Wohnung. Es gibt Mietangebote und WG-Zimmer, aber kein Angebot für den Wohnungsverkauf."
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Lesen Sie die Texte 1 bis 5. Sind die Sätze richtig oder falsch? Kreuzen Sie an.",
+          "instructionsTranslation": "Read texts 1 to 5. Are the sentences correct or incorrect? Mark the correct answer.",
+          "texts": [
+            {
+              "id": "A1_m10_R3_text1",
+              "type": "notice",
+              "content": "SUPERMARKT FRISCH & GUT\nAb sofort: Selbst-Scan-Kassen!\nScannen Sie Ihre Einkäufe selbst und zahlen Sie schnell und einfach.\nNur mit Kundenkarte möglich.\nWeitere Informationen an der Servicetheke."
+            },
+            {
+              "id": "A1_m10_R3_text2",
+              "type": "notice",
+              "content": "Liebe Mieter,\nbitte beachten Sie: Fahrräder dürfen nicht im Treppenhaus abgestellt werden. Nutzen Sie bitte den Fahrradkeller im Erdgeschoss. Schlüssel erhalten Sie bei Frau Sommer, Wohnung 1.\nDie Hausverwaltung"
+            },
+            {
+              "id": "A1_m10_R3_text3",
+              "type": "notice",
+              "content": "ACHTUNG!\nDieser Aufzug ist von Montag, 10. Juni bis Freitag, 14. Juni wegen Wartungsarbeiten außer Betrieb.\nWir bitten um Entschuldigung.\nDie Hausverwaltung"
+            },
+            {
+              "id": "A1_m10_R3_text4",
+              "type": "notice",
+              "content": "WOCHENMARKT — SONDERANGEBOT\nErdbeeren aus der Region: 2 kg für nur 3,50 Euro!\nNur solange der Vorrat reicht.\nJeden Samstag von 7 bis 13 Uhr auf dem Marktplatz."
+            },
+            {
+              "id": "A1_m10_R3_text5",
+              "type": "notice",
+              "content": "Möbelhaus Kaiser informiert:\nUnser Showroom ist ab sofort auch sonntags geöffnet!\nSonntag 12–18 Uhr — nur Besichtigung, kein Verkauf.\nShopping-Erlebnis für die ganze Familie."
+            }
+          ],
+          "questions": [
+            {
+              "id": "A1_m10_R3_q1",
+              "type": "true_false",
+              "questionText": "Man kann im Supermarkt ohne Kundenkarte selbst scannen.",
+              "relatedTextId": "A1_m10_R3_text1",
+              "correctAnswer": "falsch",
+              "explanation": "Im Schild steht: 'Nur mit Kundenkarte möglich.' Man braucht also eine Kundenkarte — ohne Kundenkarte geht es nicht."
+            },
+            {
+              "id": "A1_m10_R3_q2",
+              "type": "true_false",
+              "questionText": "Mieter können ihre Fahrräder im Treppenhaus lassen.",
+              "relatedTextId": "A1_m10_R3_text2",
+              "correctAnswer": "falsch",
+              "explanation": "Der Aushang sagt klar: 'Fahrräder dürfen nicht im Treppenhaus abgestellt werden.' Es ist verboten."
+            },
+            {
+              "id": "A1_m10_R3_q3",
+              "type": "true_false",
+              "questionText": "Der Aufzug funktioniert am Mittwoch, 12. Juni nicht.",
+              "relatedTextId": "A1_m10_R3_text3",
+              "correctAnswer": "richtig",
+              "explanation": "Der Aufzug ist von Montag 10. bis Freitag 14. Juni außer Betrieb. Der Mittwoch, 12. Juni liegt in diesem Zeitraum — das ist richtig."
+            },
+            {
+              "id": "A1_m10_R3_q4",
+              "type": "true_false",
+              "questionText": "Man kann die Erdbeeren nur am Samstag kaufen.",
+              "relatedTextId": "A1_m10_R3_text4",
+              "correctAnswer": "richtig",
+              "explanation": "Im Schild steht: 'Jeden Samstag von 7 bis 13 Uhr auf dem Marktplatz.' Der Markt ist nur samstags — das ist richtig."
+            },
+            {
+              "id": "A1_m10_R3_q5",
+              "type": "true_false",
+              "questionText": "Man kann sonntags im Möbelhaus Kaiser Möbel kaufen.",
+              "relatedTextId": "A1_m10_R3_text5",
+              "correctAnswer": "falsch",
+              "explanation": "Der Hinweis sagt: 'nur Besichtigung, kein Verkauf.' Am Sonntag kann man sich Möbel anschauen, aber nicht kaufen."
+            }
+          ]
+        }
+      ]
+    },
+    "writing": {
+      "totalTimeMinutes": 20,
+      "tasks": [
+        {
+          "taskNumber": 1,
+          "type": "form_fill",
+          "instructions": "Frau Katja Brandt möchte eine Wohnung besichtigen. Füllen Sie das Formular für die Besichtigungsanmeldung aus. Schreiben Sie die Informationen aus dem Steckbrief in das Formular.",
+          "instructionsTranslation": "Mrs Katja Brandt would like to view an apartment. Fill in the viewing registration form. Write the information from the profile into the form.",
+          "formFields": [
+            {
+              "label": "Name",
+              "correctAnswer": "Katja Brandt",
+              "hint": "Vor- und Nachname der Interessentin"
+            },
+            {
+              "label": "Telefonnummer",
+              "correctAnswer": "0163 4455667",
+              "hint": "Handynummer für die Terminbestätigung"
+            },
+            {
+              "label": "Gewünschte Zimmerzahl",
+              "correctAnswer": "2 Zimmer",
+              "hint": "Wie viele Zimmer braucht Frau Brandt?"
+            },
+            {
+              "label": "Maximale Monatsmiete (warm)",
+              "correctAnswer": "750 Euro",
+              "hint": "Die Warmmiete inklusive Nebenkosten"
+            },
+            {
+              "label": "Einzugsdatum (gewünscht)",
+              "correctAnswer": "1. August",
+              "hint": "Ab wann möchte Frau Brandt einziehen?"
+            }
+          ],
+          "sampleAnswer": "Name: Katja Brandt\nTelefonnummer: 0163 4455667\nGewünschte Zimmerzahl: 2 Zimmer\nMaximale Monatsmiete (warm): 750 Euro\nEinzugsdatum (gewünscht): 1. August",
+          "scoringCriteria": [
+            {
+              "criterion": "Vollständigkeit",
+              "maxPoints": 5,
+              "description": "Alle fünf Felder sind ausgefüllt. Für jede korrekte Angabe gibt es einen Punkt."
+            },
+            {
+              "criterion": "Korrektheit",
+              "maxPoints": 5,
+              "description": "Die Angaben sind korrekt aus dem Steckbrief übertragen, gut lesbar und ohne sinnverfälschende Fehler."
+            }
+          ]
+        },
+        {
+          "taskNumber": 2,
+          "type": "short_message",
+          "instructions": "Sie möchten Ihren Freund / Ihre Freundin fragen, ob er/sie mit Ihnen zusammen einkaufen geht. Schreiben Sie eine Nachricht (30–40 Wörter). Schreiben Sie zu allen drei Punkten.",
+          "instructionsTranslation": "You would like to ask your friend if he/she will go shopping with you. Write a message (30–40 words). Write about all three points.",
+          "prompt": "- Wann und wo möchten Sie einkaufen?\n- Was brauchen Sie für Ihre neue Wohnung?\n- Warum soll Ihr Freund / Ihre Freundin mitkommen?",
+          "promptTranslation": "- When and where do you want to go shopping?\n- What do you need for your new apartment?\n- Why should your friend come along?",
+          "requiredPoints": [
+            "Wann und wo möchten Sie einkaufen?",
+            "Was brauchen Sie für Ihre neue Wohnung?",
+            "Warum soll Ihr Freund / Ihre Freundin mitkommen?"
+          ],
+          "wordCountMin": 30,
+          "wordCountMax": 40,
+          "sampleAnswer": "Hallo Lena!\n\nIch gehe am Samstag um 10 Uhr ins Möbelhaus Kaiser. Ich brauche noch einen Schrank und eine Lampe für meine neue Wohnung. Komm doch mit! Du hast so einen guten Geschmack.\n\nBis dann, Anna",
+          "scoringCriteria": [
+            {
+              "criterion": "Aufgabenerfüllung",
+              "maxPoints": 4,
+              "description": "Alle drei geforderten Punkte sind angesprochen. Die Nachricht ist klar und verständlich. Für jeden vollständig behandelten Punkt gibt es einen Punkt, plus einen für die Gesamtstimmigkeit."
+            },
+            {
+              "criterion": "Kommunikative Gestaltung",
+              "maxPoints": 4,
+              "description": "Die Nachricht hat eine passende Anrede und einen Abschluss. Der Text ist flüssig lesbar und der Ton ist freundlich und natürlich."
+            },
+            {
+              "criterion": "Formale Richtigkeit",
+              "maxPoints": 4,
+              "description": "Grammatik, Rechtschreibung und Zeichensetzung sind weitgehend korrekt. Einzelne kleine Fehler sind akzeptabel, wenn die Verständlichkeit nicht leidet."
+            }
+          ]
+        }
+      ]
+    },
+    "speaking": {
+      "totalTimeMinutes": 15,
+      "prepTimeMinutes": 0,
+      "parts": [
+        {
+          "partNumber": 1,
+          "type": "introduce",
+          "instructions": "Stellen Sie sich vor! Sprechen Sie über sich: Name, Herkunft, Wohnort, Beruf, Familie und Hobbys.",
+          "instructionsTranslation": "Introduce yourself! Talk about yourself: name, origin, place of residence, job, family, and hobbies.",
+          "prompt": "Sagen Sie Ihren Namen. Woher kommen Sie? Wo wohnen Sie jetzt? Was machen Sie beruflich? Wie ist Ihre Familie? Was sind Ihre Hobbys?",
+          "sampleResponse": "Hallo, mein Name ist Petra Nowak. Ich komme aus Polen, aus Krakau. Jetzt wohne ich in Frankfurt, in einer kleinen Wohnung im Stadtzentrum. Ich arbeite als Verkäuferin in einem Supermarkt. Ich bin verheiratet und habe einen Sohn, er heißt Marek und ist fünf Jahre alt. In meiner Freizeit gehe ich gern auf den Wochenmarkt und koche für meine Familie.",
+          "sampleAudioFile": "assets/audio/A1/mock10/speaking_part1_sample.mp3",
+          "evaluationTips": [
+            "Sprechen Sie laut und deutlich — der Prüfer muss Sie gut verstehen.",
+            "Benutzen Sie einfache, vollständige Sätze im Präsens.",
+            "Nennen Sie konkrete Details (echte Stadtnamen, Berufsbezeichnungen), nicht nur allgemeine Angaben.",
+            "Wenn Sie ein Wort nicht wissen, beschreiben Sie es auf Deutsch — Pausen vermeiden."
+          ],
+          "keyPhrases": [
+            "Mein Name ist ...",
+            "Ich komme aus ...",
+            "Ich wohne in ... / in einer Wohnung in ...",
+            "Ich arbeite als ...",
+            "Ich bin verheiratet / ledig / geschieden.",
+            "Mein Hobby ist ... / In meiner Freizeit ..."
+          ]
+        },
+        {
+          "partNumber": 2,
+          "type": "picture_cards",
+          "instructions": "Sie bekommen drei Karten mit Bildern. Sagen Sie, was Sie auf den Bildern sehen. Was ist das? Wo benutzt man das?",
+          "instructionsTranslation": "You receive three cards with pictures. Say what you see in the pictures. What is it? Where do you use it?",
+          "prompt": "Schauen Sie sich die Bilder an. Sagen Sie für jedes Bild: Was ist das? Welche Farbe hat es? Wo findet man das — in der Wohnung oder im Geschäft? Was macht man damit?",
+          "promptImage": "assets/images/A1/mock10/speaking_part2_cards.png",
+          "sampleResponse": "Das erste Bild zeigt einen Stuhl. Er ist braun. Einen Stuhl benutzt man zu Hause, zum Beispiel am Esstisch. Man sitzt darauf. Das zweite Bild zeigt einen Kühlschrank. Er ist weiß und groß. Den Kühlschrank hat man in der Küche. Man lagert dort Lebensmittel, zum Beispiel Milch und Käse. Das dritte Bild zeigt eine Einkaufstasche. Sie ist rot und aus Stoff. Die Einkaufstasche nimmt man mit in den Supermarkt oder auf den Markt. Man trägt darin seine Einkäufe.",
+          "sampleAudioFile": "assets/audio/A1/mock10/speaking_part2_sample.mp3",
+          "evaluationTips": [
+            "Benennen Sie das Objekt zuerst klar: 'Das ist ein/eine ...'",
+            "Beschreiben Sie Farbe, Größe oder Material, wenn Sie die Wörter kennen.",
+            "Erklären Sie die Funktion in einem einfachen Satz: 'Man ... damit.'",
+            "Sprechen Sie alle drei Karten an — nicht nur eine oder zwei."
+          ],
+          "keyPhrases": [
+            "Das ist ein/eine ...",
+            "Er/Sie/Es ist ... (Farbe/Größe).",
+            "Man benutzt das in der Küche / im Wohnzimmer / im Supermarkt.",
+            "Man sitzt / legt / trägt ... damit.",
+            "Das findet man in der Wohnung / im Geschäft.",
+            "Das braucht man zum Einkaufen / zum Kochen / zum Schlafen."
+          ]
+        },
+        {
+          "partNumber": 3,
+          "type": "und_du",
+          "instructions": "Sprechen Sie mit Ihrem Partner / Ihrer Partnerin. Sie bekommen drei Karten mit Themen. Fragen Sie und antworten Sie.",
+          "instructionsTranslation": "Talk with your partner. You receive three cards with topics. Ask questions and answer them.",
+          "prompt": "Thema 1: Wohnen — Wo wohnen Sie? Wie ist Ihre Wohnung?\nThema 2: Einkaufen — Wo kaufen Sie ein? Was kaufen Sie oft?\nThema 3: Lieblingsessen — Was essen Sie gern? Können Sie kochen?",
+          "sampleResponse": "Prüfer: Wo wohnen Sie?\nKandidat: Ich wohne in München, in einer Zweizimmerwohnung. Die Wohnung ist nicht groß, aber ich finde sie schön.\nPrüfer: Und du? Wo kaufst du ein?\nKandidat: Ich kaufe meistens im Supermarkt ein, aber am Wochenende gehe ich gern auf den Markt. Dort kaufe ich frisches Obst und Gemüse.\nPrüfer: Was ist dein Lieblingsessen?\nKandidat: Mein Lieblingsessen ist Pasta mit Tomatensauce. Das kann ich auch selbst kochen — es ist nicht schwer!",
+          "sampleAudioFile": "assets/audio/A1/mock10/speaking_part3_sample.mp3",
+          "evaluationTips": [
+            "Hören Sie genau zu und antworten Sie auf die Frage — nicht auf ein anderes Thema.",
+            "Geben Sie mehr als ein Wort: Benutzen Sie ganze Sätze und fügen Sie Details hinzu.",
+            "Stellen Sie auch Ihrem Partner eine Frage — der Dialog soll in beide Richtungen gehen.",
+            "Ruhig bleiben bei unbekannten Wörtern — beschreiben Sie auf Deutsch oder fragen Sie nach."
+          ],
+          "keyPhrases": [
+            "Ich wohne in ... / in einer Wohnung mit ... Zimmern.",
+            "Meine Wohnung ist groß / klein / hell / ruhig.",
+            "Ich kaufe ein im Supermarkt / auf dem Markt / im Bioladen.",
+            "Ich kaufe oft / manchmal / selten ...",
+            "Mein Lieblingsessen ist ...",
+            "Ich kann ... kochen / Ich koche gern ..."
+          ]
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds 5 complete A1 mock exams (mock_06 through mock_10)
- Themes: Arbeit (06), Freizeit (07), Gesundheit (08), Reisen (09), Einkaufen/Wohnen (10)
- Each mock: 3 listening parts + 3 reading parts + 2 writing tasks + 3 speaking parts (26 questions)
- All passed Layer A exam-tester, language-checker, and pedagogy-director review

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Load each mock in exam flow, verify all questions render correctly
- [ ] Spot-check answer keys for correctness