### PR TITLE
feat(web): vocabulary flashcard session UI (#14)

### DIFF
--- a/apps/web/src/__tests__/vocab/FlashCard.test.tsx
+++ b/apps/web/src/__tests__/vocab/FlashCard.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FlashCard } from '../../components/vocab/FlashCard';
+import type { VocabularyWord } from '../../lib/loadVocabulary';
+
+const mockWord: VocabularyWord = {
+  id: 1,
+  level: 'A1',
+  german: 'der Name',
+  english: 'name',
+  article: 'der',
+  plural: 'die Namen',
+  exampleSentence: 'Mein Name ist Thomas.',
+  topic: 'Persönliche Angaben',
+  audioFile: null,
+  easeFactor: 2.5,
+  intervalDays: 0,
+  repetitions: 0,
+  nextReviewDate: null,
+  lastReviewedAt: null,
+};
+
+const wordWithoutArticle: VocabularyWord = {
+  ...mockWord,
+  id: 2,
+  german: 'sprechen',
+  english: 'to speak',
+  article: null,
+  plural: null,
+  exampleSentence: 'Ich spreche Deutsch.',
+  topic: 'Sprache',
+};
+
+describe('FlashCard', () => {
+  it('renders the front with German word and topic', () => {
+    render(<FlashCard word={mockWord} isFlipped={false} onFlip={() => {}} />);
+    const front = screen.getByTestId('flashcard-front');
+    expect(front).toHaveTextContent('der Name');
+    expect(front).toHaveTextContent('Persönliche Angaben');
+  });
+
+  it('renders the back with English, article gender, plural, and example', () => {
+    render(<FlashCard word={mockWord} isFlipped={true} onFlip={() => {}} />);
+    const back = screen.getByTestId('flashcard-back');
+    expect(back).toHaveTextContent('name');
+    expect(back).toHaveTextContent('der (masculine)');
+    expect(back).toHaveTextContent('Plural: die Namen');
+    expect(back).toHaveTextContent('Mein Name ist Thomas.');
+  });
+
+  it('does not render article or plural when absent', () => {
+    render(<FlashCard word={wordWithoutArticle} isFlipped={true} onFlip={() => {}} />);
+    const back = screen.getByTestId('flashcard-back');
+    expect(back).not.toHaveTextContent('masculine');
+    expect(back).not.toHaveTextContent('Plural:');
+  });
+
+  it('calls onFlip when card is clicked', () => {
+    const onFlip = vi.fn();
+    render(<FlashCard word={mockWord} isFlipped={false} onFlip={onFlip} />);
+    fireEvent.click(screen.getByTestId('flashcard'));
+    expect(onFlip).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onFlip on Enter key', () => {
+    const onFlip = vi.fn();
+    render(<FlashCard word={mockWord} isFlipped={false} onFlip={onFlip} />);
+    fireEvent.keyDown(screen.getByTestId('flashcard'), { key: 'Enter' });
+    expect(onFlip).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onFlip on Space key', () => {
+    const onFlip = vi.fn();
+    render(<FlashCard word={mockWord} isFlipped={false} onFlip={onFlip} />);
+    fireEvent.keyDown(screen.getByTestId('flashcard'), { key: ' ' });
+    expect(onFlip).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/__tests__/vocab/FlashcardSession.test.tsx
+++ b/apps/web/src/__tests__/vocab/FlashcardSession.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FlashcardSession } from '../../components/vocab/FlashcardSession';
+import type { VocabularyWord } from '../../lib/loadVocabulary';
+
+vi.mock('@telc/core', () => ({
+  calculateNextReview: vi.fn((quality: number) => ({
+    easeFactor: quality >= 3 ? 2.6 : 2.1,
+    intervalDays: quality >= 3 ? 1 : 0,
+    repetitions: quality >= 3 ? 1 : 0,
+    nextReviewDate: '2026-04-20',
+  })),
+  getQualityLabel: vi.fn((quality: number) => {
+    if (quality <= 1) return 'Again';
+    if (quality === 2) return 'Hard';
+    if (quality <= 4) return 'Good';
+    return 'Easy';
+  }),
+}));
+
+function makeWords(count: number): VocabularyWord[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    level: 'A1',
+    german: `Wort ${i + 1}`,
+    english: `Word ${i + 1}`,
+    article: i % 3 === 0 ? 'der' : null,
+    plural: null,
+    exampleSentence: `Beispiel ${i + 1}.`,
+    topic: 'Test',
+    audioFile: null,
+    easeFactor: 2.5,
+    intervalDays: 0,
+    repetitions: 0,
+    nextReviewDate: null,
+    lastReviewedAt: null,
+  }));
+}
+
+const defaultProps = {
+  levelLabel: 'A1 Vocabulary',
+  levelColor: '#4caf50',
+  onBack: vi.fn(),
+};
+
+describe('FlashcardSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders idle state with start button', () => {
+    render(<FlashcardSession allWords={makeWords(650)} {...defaultProps} />);
+    expect(screen.getByTestId('start-review')).toBeInTheDocument();
+    expect(screen.getByText(/650 words available/)).toBeInTheDocument();
+  });
+
+  it('selects 20 cards on session start', () => {
+    render(<FlashcardSession allWords={makeWords(650)} {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('start-review'));
+    expect(screen.getByTestId('progress-bar')).toBeInTheDocument();
+    expect(screen.getByText('Card 1 of 20')).toBeInTheDocument();
+  });
+
+  it('uses all words when fewer than 20 are available', () => {
+    render(<FlashcardSession allWords={makeWords(5)} {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('start-review'));
+    expect(screen.getByText('Card 1 of 5')).toBeInTheDocument();
+  });
+
+  it('shows flip button on front, grade buttons after flip', () => {
+    render(<FlashcardSession allWords={makeWords(25)} {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('start-review'));
+
+    expect(screen.getByTestId('flip-button')).toBeInTheDocument();
+    expect(screen.queryByTestId('grade-buttons')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('flip-button'));
+    expect(screen.getByTestId('grade-buttons')).toBeInTheDocument();
+  });
+
+  it('advances to next card after grading', () => {
+    render(<FlashcardSession allWords={makeWords(25)} {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('start-review'));
+    fireEvent.click(screen.getByTestId('flip-button'));
+    fireEvent.click(screen.getByTestId('grade-3'));
+
+    expect(screen.getByText('Card 2 of 20')).toBeInTheDocument();
+  });
+
+  it('resets flip state on card advance', () => {
+    render(<FlashcardSession allWords={makeWords(25)} {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('start-review'));
+    fireEvent.click(screen.getByTestId('flip-button'));
+    fireEvent.click(screen.getByTestId('grade-5'));
+
+    expect(screen.getByTestId('flip-button')).toBeInTheDocument();
+    expect(screen.queryByTestId('grade-buttons')).not.toBeInTheDocument();
+  });
+
+  it('calls calculateNextReview with correct args on grade', async () => {
+    const { calculateNextReview } = await import('@telc/core');
+    render(<FlashcardSession allWords={makeWords(25)} {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('start-review'));
+    fireEvent.click(screen.getByTestId('flip-button'));
+    fireEvent.click(screen.getByTestId('grade-3'));
+
+    expect(calculateNextReview).toHaveBeenCalledWith(3, 2.5, 0, 0);
+  });
+
+  it('shows summary after all cards are graded', () => {
+    const words = makeWords(3);
+    render(<FlashcardSession allWords={words} {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('start-review'));
+
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(screen.getByTestId('flip-button'));
+      fireEvent.click(screen.getByTestId('grade-3'));
+    }
+
+    expect(screen.getByTestId('session-summary')).toBeInTheDocument();
+    expect(screen.getByText('Session Complete')).toBeInTheDocument();
+    expect(screen.getByText('Cards reviewed')).toBeInTheDocument();
+  });
+
+  it('shows quality breakdown in summary', () => {
+    const words = makeWords(3);
+    render(<FlashcardSession allWords={words} {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('start-review'));
+
+    fireEvent.click(screen.getByTestId('flip-button'));
+    fireEvent.click(screen.getByTestId('grade-0'));
+
+    fireEvent.click(screen.getByTestId('flip-button'));
+    fireEvent.click(screen.getByTestId('grade-3'));
+
+    fireEvent.click(screen.getByTestId('flip-button'));
+    fireEvent.click(screen.getByTestId('grade-5'));
+
+    expect(screen.getByTestId('session-summary')).toBeInTheDocument();
+    expect(screen.getByText('Again')).toBeInTheDocument();
+    expect(screen.getByText('Good')).toBeInTheDocument();
+    expect(screen.getByText('Easy')).toBeInTheDocument();
+  });
+
+  it('starts a new session when clicking New Session', () => {
+    const words = makeWords(3);
+    render(<FlashcardSession allWords={words} {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('start-review'));
+
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(screen.getByTestId('flip-button'));
+      fireEvent.click(screen.getByTestId('grade-3'));
+    }
+
+    expect(screen.getByTestId('session-summary')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('new-session'));
+    expect(screen.getByText('Card 1 of 3')).toBeInTheDocument();
+  });
+
+  it('calls onBack when Back to Vocabulary is clicked from summary', () => {
+    const onBack = vi.fn();
+    const words = makeWords(2);
+    render(<FlashcardSession allWords={words} {...{ ...defaultProps, onBack }} />);
+    fireEvent.click(screen.getByTestId('start-review'));
+
+    for (let i = 0; i < 2; i++) {
+      fireEvent.click(screen.getByTestId('flip-button'));
+      fireEvent.click(screen.getByTestId('grade-3'));
+    }
+
+    fireEvent.click(screen.getByTestId('back-to-vocab'));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('progress bar has correct ARIA attributes', () => {
+    render(<FlashcardSession allWords={makeWords(25)} {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('start-review'));
+
+    const bar = screen.getByTestId('progress-bar');
+    expect(bar).toHaveAttribute('aria-valuenow', '1');
+    expect(bar).toHaveAttribute('aria-valuemax', '20');
+  });
+});

--- a/apps/web/src/app/vocab/VocabPageClient.tsx
+++ b/apps/web/src/app/vocab/VocabPageClient.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+import type { VocabularyWord } from '@/lib/loadVocabulary';
+import { FlashcardSession } from '@/components/vocab/FlashcardSession';
+
+interface LevelConfig {
+  level: string;
+  color: string;
+  label: string;
+  wordCount: number;
+  words: VocabularyWord[];
+}
+
+interface VocabPageClientProps {
+  levels: LevelConfig[];
+}
+
+export function VocabPageClient({ levels }: VocabPageClientProps) {
+  const [activeLevel, setActiveLevel] = useState<string | null>(null);
+
+  const activeLevelConfig = levels.find((l) => l.level === activeLevel);
+
+  if (activeLevelConfig && activeLevelConfig.wordCount > 0) {
+    return (
+      <div className="space-y-6">
+        <FlashcardSession
+          allWords={activeLevelConfig.words}
+          levelLabel={`${activeLevelConfig.level} Vocabulary`}
+          levelColor={activeLevelConfig.color}
+          onBack={() => setActiveLevel(null)}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-text-primary">Vocabulary</h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          Flashcards with SM-2 spaced repetition. Review daily for best results.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {levels.map((cfg) => {
+          const hasWords = cfg.wordCount > 0;
+          return (
+            <div
+              key={cfg.level}
+              className="rounded-xl border border-border bg-white p-6"
+            >
+              <div className="flex items-center gap-3">
+                <span
+                  className="flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold text-white"
+                  style={{ backgroundColor: cfg.color }}
+                >
+                  {cfg.level}
+                </span>
+                <div>
+                  <div className="font-semibold text-text-primary">
+                    {cfg.level} Vocabulary
+                  </div>
+                  <div className="text-xs text-text-secondary">
+                    {hasWords ? `~${cfg.wordCount} words` : 'Coming soon'}
+                  </div>
+                </div>
+              </div>
+              <div className="mt-4">
+                <button
+                  data-testid={`start-review-${cfg.level}`}
+                  className="w-full rounded-lg px-4 py-2.5 text-sm font-medium text-white transition-colors hover:opacity-90 disabled:opacity-50"
+                  style={{ backgroundColor: cfg.color }}
+                  disabled={!hasWords}
+                  onClick={() => setActiveLevel(cfg.level)}
+                >
+                  {hasWords ? 'Start Review' : 'Coming Soon'}
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/vocab/page.tsx
+++ b/apps/web/src/app/vocab/page.tsx
@@ -1,55 +1,24 @@
-import { LEVEL_CONFIG } from "@telc/config";
-import type { Level } from "@telc/types";
+import { LEVEL_CONFIG } from '@telc/config';
+import type { Level } from '@telc/types';
+import { loadVocabulary } from '@/lib/loadVocabulary';
+import { VocabPageClient } from './VocabPageClient';
 
-const levels: Level[] = ["A1", "A2", "B1", "B2", "C1"];
+const levels: Level[] = ['A1', 'A2', 'B1', 'B2', 'C1'];
 
-export default function VocabPage() {
-  return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-text-primary">Vocabulary</h1>
-        <p className="mt-1 text-sm text-text-secondary">
-          Flashcards with SM-2 spaced repetition. Review daily for best results.
-        </p>
-      </div>
+export default async function VocabPage() {
+  const vocabByLevel: Record<string, Awaited<ReturnType<typeof loadVocabulary>>> = {};
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {levels.map((level) => {
-          const cfg = LEVEL_CONFIG[level];
-          return (
-            <div
-              key={level}
-              className="rounded-xl border border-[#e0e0e0] bg-white p-6"
-            >
-              <div className="flex items-center gap-3">
-                <span
-                  className="flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold text-white"
-                  style={{ backgroundColor: cfg.color }}
-                >
-                  {level}
-                </span>
-                <div>
-                  <div className="font-semibold text-text-primary">
-                    {level} Vocabulary
-                  </div>
-                  <div className="text-xs text-text-secondary">
-                    {level === "A1" ? "~650 words" : "Coming soon"}
-                  </div>
-                </div>
-              </div>
-              <div className="mt-4">
-                <button
-                  className="w-full rounded-lg px-4 py-2.5 text-sm font-medium text-white transition-colors hover:opacity-90 disabled:opacity-50"
-                  style={{ backgroundColor: cfg.color }}
-                  disabled={level !== "A1"}
-                >
-                  {level === "A1" ? "Start Review" : "Coming Soon"}
-                </button>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
+  for (const level of levels) {
+    vocabByLevel[level] = await loadVocabulary(level);
+  }
+
+  const levelConfigs = levels.map((level) => ({
+    level,
+    color: LEVEL_CONFIG[level].color,
+    label: LEVEL_CONFIG[level].label,
+    wordCount: vocabByLevel[level].length,
+    words: vocabByLevel[level],
+  }));
+
+  return <VocabPageClient levels={levelConfigs} />;
 }

--- a/apps/web/src/components/vocab/FlashCard.tsx
+++ b/apps/web/src/components/vocab/FlashCard.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import type { VocabularyWord } from '@/lib/loadVocabulary';
+
+interface FlashCardProps {
+  word: VocabularyWord;
+  isFlipped: boolean;
+  onFlip: () => void;
+}
+
+const GENDER_HINTS: Record<string, string> = {
+  der: 'masculine',
+  die: 'feminine',
+  das: 'neuter',
+};
+
+export function FlashCard({ word, isFlipped, onFlip }: FlashCardProps) {
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onFlip();
+      }
+    },
+    [onFlip],
+  );
+
+  return (
+    <div
+      data-testid="flashcard"
+      className="relative mx-auto w-full max-w-md cursor-pointer select-none"
+      style={{ perspective: '1000px' }}
+      onClick={onFlip}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
+      aria-label={isFlipped ? 'Card showing answer. Click to flip back.' : 'Click to reveal answer.'}
+    >
+      <div
+        className="relative w-full transition-transform duration-500"
+        style={{
+          transformStyle: 'preserve-3d',
+          transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
+        }}
+      >
+        {/* Front */}
+        <div
+          data-testid="flashcard-front"
+          className="rounded-xl border border-border bg-white p-8 shadow-sm"
+          style={{ backfaceVisibility: 'hidden', minHeight: '260px' }}
+        >
+          <div className="flex h-full flex-col items-center justify-center gap-4">
+            <span className="inline-block rounded-full bg-surface-container px-3 py-1 text-xs font-medium text-text-secondary">
+              {word.topic}
+            </span>
+            <p className="text-3xl font-bold text-text-primary">{word.german}</p>
+            <p className="text-sm text-text-secondary">Tap card or press Enter to flip</p>
+          </div>
+        </div>
+
+        {/* Back */}
+        <div
+          data-testid="flashcard-back"
+          className="absolute inset-0 rounded-xl border border-border bg-white p-8 shadow-sm"
+          style={{
+            backfaceVisibility: 'hidden',
+            transform: 'rotateY(180deg)',
+            minHeight: '260px',
+          }}
+        >
+          <div className="flex h-full flex-col items-center justify-center gap-3">
+            <p className="text-2xl font-bold text-text-primary">{word.english}</p>
+
+            {word.article && (
+              <p className="text-sm text-text-secondary">
+                {word.article} ({GENDER_HINTS[word.article] ?? 'unknown'})
+              </p>
+            )}
+
+            {word.plural && (
+              <p className="text-sm text-text-secondary">
+                Plural: {word.plural}
+              </p>
+            )}
+
+            <div className="mt-2 w-full rounded-lg bg-surface-container p-3">
+              <p className="text-center text-sm italic text-text-secondary">
+                {word.exampleSentence}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/vocab/FlashcardSession.tsx
+++ b/apps/web/src/components/vocab/FlashcardSession.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { useState, useCallback, useMemo, useRef } from 'react';
+import { calculateNextReview, getQualityLabel } from '@telc/core';
+import type { SM2Result } from '@telc/core';
+import type { VocabularyWord } from '@/lib/loadVocabulary';
+import { FlashCard } from './FlashCard';
+
+type SessionState = 'idle' | 'active' | 'summary';
+
+interface SessionCard {
+  word: VocabularyWord;
+  easeFactor: number;
+  intervalDays: number;
+  repetitions: number;
+  result: SM2Result | null;
+  gradedQuality: number | null;
+}
+
+interface GradeButton {
+  quality: number;
+  label: string;
+  className: string;
+}
+
+const GRADE_BUTTONS: GradeButton[] = [
+  { quality: 0, label: 'Again', className: 'bg-error text-white hover:opacity-90' },
+  { quality: 2, label: 'Hard', className: 'bg-warning text-white hover:opacity-90' },
+  { quality: 3, label: 'Good', className: 'bg-level-a2 text-white hover:opacity-90' },
+  { quality: 5, label: 'Easy', className: 'bg-success text-white hover:opacity-90' },
+];
+
+const SESSION_SIZE = 20;
+
+function shuffleAndPick<T>(arr: T[], count: number): T[] {
+  const shuffled = [...arr];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled.slice(0, count);
+}
+
+interface FlashcardSessionProps {
+  allWords: VocabularyWord[];
+  levelLabel: string;
+  levelColor: string;
+  onBack: () => void;
+}
+
+export function FlashcardSession({
+  allWords,
+  levelLabel,
+  levelColor,
+  onBack,
+}: FlashcardSessionProps) {
+  const [state, setState] = useState<SessionState>('idle');
+  const [cards, setCards] = useState<SessionCard[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isFlipped, setIsFlipped] = useState(false);
+  const gradingRef = useRef(false);
+
+  const startSession = useCallback(() => {
+    const selected = shuffleAndPick(allWords, SESSION_SIZE);
+    setCards(
+      selected.map((word) => ({
+        word,
+        easeFactor: 2.5,
+        intervalDays: 0,
+        repetitions: 0,
+        result: null,
+        gradedQuality: null,
+      })),
+    );
+    setCurrentIndex(0);
+    setIsFlipped(false);
+    setState('active');
+  }, [allWords]);
+
+  const handleFlip = useCallback(() => {
+    setIsFlipped((prev) => !prev);
+  }, []);
+
+  const handleGrade = useCallback(
+    (quality: number) => {
+      if (gradingRef.current) return;
+      gradingRef.current = true;
+
+      setCards((prev) => {
+        const updated = [...prev];
+        const card = updated[currentIndex];
+        const result = calculateNextReview(
+          quality,
+          card.easeFactor,
+          card.intervalDays,
+          card.repetitions,
+        );
+        updated[currentIndex] = {
+          ...card,
+          result,
+          gradedQuality: quality,
+          easeFactor: result.easeFactor,
+          intervalDays: result.intervalDays,
+          repetitions: result.repetitions,
+        };
+        return updated;
+      });
+
+      const nextIndex = currentIndex + 1;
+      if (nextIndex >= cards.length) {
+        setState('summary');
+      } else {
+        setCurrentIndex(nextIndex);
+        setIsFlipped(false);
+      }
+
+      gradingRef.current = false;
+    },
+    [currentIndex, cards.length],
+  );
+
+  const summaryStats = useMemo(() => {
+    if (state !== 'summary') return null;
+
+    const graded = cards.filter((c) => c.gradedQuality !== null);
+    const breakdown: Record<string, number> = { Again: 0, Hard: 0, Good: 0, Easy: 0 };
+    let totalEase = 0;
+
+    for (const card of graded) {
+      const label = getQualityLabel(card.gradedQuality!);
+      breakdown[label] = (breakdown[label] ?? 0) + 1;
+      totalEase += card.easeFactor;
+    }
+
+    return {
+      total: graded.length,
+      breakdown,
+      avgEase: graded.length > 0 ? (totalEase / graded.length).toFixed(2) : '0.00',
+    };
+  }, [state, cards]);
+
+  if (state === 'idle') {
+    return (
+      <div className="flex flex-col items-center gap-6 py-8">
+        <div
+          className="flex h-16 w-16 items-center justify-center rounded-full text-lg font-bold text-white"
+          style={{ backgroundColor: levelColor }}
+        >
+          A1
+        </div>
+        <h2 className="text-xl font-bold text-text-primary">{levelLabel}</h2>
+        <p className="text-sm text-text-secondary">
+          {allWords.length} words available. Each session reviews {Math.min(SESSION_SIZE, allWords.length)} random cards.
+        </p>
+        <button
+          data-testid="start-review"
+          className="rounded-lg px-6 py-3 text-sm font-medium text-white transition-colors hover:opacity-90"
+          style={{ backgroundColor: levelColor }}
+          onClick={startSession}
+        >
+          Start Review
+        </button>
+        <button
+          data-testid="back-to-vocab"
+          className="text-sm text-text-secondary underline hover:text-text-primary"
+          onClick={onBack}
+        >
+          Back to Vocabulary
+        </button>
+      </div>
+    );
+  }
+
+  if (state === 'summary' && summaryStats) {
+    return (
+      <div data-testid="session-summary" className="mx-auto max-w-md space-y-6 py-8">
+        <h2 className="text-center text-xl font-bold text-text-primary">Session Complete</h2>
+
+        <div className="rounded-xl border border-border bg-white p-6 shadow-sm">
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-text-secondary">Cards reviewed</span>
+              <span className="font-bold text-text-primary">{summaryStats.total}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-text-secondary">Avg. ease factor</span>
+              <span className="font-bold text-text-primary">{summaryStats.avgEase}</span>
+            </div>
+
+            <hr className="border-border" />
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-text-primary">Breakdown</p>
+              {Object.entries(summaryStats.breakdown).map(([label, count]) => (
+                <div key={label} className="flex items-center justify-between">
+                  <span className="text-sm text-text-secondary">{label}</span>
+                  <span className="text-sm font-medium text-text-primary">{count}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <button
+            data-testid="new-session"
+            className="w-full rounded-lg px-4 py-2.5 text-sm font-medium text-white transition-colors hover:opacity-90"
+            style={{ backgroundColor: levelColor }}
+            onClick={startSession}
+          >
+            New Session
+          </button>
+          <button
+            data-testid="back-to-vocab"
+            className="w-full rounded-lg border border-border bg-white px-4 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-surface-container"
+            onClick={onBack}
+          >
+            Back to Vocabulary
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const currentCard = cards[currentIndex];
+  if (!currentCard) return null;
+
+  const progress = currentIndex + 1;
+  const total = cards.length;
+  const progressPercent = (progress / total) * 100;
+
+  return (
+    <div className="mx-auto max-w-md space-y-6 py-4">
+      {/* Progress bar */}
+      <div className="space-y-1">
+        <div className="flex items-center justify-between text-sm text-text-secondary">
+          <span>Card {progress} of {total}</span>
+          <button
+            className="text-xs text-text-secondary underline hover:text-text-primary"
+            onClick={onBack}
+          >
+            End session
+          </button>
+        </div>
+        <div
+          className="h-2 w-full overflow-hidden rounded-full bg-surface-container"
+          role="progressbar"
+          aria-valuenow={progress}
+          aria-valuemin={0}
+          aria-valuemax={total}
+          data-testid="progress-bar"
+        >
+          <div
+            className="h-full rounded-full transition-all duration-300"
+            style={{ width: `${progressPercent}%`, backgroundColor: levelColor }}
+          />
+        </div>
+      </div>
+
+      {/* Card */}
+      <FlashCard
+        word={currentCard.word}
+        isFlipped={isFlipped}
+        onFlip={handleFlip}
+      />
+
+      {/* Flip button (explicit) */}
+      {!isFlipped && (
+        <div className="flex justify-center">
+          <button
+            data-testid="flip-button"
+            className="rounded-lg border border-border bg-white px-6 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-surface-container"
+            onClick={handleFlip}
+          >
+            Show Answer
+          </button>
+        </div>
+      )}
+
+      {/* Grade buttons — visible only when flipped */}
+      {isFlipped && (
+        <div className="space-y-2">
+          <p className="text-center text-xs text-text-secondary">How well did you know this?</p>
+          <div data-testid="grade-buttons" className="grid grid-cols-4 gap-2">
+            {GRADE_BUTTONS.map((btn) => (
+              <button
+                key={btn.quality}
+                data-testid={`grade-${btn.quality}`}
+                className={`rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${btn.className}`}
+                onClick={() => handleGrade(btn.quality)}
+              >
+                {btn.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/loadVocabulary.ts
+++ b/apps/web/src/lib/loadVocabulary.ts
@@ -1,0 +1,36 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+export interface VocabularyWord {
+  id: number;
+  level: string;
+  german: string;
+  english: string;
+  article: string | null;
+  plural?: string | null;
+  exampleSentence: string;
+  topic: string;
+  audioFile: string | null;
+  easeFactor: number;
+  intervalDays: number;
+  repetitions: number;
+  nextReviewDate: string | null;
+  lastReviewedAt: string | null;
+}
+
+const VOCAB_DIR =
+  process.env.VOCAB_DIR ??
+  path.resolve(process.cwd(), '../mobile/src/data/vocabulary');
+
+export async function loadVocabulary(level: string): Promise<VocabularyWord[]> {
+  const filePath = path.join(VOCAB_DIR, `${level}_vocabulary.json`);
+
+  try {
+    const raw = await readFile(filePath, 'utf-8');
+    const data = JSON.parse(raw) as unknown;
+    if (!Array.isArray(data)) return [];
+    return data as VocabularyWord[];
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary

- **#14**: Add vocabulary flashcard session UI to `/vocab` page — level selector, 3D flip cards with SM-2 grading, session progress bar, and summary with quality breakdown
- 18 new tests across 2 test files (FlashCard + FlashcardSession), 58 total tests passing

## Quality Gates

| Gate | Result |
|------|--------|
| typecheck | PASS — zero errors |
| vitest | PASS — 58/58 tests (7 files) |

## Test plan

- [ ] CI green (typecheck + tests)
- [ ] product-owner sign-off after merge