### PR TITLE
feat(web): exam session state persistence + combined results (#15)

### DIFF
--- a/apps/web/e2e/exam-listening.spec.ts
+++ b/apps/web/e2e/exam-listening.spec.ts
@@ -60,3 +60,56 @@ test.describe('Listening MCQ answer selection and part tab progress', () => {
     await expect(page.getByTestId('section-nav-prev')).toBeDisabled();
   });
 });
+
+test.describe('Listening Part 2 true_false rendering and submission', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`/exam/${MOCK}/listening`);
+    await page.getByTestId('section-start-btn').click();
+    await page.getByTestId('section-nav-next').click();
+    await expect(page.getByTestId('part-tab-2')).toHaveClass(/bg-brand-primary/);
+  });
+
+  test('Part 2 renders richtig/falsch buttons instead of MCQ options', async ({ page }) => {
+    await expect(page.getByTestId('question-option-A1_m01_L2_q1-richtig')).toBeVisible();
+    await expect(page.getByTestId('question-option-A1_m01_L2_q1-falsch')).toBeVisible();
+  });
+
+  test('selecting richtig applies selected styling, falsch stays neutral', async ({ page }) => {
+    const richtig = page.getByTestId('question-option-A1_m01_L2_q1-richtig');
+    const falsch = page.getByTestId('question-option-A1_m01_L2_q1-falsch');
+
+    await richtig.click();
+    await expect(richtig).toHaveClass(/border-brand-primary/);
+    await expect(richtig).toHaveClass(/bg-brand-primary-surface/);
+    await expect(falsch).not.toHaveClass(/border-brand-primary/);
+  });
+
+  test('answering all parts enables submit and shows results', async ({ page }) => {
+    // Answer Part 1 MCQ questions first
+    await page.getByTestId('part-tab-1').click();
+    for (const qId of ['A1_m01_L1_q1', 'A1_m01_L1_q2', 'A1_m01_L1_q3']) {
+      await page.getByTestId(`question-option-${qId}-a`).click();
+    }
+
+    // Answer Part 2 true_false questions
+    await page.getByTestId('part-tab-2').click();
+    for (const qId of ['A1_m01_L2_q1', 'A1_m01_L2_q2', 'A1_m01_L2_q3', 'A1_m01_L2_q4', 'A1_m01_L2_q5']) {
+      await page.getByTestId(`question-option-${qId}-richtig`).click();
+    }
+
+    // Answer Part 3 MCQ questions
+    await page.getByTestId('section-nav-next').click();
+    for (const qId of ['A1_m01_L3_q1', 'A1_m01_L3_q2', 'A1_m01_L3_q3']) {
+      await page.getByTestId(`question-option-${qId}-a`).click();
+    }
+
+    // Submit
+    const submitBtn = page.getByTestId('submit-btn');
+    await expect(submitBtn).not.toBeDisabled();
+    await submitBtn.click();
+
+    // Results screen shows score
+    await expect(page.getByText(/Bestanden|Nicht bestanden/)).toBeVisible();
+    await expect(page.getByTestId('next-section-link')).toBeVisible();
+  });
+});

--- a/apps/web/src/__tests__/exam/ExamResults.test.tsx
+++ b/apps/web/src/__tests__/exam/ExamResults.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ExamResults } from '@/components/exam/ExamResults';
+import { saveSection, clearSession } from '@/lib/examSession';
+import type { SectionResult } from '@/lib/examSession';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+const listeningResult: SectionResult = {
+  answers: { q1: 'a' },
+  score: { earned: 20, max: 24, percentage: 0.833, passed: true },
+  submittedAt: '2026-04-12T10:00:00.000Z',
+};
+
+const readingResult: SectionResult = {
+  answers: { q1: 'b' },
+  score: { earned: 18, max: 24, percentage: 0.75, passed: true },
+  submittedAt: '2026-04-12T10:05:00.000Z',
+};
+
+const writingResult: SectionResult = {
+  answers: {},
+  taskAnswers: { 1: { _freetext: 'Test' } },
+  score: { earned: 8, max: 12, percentage: 0.667, passed: true },
+  submittedAt: '2026-04-12T10:10:00.000Z',
+  selfAssessment: 67,
+};
+
+const speakingResult: SectionResult = {
+  answers: {},
+  score: { earned: 16, max: 24, percentage: 0.667, passed: true },
+  submittedAt: '2026-04-12T10:15:00.000Z',
+  selfAssessment: 67,
+};
+
+describe('ExamResults', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('shows empty state when no session exists', () => {
+    render(<ExamResults mockId="A1_mock_01" level="A1" mockNumber={1} />);
+    expect(screen.getByTestId('results-empty')).toBeInTheDocument();
+    expect(screen.getByText('Keine Prüfungsdaten vorhanden')).toBeInTheDocument();
+  });
+
+  it('shows partial results with incomplete indicator', () => {
+    saveSection('A1_mock_01', 'A1', 'listening', listeningResult);
+    saveSection('A1_mock_01', 'A1', 'reading', readingResult);
+
+    render(<ExamResults mockId="A1_mock_01" level="A1" mockNumber={1} />);
+    expect(screen.getByTestId('results-page')).toBeInTheDocument();
+    expect(screen.getByText(/Unvollständig/)).toBeInTheDocument();
+    const notDone = screen.getAllByText('Nicht bearbeitet');
+    expect(notDone.length).toBe(2);
+  });
+
+  it('shows full results with pass verdict', () => {
+    saveSection('A1_mock_01', 'A1', 'listening', listeningResult);
+    saveSection('A1_mock_01', 'A1', 'reading', readingResult);
+    saveSection('A1_mock_01', 'A1', 'writing', writingResult);
+    saveSection('A1_mock_01', 'A1', 'speaking', speakingResult);
+
+    render(<ExamResults mockId="A1_mock_01" level="A1" mockNumber={1} />);
+    const verdict = screen.getByTestId('overall-verdict');
+    expect(verdict).toBeInTheDocument();
+    expect(verdict.textContent).toContain('Bestanden');
+  });
+
+  it('shows written and oral aggregates', () => {
+    saveSection('A1_mock_01', 'A1', 'listening', listeningResult);
+    saveSection('A1_mock_01', 'A1', 'reading', readingResult);
+    saveSection('A1_mock_01', 'A1', 'writing', writingResult);
+    saveSection('A1_mock_01', 'A1', 'speaking', speakingResult);
+
+    render(<ExamResults mockId="A1_mock_01" level="A1" mockNumber={1} />);
+    expect(screen.getByTestId('written-aggregate')).toBeInTheDocument();
+    expect(screen.getByTestId('oral-aggregate')).toBeInTheDocument();
+  });
+
+  it('shows self-assessment note for writing and speaking', () => {
+    saveSection('A1_mock_01', 'A1', 'writing', writingResult);
+    saveSection('A1_mock_01', 'A1', 'speaking', speakingResult);
+
+    render(<ExamResults mockId="A1_mock_01" level="A1" mockNumber={1} />);
+    const assessmentNotes = screen.getAllByText(/Selbsteinschätzung: 67%/);
+    expect(assessmentNotes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows "Prüferbewertung ausstehend" when no self-assessment', () => {
+    const noAssessment: SectionResult = {
+      answers: {},
+      score: { earned: 0, max: 12, percentage: 0, passed: false },
+      submittedAt: '2026-04-12T10:10:00.000Z',
+    };
+    saveSection('A1_mock_01', 'A1', 'writing', noAssessment);
+
+    render(<ExamResults mockId="A1_mock_01" level="A1" mockNumber={1} />);
+    expect(screen.getByText('Prüferbewertung ausstehend')).toBeInTheDocument();
+  });
+
+  it('has restart button that clears session', async () => {
+    const user = userEvent.setup();
+    saveSection('A1_mock_01', 'A1', 'listening', listeningResult);
+
+    render(<ExamResults mockId="A1_mock_01" level="A1" mockNumber={1} />);
+    const btn = screen.getByTestId('restart-btn');
+    await user.click(btn);
+
+    expect(sessionStorage.getItem('exam_session_A1_mock_01')).toBeNull();
+  });
+
+  it('shows fail verdict when oral fails', () => {
+    saveSection('A1_mock_01', 'A1', 'listening', listeningResult);
+    saveSection('A1_mock_01', 'A1', 'reading', readingResult);
+    saveSection('A1_mock_01', 'A1', 'writing', writingResult);
+    const failSpeaking: SectionResult = {
+      answers: {},
+      score: { earned: 5, max: 24, percentage: 0.208, passed: false },
+      submittedAt: '2026-04-12T10:15:00.000Z',
+      selfAssessment: 21,
+    };
+    saveSection('A1_mock_01', 'A1', 'speaking', failSpeaking);
+
+    render(<ExamResults mockId="A1_mock_01" level="A1" mockNumber={1} />);
+    const verdict = screen.getByTestId('overall-verdict');
+    expect(verdict.textContent).toContain('Nicht bestanden');
+  });
+});

--- a/apps/web/src/__tests__/exam/ListeningExam.test.tsx
+++ b/apps/web/src/__tests__/exam/ListeningExam.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ListeningExam } from '../../components/exam/ListeningExam';
+import type { ListeningSection, ListeningPart } from '@telc/types';
+
+vi.mock('@telc/core', () => ({
+  SECTION_DURATIONS: { A1: { listening: 1200 } },
+  calculateSectionScore: vi.fn(() => ({
+    earned: 8,
+    max: 10,
+    percentage: 0.8,
+    passed: true,
+  })),
+  formatTime: (s: number) => `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`,
+  createTimerState: vi.fn(),
+  tickTimer: vi.fn(),
+}));
+
+const mcqPart: ListeningPart = {
+  partNumber: 1,
+  instructions: 'Listen and choose.',
+  instructionsTranslation: 'Hören Sie und wählen Sie.',
+  audioFile: 'audio.mp3',
+  playCount: 2,
+  questions: [
+    {
+      id: 'q1',
+      type: 'mcq' as const,
+      questionText: 'What did you hear?',
+      options: ['a) Hund', 'b) Katze', 'c) Vogel'],
+      correctAnswer: 'a',
+      explanation: 'Dog',
+    },
+  ],
+};
+
+const trueFalsePart: ListeningPart = {
+  partNumber: 2,
+  instructions: 'True or false?',
+  instructionsTranslation: 'Richtig oder falsch?',
+  audioFile: 'audio2.mp3',
+  playCount: 2,
+  questions: [
+    {
+      id: 'tf1',
+      type: 'true_false' as const,
+      questionText: 'Der Mann geht einkaufen.',
+      correctAnswer: 'richtig',
+      explanation: 'He goes shopping.',
+    },
+    {
+      id: 'tf2',
+      type: 'true_false' as const,
+      questionText: 'Die Frau bleibt zu Hause.',
+      correctAnswer: 'falsch',
+      explanation: 'She leaves.',
+    },
+  ],
+};
+
+function buildSection(parts: ListeningPart[]): ListeningSection {
+  return { totalTimeMinutes: 20, parts };
+}
+
+async function startExam() {
+  await userEvent.click(screen.getByTestId('section-start-btn'));
+}
+
+describe('ListeningExam question type rendering', () => {
+  it('renders richtig/falsch buttons for true_false questions', async () => {
+    render(
+      <ListeningExam
+        mockId="A1_mock_01"
+        level="A1"
+        mockNumber={1}
+        section={buildSection([trueFalsePart])}
+      />,
+    );
+    await startExam();
+
+    expect(screen.getByTestId('question-option-tf1-richtig')).toBeTruthy();
+    expect(screen.getByTestId('question-option-tf1-falsch')).toBeTruthy();
+    expect(screen.getByTestId('question-option-tf2-richtig')).toBeTruthy();
+    expect(screen.getByTestId('question-option-tf2-falsch')).toBeTruthy();
+  });
+
+  it('renders MCQ options for mcq questions', async () => {
+    render(
+      <ListeningExam
+        mockId="A1_mock_01"
+        level="A1"
+        mockNumber={1}
+        section={buildSection([mcqPart])}
+      />,
+    );
+    await startExam();
+
+    expect(screen.getByTestId('question-option-q1-a')).toBeTruthy();
+    expect(screen.getByTestId('question-option-q1-b')).toBeTruthy();
+    expect(screen.getByTestId('question-option-q1-c')).toBeTruthy();
+  });
+
+  it('does not render MCQ options for true_false questions', async () => {
+    render(
+      <ListeningExam
+        mockId="A1_mock_01"
+        level="A1"
+        mockNumber={1}
+        section={buildSection([trueFalsePart])}
+      />,
+    );
+    await startExam();
+
+    expect(screen.queryByText('a)')).toBeNull();
+    expect(screen.queryByText('b)')).toBeNull();
+  });
+
+  it('selecting richtig applies selected styling', async () => {
+    render(
+      <ListeningExam
+        mockId="A1_mock_01"
+        level="A1"
+        mockNumber={1}
+        section={buildSection([trueFalsePart])}
+      />,
+    );
+    await startExam();
+
+    const richtig = screen.getByTestId('question-option-tf1-richtig');
+    const falsch = screen.getByTestId('question-option-tf1-falsch');
+
+    await userEvent.click(richtig);
+    expect(richtig.className).toContain('border-brand-primary');
+    expect(richtig.className).toContain('bg-brand-primary-surface');
+    expect(falsch.className).not.toContain('border-brand-primary');
+  });
+
+  it('switching between part tabs renders correct UI per type', async () => {
+    render(
+      <ListeningExam
+        mockId="A1_mock_01"
+        level="A1"
+        mockNumber={1}
+        section={buildSection([mcqPart, trueFalsePart])}
+      />,
+    );
+    await startExam();
+
+    // Part 1 — MCQ
+    expect(screen.getByTestId('question-option-q1-a')).toBeTruthy();
+    expect(screen.queryByTestId('question-option-tf1-richtig')).toBeNull();
+
+    // Navigate to Part 2
+    await userEvent.click(screen.getByTestId('section-nav-next'));
+
+    // Part 2 — true_false
+    expect(screen.getByTestId('question-option-tf1-richtig')).toBeTruthy();
+    expect(screen.getByTestId('question-option-tf1-falsch')).toBeTruthy();
+    expect(screen.queryByTestId('question-option-q1-a')).toBeNull();
+  });
+
+  it('allAnswered spans both MCQ and true_false — submit disabled until all answered', async () => {
+    render(
+      <ListeningExam
+        mockId="A1_mock_01"
+        level="A1"
+        mockNumber={1}
+        section={buildSection([mcqPart, trueFalsePart])}
+      />,
+    );
+    await startExam();
+
+    // Answer Part 1 MCQ
+    await userEvent.click(screen.getByTestId('question-option-q1-a'));
+
+    // Navigate to Part 2
+    await userEvent.click(screen.getByTestId('section-nav-next'));
+
+    // Submit should be disabled (Part 2 unanswered)
+    expect(screen.getByTestId('submit-btn')).toBeDisabled();
+
+    // Answer all true_false questions
+    await userEvent.click(screen.getByTestId('question-option-tf1-richtig'));
+    await userEvent.click(screen.getByTestId('question-option-tf2-falsch'));
+
+    // Submit should now be enabled
+    expect(screen.getByTestId('submit-btn')).not.toBeDisabled();
+  });
+});

--- a/apps/web/src/__tests__/exam/examSession.test.ts
+++ b/apps/web/src/__tests__/exam/examSession.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getSession,
+  saveSection,
+  clearSession,
+  isSessionComplete,
+  hasAnySection,
+} from '@/lib/examSession';
+import type { ExamSessionState, SectionResult } from '@/lib/examSession';
+
+const mockResult: SectionResult = {
+  answers: { q1: 'a', q2: 'b' },
+  score: { earned: 8, max: 10, percentage: 0.8, passed: true },
+  submittedAt: '2026-04-12T10:00:00.000Z',
+};
+
+const writingResult: SectionResult = {
+  answers: {},
+  taskAnswers: { 1: { _freetext: 'Hallo' } },
+  score: { earned: 6, max: 12, percentage: 0.5, passed: false },
+  submittedAt: '2026-04-12T10:05:00.000Z',
+  selfAssessment: 50,
+};
+
+const speakingResult: SectionResult = {
+  answers: {},
+  score: { earned: 14, max: 24, percentage: 0.583, passed: false },
+  submittedAt: '2026-04-12T10:10:00.000Z',
+  selfAssessment: 58,
+};
+
+describe('examSession', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  describe('getSession', () => {
+    it('returns null when no session exists', () => {
+      expect(getSession('A1_mock_01')).toBeNull();
+    });
+
+    it('returns session after saveSection creates it', () => {
+      saveSection('A1_mock_01', 'A1', 'listening', mockResult);
+      const session = getSession('A1_mock_01');
+      expect(session).not.toBeNull();
+      expect(session!.mockId).toBe('A1_mock_01');
+      expect(session!.level).toBe('A1');
+      expect(session!.sections.listening).toEqual(mockResult);
+    });
+  });
+
+  describe('saveSection', () => {
+    it('creates a new session on first save', () => {
+      saveSection('A1_mock_01', 'A1', 'listening', mockResult);
+      const session = getSession('A1_mock_01');
+      expect(session!.startedAt).toBeDefined();
+      expect(session!.sections.listening!.score.earned).toBe(8);
+    });
+
+    it('appends to existing session without overwriting other sections', () => {
+      saveSection('A1_mock_01', 'A1', 'listening', mockResult);
+      saveSection('A1_mock_01', 'A1', 'reading', {
+        ...mockResult,
+        score: { earned: 6, max: 10, percentage: 0.6, passed: true },
+      });
+      const session = getSession('A1_mock_01');
+      expect(session!.sections.listening!.score.earned).toBe(8);
+      expect(session!.sections.reading!.score.earned).toBe(6);
+    });
+
+    it('overwrites a section on retake', () => {
+      saveSection('A1_mock_01', 'A1', 'listening', mockResult);
+      const updated: SectionResult = {
+        ...mockResult,
+        score: { earned: 10, max: 10, percentage: 1, passed: true },
+      };
+      saveSection('A1_mock_01', 'A1', 'listening', updated);
+      expect(getSession('A1_mock_01')!.sections.listening!.score.earned).toBe(10);
+    });
+
+    it('saves writing with taskAnswers and selfAssessment', () => {
+      saveSection('A1_mock_01', 'A1', 'writing', writingResult);
+      const session = getSession('A1_mock_01');
+      expect(session!.sections.writing!.taskAnswers).toEqual({ 1: { _freetext: 'Hallo' } });
+      expect(session!.sections.writing!.selfAssessment).toBe(50);
+    });
+  });
+
+  describe('clearSession', () => {
+    it('removes session from storage', () => {
+      saveSection('A1_mock_01', 'A1', 'listening', mockResult);
+      clearSession('A1_mock_01');
+      expect(getSession('A1_mock_01')).toBeNull();
+    });
+
+    it('does not affect other mock sessions', () => {
+      saveSection('A1_mock_01', 'A1', 'listening', mockResult);
+      saveSection('A1_mock_02', 'A1', 'listening', mockResult);
+      clearSession('A1_mock_01');
+      expect(getSession('A1_mock_01')).toBeNull();
+      expect(getSession('A1_mock_02')).not.toBeNull();
+    });
+  });
+
+  describe('isSessionComplete', () => {
+    it('returns false when some sections missing', () => {
+      saveSection('A1_mock_01', 'A1', 'listening', mockResult);
+      saveSection('A1_mock_01', 'A1', 'reading', mockResult);
+      const session = getSession('A1_mock_01')!;
+      expect(isSessionComplete(session)).toBe(false);
+    });
+
+    it('returns true when all 4 sections present', () => {
+      saveSection('A1_mock_01', 'A1', 'listening', mockResult);
+      saveSection('A1_mock_01', 'A1', 'reading', mockResult);
+      saveSection('A1_mock_01', 'A1', 'writing', writingResult);
+      saveSection('A1_mock_01', 'A1', 'speaking', speakingResult);
+      const session = getSession('A1_mock_01')!;
+      expect(isSessionComplete(session)).toBe(true);
+    });
+  });
+
+  describe('hasAnySection', () => {
+    it('returns false for empty sections', () => {
+      const session: ExamSessionState = {
+        mockId: 'A1_mock_01',
+        level: 'A1',
+        startedAt: new Date().toISOString(),
+        sections: {},
+      };
+      expect(hasAnySection(session)).toBe(false);
+    });
+
+    it('returns true when at least one section exists', () => {
+      saveSection('A1_mock_01', 'A1', 'speaking', speakingResult);
+      const session = getSession('A1_mock_01')!;
+      expect(hasAnySection(session)).toBe(true);
+    });
+  });
+
+  describe('serialization round-trip', () => {
+    it('preserves all fields through write and read', () => {
+      saveSection('A1_mock_01', 'A1', 'listening', mockResult);
+      saveSection('A1_mock_01', 'A1', 'reading', mockResult);
+      saveSection('A1_mock_01', 'A1', 'writing', writingResult);
+      saveSection('A1_mock_01', 'A1', 'speaking', speakingResult);
+
+      const session = getSession('A1_mock_01')!;
+      expect(session.mockId).toBe('A1_mock_01');
+      expect(session.level).toBe('A1');
+      expect(session.sections.listening).toEqual(mockResult);
+      expect(session.sections.reading).toEqual(mockResult);
+      expect(session.sections.writing).toEqual(writingResult);
+      expect(session.sections.speaking).toEqual(speakingResult);
+    });
+  });
+
+  describe('isolation', () => {
+    it('separate mocks have independent sessions', () => {
+      saveSection('A1_mock_01', 'A1', 'listening', mockResult);
+      saveSection('A1_mock_02', 'A1', 'reading', {
+        ...mockResult,
+        score: { earned: 5, max: 10, percentage: 0.5, passed: false },
+      });
+
+      const s1 = getSession('A1_mock_01')!;
+      const s2 = getSession('A1_mock_02')!;
+      expect(s1.sections.listening).toBeDefined();
+      expect(s1.sections.reading).toBeUndefined();
+      expect(s2.sections.reading).toBeDefined();
+      expect(s2.sections.listening).toBeUndefined();
+    });
+  });
+});

--- a/apps/web/src/app/exam/[mockId]/page.tsx
+++ b/apps/web/src/app/exam/[mockId]/page.tsx
@@ -3,6 +3,7 @@ import { LEVEL_CONFIG } from "@telc/config";
 import { SECTION_DURATIONS, formatTime } from "@telc/core";
 import type { Level } from "@telc/types";
 import { loadMockExam, parseMockId } from "@/lib/loadMockExam";
+import { SectionStatusBadge, SectionActionButton, ViewResultsLink } from "@/components/exam/SectionStatus";
 
 export default async function MockExamDetailPage({
   params,
@@ -98,8 +99,11 @@ export default async function MockExamDetailPage({
                   {section.icon}
                 </span>
                 <div>
-                  <div className="font-semibold text-text-primary">
+                  <div className="flex items-center font-semibold text-text-primary">
                     {section.name}
+                    {hasContent && (
+                      <SectionStatusBadge mockId={mockId} sectionKey={section.key} />
+                    )}
                   </div>
                   <div className="text-sm text-text-secondary">
                     {duration > 0 ? `${Math.round(duration / 60)} Min.` : "—"}
@@ -107,13 +111,12 @@ export default async function MockExamDetailPage({
                 </div>
               </div>
               {hasContent ? (
-                <a
+                <SectionActionButton
+                  mockId={mockId}
+                  sectionKey={section.key}
                   href={href}
-                  className="rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors hover:opacity-90"
-                  style={{ backgroundColor: cfg.color }}
-                >
-                  Starten
-                </a>
+                  color={cfg.color}
+                />
               ) : (
                 <span className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-disabled">
                   Bald
@@ -123,6 +126,9 @@ export default async function MockExamDetailPage({
           );
         })}
       </div>
+
+      {/* View results (shown when at least one section completed) */}
+      {hasContent && <ViewResultsLink mockId={mockId} />}
 
       {/* Start full exam */}
       {hasContent ? (

--- a/apps/web/src/app/exam/[mockId]/results/page.tsx
+++ b/apps/web/src/app/exam/[mockId]/results/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from 'next/navigation';
+import { parseMockId } from '@/lib/loadMockExam';
+import type { Level } from '@telc/types';
+import { ExamResults } from '@/components/exam/ExamResults';
+
+export default async function ResultsPage({
+  params,
+}: {
+  params: Promise<{ mockId: string }>;
+}) {
+  const { mockId } = await params;
+  const parsed = parseMockId(mockId);
+  if (!parsed) notFound();
+
+  const level = parsed.level as Level;
+
+  return (
+    <ExamResults
+      mockId={mockId}
+      level={level}
+      mockNumber={parsed.mockNumber}
+    />
+  );
+}

--- a/apps/web/src/components/exam/ExamResults.tsx
+++ b/apps/web/src/components/exam/ExamResults.tsx
@@ -1,0 +1,295 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import type { Level } from '@telc/types';
+import { getSession, clearSession, hasAnySection } from '@/lib/examSession';
+import type { ExamSessionState, SectionResult } from '@/lib/examSession';
+
+interface ExamResultsProps {
+  mockId: string;
+  level: Level;
+  mockNumber: number;
+}
+
+const SECTION_META = [
+  { key: 'listening' as const, label: 'Hören', icon: '🎧', aggregate: 'written' as const },
+  { key: 'reading' as const, label: 'Lesen', icon: '📖', aggregate: 'written' as const },
+  { key: 'writing' as const, label: 'Schreiben', icon: '✍️', aggregate: 'written' as const },
+  { key: 'speaking' as const, label: 'Sprechen', icon: '🗣️', aggregate: 'oral' as const },
+] as const;
+
+function SectionScoreCard({
+  label,
+  icon,
+  result,
+  isHumanGraded,
+}: {
+  label: string;
+  icon: string;
+  result: SectionResult | undefined;
+  isHumanGraded: boolean;
+}) {
+  if (!result) {
+    return (
+      <div className="flex items-center justify-between rounded-xl border border-border bg-white p-5">
+        <div className="flex items-center gap-3">
+          <span className="text-2xl">{icon}</span>
+          <span className="font-semibold text-text-primary">{label}</span>
+        </div>
+        <span
+          data-testid={`section-status-${label.toLowerCase()}`}
+          className="text-sm font-medium text-text-disabled"
+        >
+          Nicht bearbeitet
+        </span>
+      </div>
+    );
+  }
+
+  const pct = Math.round(result.score.percentage * 100);
+  const hasAssessment = result.selfAssessment !== undefined;
+
+  return (
+    <div
+      data-testid={`section-result-${label.toLowerCase()}`}
+      className={`rounded-xl border-2 p-5 ${
+        result.score.passed ? 'border-pass bg-pass-light' : 'border-fail bg-fail-light'
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <span className="text-2xl">{icon}</span>
+          <span className="font-semibold text-text-primary">{label}</span>
+        </div>
+        <div className="text-right">
+          <div className={`text-xl font-bold ${result.score.passed ? 'text-pass' : 'text-fail'}`}>
+            {result.score.earned}/{result.score.max}
+          </div>
+          <div className={`text-sm ${result.score.passed ? 'text-pass' : 'text-fail'}`}>
+            {pct}%
+          </div>
+        </div>
+      </div>
+      {isHumanGraded && !hasAssessment && (
+        <p className="mt-2 text-xs text-text-secondary italic">
+          Prüferbewertung ausstehend
+        </p>
+      )}
+      {isHumanGraded && hasAssessment && (
+        <p className="mt-2 text-xs text-text-secondary">
+          Selbsteinschätzung: {result.selfAssessment}%
+        </p>
+      )}
+    </div>
+  );
+}
+
+function computeAggregates(session: ExamSessionState) {
+  const sections = session.sections;
+  let writtenEarned = 0, writtenMax = 0;
+  let oralEarned = 0, oralMax = 0;
+
+  for (const meta of SECTION_META) {
+    const result = sections[meta.key];
+    if (!result) continue;
+    if (meta.aggregate === 'written') {
+      writtenEarned += result.score.earned;
+      writtenMax += result.score.max;
+    } else {
+      oralEarned += result.score.earned;
+      oralMax += result.score.max;
+    }
+  }
+
+  const writtenPct = writtenMax > 0 ? writtenEarned / writtenMax : 0;
+  const oralPct = oralMax > 0 ? oralEarned / oralMax : 0;
+  const totalEarned = writtenEarned + oralEarned;
+  const totalMax = writtenMax + oralMax;
+  const totalPct = totalMax > 0 ? totalEarned / totalMax : 0;
+
+  const writtenPassed = writtenPct >= 0.6;
+  const oralPassed = oralPct >= 0.6;
+  const passed = writtenPassed && oralPassed;
+
+  const isComplete = !!(sections.listening && sections.reading && sections.writing && sections.speaking);
+
+  return {
+    written: { earned: writtenEarned, max: writtenMax, pct: writtenPct, passed: writtenPassed },
+    oral: { earned: oralEarned, max: oralMax, pct: oralPct, passed: oralPassed },
+    total: { earned: totalEarned, max: totalMax, pct: totalPct },
+    passed,
+    isComplete,
+  };
+}
+
+export function ExamResults({ mockId, level, mockNumber }: ExamResultsProps) {
+  const router = useRouter();
+  const [session, setSession] = useState<ExamSessionState | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    setSession(getSession(mockId));
+    setLoaded(true);
+  }, [mockId]);
+
+  if (!loaded) return null;
+
+  if (!session || !hasAnySection(session)) {
+    return (
+      <div data-testid="results-empty" className="mx-auto max-w-3xl space-y-6">
+        <div className="rounded-xl border border-border bg-white p-8 text-center">
+          <div className="text-4xl">📋</div>
+          <h2 className="mt-3 text-xl font-bold text-text-primary">
+            Keine Prüfungsdaten vorhanden
+          </h2>
+          <p className="mt-2 text-sm text-text-secondary">
+            Starten Sie zuerst eine Prüfung, um Ergebnisse zu sehen.
+          </p>
+          <a
+            href={`/exam/${mockId}`}
+            className="mt-4 inline-block rounded-xl bg-brand-primary px-6 py-3 text-sm font-semibold text-white hover:opacity-90"
+          >
+            Zur Prüfungsübersicht
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  const agg = computeAggregates(session);
+
+  const handleRestart = () => {
+    clearSession(mockId);
+    router.push(`/exam/${mockId}`);
+  };
+
+  return (
+    <div data-testid="results-page" className="mx-auto max-w-3xl space-y-6">
+      <a
+        href={`/exam/${mockId}`}
+        className="inline-flex items-center gap-1 text-sm text-text-secondary hover:text-brand-primary"
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+        Zurück zur Prüfung
+      </a>
+
+      <div className="rounded-xl border border-border bg-white p-6 text-center">
+        <h1 className="text-xl font-bold text-text-primary">
+          Übungstest {mockNumber} — Ergebnisse
+        </h1>
+        <p className="mt-1 text-sm text-text-secondary">{level} Prüfungsergebnis</p>
+      </div>
+
+      {/* Overall verdict */}
+      <div
+        data-testid="overall-verdict"
+        className={`rounded-xl border-2 p-6 text-center ${
+          agg.isComplete
+            ? agg.passed
+              ? 'border-pass bg-pass-light'
+              : 'border-fail bg-fail-light'
+            : 'border-warning bg-warning-light'
+        }`}
+      >
+        <div
+          className={`text-3xl font-bold ${
+            agg.isComplete
+              ? agg.passed
+                ? 'text-pass'
+                : 'text-fail'
+              : 'text-warning'
+          }`}
+        >
+          {agg.total.earned}/{agg.total.max}
+        </div>
+        <div
+          className={`mt-1 text-lg font-medium ${
+            agg.isComplete
+              ? agg.passed
+                ? 'text-pass'
+                : 'text-fail'
+              : 'text-warning'
+          }`}
+        >
+          {Math.round(agg.total.pct * 100)}% —{' '}
+          {agg.isComplete
+            ? agg.passed
+              ? 'Bestanden'
+              : 'Nicht bestanden'
+            : 'Unvollständig'}
+        </div>
+        {!agg.isComplete && (
+          <p className="mt-1 text-sm text-text-secondary">
+            Einige Abschnitte wurden noch nicht bearbeitet.
+          </p>
+        )}
+      </div>
+
+      {/* Written / Oral aggregates */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div
+          data-testid="written-aggregate"
+          className={`rounded-xl border p-4 text-center ${
+            agg.written.passed ? 'border-pass' : 'border-fail'
+          }`}
+        >
+          <div className="text-sm font-medium text-text-secondary">Schriftlich</div>
+          <div className={`text-2xl font-bold ${agg.written.passed ? 'text-pass' : 'text-fail'}`}>
+            {agg.written.earned}/{agg.written.max}
+          </div>
+          <div className={`text-sm ${agg.written.passed ? 'text-pass' : 'text-fail'}`}>
+            {Math.round(agg.written.pct * 100)}% — {agg.written.passed ? 'Bestanden' : 'Nicht bestanden'}
+          </div>
+        </div>
+        <div
+          data-testid="oral-aggregate"
+          className={`rounded-xl border p-4 text-center ${
+            agg.oral.passed ? 'border-pass' : 'border-fail'
+          }`}
+        >
+          <div className="text-sm font-medium text-text-secondary">Mündlich</div>
+          <div className={`text-2xl font-bold ${agg.oral.passed ? 'text-pass' : 'text-fail'}`}>
+            {agg.oral.earned}/{agg.oral.max}
+          </div>
+          <div className={`text-sm ${agg.oral.passed ? 'text-pass' : 'text-fail'}`}>
+            {Math.round(agg.oral.pct * 100)}% — {agg.oral.passed ? 'Bestanden' : 'Nicht bestanden'}
+          </div>
+        </div>
+      </div>
+
+      {/* Per-section scores */}
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold text-text-primary">Abschnitte</h2>
+        {SECTION_META.map((meta) => (
+          <SectionScoreCard
+            key={meta.key}
+            label={meta.label}
+            icon={meta.icon}
+            result={session.sections[meta.key]}
+            isHumanGraded={meta.key === 'writing' || meta.key === 'speaking'}
+          />
+        ))}
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-3 pt-2">
+        <button
+          data-testid="restart-btn"
+          onClick={handleRestart}
+          className="rounded-xl border border-border px-5 py-3 text-sm font-medium text-text-secondary hover:border-border-hover"
+        >
+          Prüfung neu starten
+        </button>
+        <a
+          href="/exam"
+          className="flex-1 rounded-xl bg-brand-primary py-3 text-center text-sm font-semibold text-white hover:opacity-90"
+        >
+          Alle Übungstests
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/exam/ListeningExam.tsx
+++ b/apps/web/src/components/exam/ListeningExam.tsx
@@ -179,33 +179,67 @@ export function ListeningExam({ mockId, level, section }: ListeningExamProps) {
             <p className="mb-3 font-medium text-text-primary">
               {qi + 1}. {q.questionText}
             </p>
-            <div className="space-y-2">
-              {(q.options ?? []).map((opt) => {
-                const value = opt.split(')')[0].trim();
-                const selected = answers[q.id] === value;
-                return (
-                  <label
-                    key={opt}
-                    data-testid={`question-option-${q.id}-${value}`}
-                    className={`flex cursor-pointer items-center gap-3 rounded-lg border px-4 py-3 transition-colors ${
-                      selected
-                        ? 'border-brand-primary bg-brand-primary-surface'
-                        : 'border-border bg-white hover:border-border-hover'
-                    }`}
-                  >
-                    <input
-                      type="radio"
-                      name={q.id}
-                      value={value}
-                      checked={selected}
-                      onChange={() => handleAnswer(q.id, value)}
-                      className="accent-brand-primary"
-                    />
-                    <span className="text-sm text-text-primary">{opt}</span>
-                  </label>
-                );
-              })}
-            </div>
+
+            {q.type === 'true_false' && (
+              <div className="flex gap-3">
+                {['richtig', 'falsch'].map((opt) => {
+                  const selected = answers[q.id] === opt;
+                  return (
+                    <label
+                      key={opt}
+                      data-testid={`question-option-${q.id}-${opt}`}
+                      className={`flex cursor-pointer items-center gap-2 rounded-lg border px-5 py-2.5 transition-colors ${
+                        selected
+                          ? 'border-brand-primary bg-brand-primary-surface'
+                          : 'border-border bg-white hover:border-border-hover'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name={q.id}
+                        value={opt}
+                        checked={selected}
+                        onChange={() => handleAnswer(q.id, opt)}
+                        className="accent-brand-primary"
+                      />
+                      <span className="text-sm font-medium text-text-primary capitalize">
+                        {opt}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+
+            {q.type === 'mcq' && (
+              <div className="space-y-2">
+                {(q.options ?? []).map((opt) => {
+                  const value = opt.split(')')[0].trim();
+                  const selected = answers[q.id] === value;
+                  return (
+                    <label
+                      key={opt}
+                      data-testid={`question-option-${q.id}-${value}`}
+                      className={`flex cursor-pointer items-center gap-3 rounded-lg border px-4 py-3 transition-colors ${
+                        selected
+                          ? 'border-brand-primary bg-brand-primary-surface'
+                          : 'border-border bg-white hover:border-border-hover'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name={q.id}
+                        value={value}
+                        checked={selected}
+                        onChange={() => handleAnswer(q.id, value)}
+                        className="accent-brand-primary"
+                      />
+                      <span className="text-sm text-text-primary">{opt}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/apps/web/src/components/exam/ListeningExam.tsx
+++ b/apps/web/src/components/exam/ListeningExam.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { SECTION_DURATIONS, calculateSectionScore } from '@telc/core';
 import type { ListeningSection, Level } from '@telc/types';
 import type { ExamPhase } from '@/lib/examTypes';
+import { saveSection } from '@/lib/examSession';
 import { ExamTimer } from './ExamTimer';
 import { SectionIntro } from './SectionIntro';
 import { QuestionResultRow } from './QuestionResultRow';
@@ -32,6 +33,16 @@ export function ListeningExam({ mockId, level, section }: ListeningExamProps) {
     () => (phase === 'submitted' ? calculateSectionScore(answers, section) : null),
     [phase, answers, section],
   );
+
+  useEffect(() => {
+    if (phase === 'submitted' && score) {
+      saveSection(mockId, level, 'listening', {
+        answers,
+        score,
+        submittedAt: new Date().toISOString(),
+      });
+    }
+  }, [phase, score, mockId, level, answers]);
 
   const allAnswered = useMemo(
     () => section.parts.every((p) => p.questions.every((q) => answers[q.id] !== undefined)),

--- a/apps/web/src/components/exam/ReadingExam.tsx
+++ b/apps/web/src/components/exam/ReadingExam.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { SECTION_DURATIONS, calculateSectionScore } from '@telc/core';
 import type { ReadingSection, ReadingPart, Level } from '@telc/types';
 import type { ExamPhase } from '@/lib/examTypes';
+import { saveSection } from '@/lib/examSession';
 import { ExamTimer } from './ExamTimer';
 import { SectionIntro } from './SectionIntro';
 import { QuestionResultRow } from './QuestionResultRow';
@@ -30,6 +31,16 @@ export function ReadingExam({ mockId, level, section }: ReadingExamProps) {
     () => (phase === 'submitted' ? calculateSectionScore(answers, section) : null),
     [phase, answers, section],
   );
+
+  useEffect(() => {
+    if (phase === 'submitted' && score) {
+      saveSection(mockId, level, 'reading', {
+        answers,
+        score,
+        submittedAt: new Date().toISOString(),
+      });
+    }
+  }, [phase, score, mockId, level, answers]);
 
   const allAnswered = useMemo(
     () => section.parts.every((p) => p.questions.every((q) => answers[q.id] !== undefined)),

--- a/apps/web/src/components/exam/SectionStatus.tsx
+++ b/apps/web/src/components/exam/SectionStatus.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getSession, hasAnySection } from '@/lib/examSession';
+
+export function SectionStatusBadge({
+  mockId,
+  sectionKey,
+}: {
+  mockId: string;
+  sectionKey: 'listening' | 'reading' | 'writing' | 'speaking';
+}) {
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    const session = getSession(mockId);
+    if (session?.sections[sectionKey]) {
+      setDone(true);
+    }
+  }, [mockId, sectionKey]);
+
+  if (!done) return null;
+
+  return (
+    <span
+      data-testid={`section-done-${sectionKey}`}
+      className="ml-2 inline-flex h-5 w-5 items-center justify-center rounded-full bg-success text-xs text-white"
+      aria-label="Abgeschlossen"
+    >
+      ✓
+    </span>
+  );
+}
+
+export function SectionActionButton({
+  mockId,
+  sectionKey,
+  href,
+  color,
+}: {
+  mockId: string;
+  sectionKey: 'listening' | 'reading' | 'writing' | 'speaking';
+  href: string;
+  color: string;
+}) {
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    const session = getSession(mockId);
+    if (session?.sections[sectionKey]) {
+      setDone(true);
+    }
+  }, [mockId, sectionKey]);
+
+  return (
+    <a
+      href={href}
+      className="rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors hover:opacity-90"
+      style={{ backgroundColor: color }}
+    >
+      {done ? 'Wiederholen' : 'Starten'}
+    </a>
+  );
+}
+
+export function ViewResultsLink({ mockId }: { mockId: string }) {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const session = getSession(mockId);
+    if (session && hasAnySection(session)) {
+      setShow(true);
+    }
+  }, [mockId]);
+
+  if (!show) return null;
+
+  return (
+    <a
+      data-testid="view-results-link"
+      href={`/exam/${mockId}/results`}
+      className="block w-full rounded-xl border-2 border-brand-primary py-4 text-center text-lg font-semibold text-brand-primary transition-colors hover:bg-brand-primary hover:text-white"
+    >
+      Ergebnisse anzeigen
+    </a>
+  );
+}

--- a/apps/web/src/components/exam/SpeakingExam.tsx
+++ b/apps/web/src/components/exam/SpeakingExam.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { SECTION_DURATIONS } from '@telc/core';
+import type { SectionScore } from '@telc/core';
 import type { SpeakingSection, Level } from '@telc/types';
 import type { ExamPhase } from '@/lib/examTypes';
+import { saveSection } from '@/lib/examSession';
 import { ExamTimer } from './ExamTimer';
 import { SectionIntro } from './SectionIntro';
 
@@ -17,7 +19,33 @@ export function SpeakingExam({ mockId, level, section }: SpeakingExamProps) {
   const [phase, setPhase] = useState<ExamPhase>('intro');
   const [currentPart, setCurrentPart] = useState(0);
   const [showSample, setShowSample] = useState<Record<number, boolean>>({});
+  const [selfAssessment, setSelfAssessment] = useState<number | null>(null);
   const totalSeconds = SECTION_DURATIONS[level].speaking;
+
+  const speakingMax = useMemo(
+    () => section.parts.length * 8,
+    [section.parts.length],
+  );
+
+  useEffect(() => {
+    if (phase === 'submitted') {
+      const score: SectionScore = selfAssessment !== null
+        ? {
+            earned: Math.round((selfAssessment / 100) * speakingMax),
+            max: speakingMax,
+            percentage: selfAssessment / 100,
+            passed: selfAssessment >= 60,
+          }
+        : { earned: 0, max: speakingMax, percentage: 0, passed: false };
+
+      saveSection(mockId, level, 'speaking', {
+        answers: {},
+        score,
+        submittedAt: new Date().toISOString(),
+        selfAssessment: selfAssessment ?? undefined,
+      });
+    }
+  }, [phase, selfAssessment, mockId, level, speakingMax]);
 
   const handleExpire = useCallback(() => setPhase('submitted'), []);
   const totalParts = section.parts.length;
@@ -55,6 +83,31 @@ export function SpeakingExam({ mockId, level, section }: SpeakingExamProps) {
           </p>
         </div>
 
+        <div className="rounded-xl border border-border bg-white p-5 space-y-3">
+          <h3 className="font-semibold text-text-primary">Selbsteinschätzung</h3>
+          <p className="text-sm text-text-secondary">
+            Wie gut haben Sie Ihrer Meinung nach abgeschnitten? (0-100%)
+          </p>
+          <div className="flex items-center gap-4">
+            <input
+              data-testid="self-assessment-slider"
+              type="range"
+              min={0}
+              max={100}
+              step={5}
+              value={selfAssessment ?? 50}
+              onChange={(e) => setSelfAssessment(Number(e.target.value))}
+              className="flex-1 accent-brand-primary"
+            />
+            <span
+              data-testid="self-assessment-value"
+              className="w-14 text-center text-lg font-bold text-text-primary"
+            >
+              {selfAssessment !== null ? `${selfAssessment}%` : '—'}
+            </span>
+          </div>
+        </div>
+
         <div className="space-y-4">
           {section.parts.map((p) => (
             <div
@@ -85,10 +138,11 @@ export function SpeakingExam({ mockId, level, section }: SpeakingExamProps) {
             Zur Prüfungsübersicht
           </a>
           <a
-            href={`/exam?level=${level}`}
+            data-testid="view-results-link"
+            href={`/exam/${mockId}/results`}
             className="flex-1 rounded-xl bg-brand-primary py-3 text-center text-sm font-semibold text-white hover:opacity-90"
           >
-            Alle Übungstests
+            Ergebnisse anzeigen
           </a>
         </div>
       </div>

--- a/apps/web/src/components/exam/WritingExam.tsx
+++ b/apps/web/src/components/exam/WritingExam.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { SECTION_DURATIONS } from '@telc/core';
+import type { SectionScore } from '@telc/core';
 import type { WritingSection, Level } from '@telc/types';
 import type { ExamPhase } from '@/lib/examTypes';
+import { saveSection } from '@/lib/examSession';
 import { ExamTimer } from './ExamTimer';
 import { SectionIntro } from './SectionIntro';
 
@@ -19,7 +21,34 @@ export function WritingExam({ mockId, level, section }: WritingExamProps) {
   const [taskAnswers, setTaskAnswers] = useState<Record<number, Record<string, string>>>({});
   const totalSeconds = SECTION_DURATIONS[level].writing;
 
+  const [selfAssessment, setSelfAssessment] = useState<number | null>(null);
   const handleExpire = useCallback(() => setPhase('submitted'), []);
+
+  const writingMax = useMemo(
+    () => section.tasks.reduce((sum, t) => sum + t.scoringCriteria.reduce((s, c) => s + c.maxPoints, 0), 0),
+    [section.tasks],
+  );
+
+  useEffect(() => {
+    if (phase === 'submitted') {
+      const score: SectionScore = selfAssessment !== null
+        ? {
+            earned: Math.round((selfAssessment / 100) * writingMax),
+            max: writingMax,
+            percentage: selfAssessment / 100,
+            passed: selfAssessment >= 60,
+          }
+        : { earned: 0, max: writingMax, percentage: 0, passed: false };
+
+      saveSection(mockId, level, 'writing', {
+        answers: {},
+        taskAnswers,
+        score,
+        submittedAt: new Date().toISOString(),
+        selfAssessment: selfAssessment ?? undefined,
+      });
+    }
+  }, [phase, selfAssessment, taskAnswers, mockId, level, writingMax]);
 
   const setFieldAnswer = (taskNum: number, field: string, value: string) => {
     setTaskAnswers((prev) => ({
@@ -48,6 +77,8 @@ export function WritingExam({ mockId, level, section }: WritingExamProps) {
         taskAnswers={taskAnswers}
         backHref={`/exam/${mockId}`}
         nextHref={`/exam/${mockId}/speaking`}
+        selfAssessment={selfAssessment}
+        onSelfAssessment={setSelfAssessment}
       />
     );
   }
@@ -176,11 +207,15 @@ function WritingResults({
   taskAnswers,
   backHref,
   nextHref,
+  selfAssessment,
+  onSelfAssessment,
 }: {
   section: WritingSection;
   taskAnswers: Record<number, Record<string, string>>;
   backHref: string;
   nextHref: string;
+  selfAssessment: number | null;
+  onSelfAssessment: (value: number) => void;
 }) {
   return (
     <div className="space-y-6">
@@ -191,6 +226,31 @@ function WritingResults({
           Schreibaufgaben werden von einem Prüfer bewertet. Vergleichen Sie Ihre Antworten mit
           den Musterlösungen unten.
         </p>
+      </div>
+
+      <div className="rounded-xl border border-border bg-white p-5 space-y-3">
+        <h3 className="font-semibold text-text-primary">Selbsteinschätzung</h3>
+        <p className="text-sm text-text-secondary">
+          Wie gut haben Sie Ihrer Meinung nach abgeschnitten? (0-100%)
+        </p>
+        <div className="flex items-center gap-4">
+          <input
+            data-testid="self-assessment-slider"
+            type="range"
+            min={0}
+            max={100}
+            step={5}
+            value={selfAssessment ?? 50}
+            onChange={(e) => onSelfAssessment(Number(e.target.value))}
+            className="flex-1 accent-brand-primary"
+          />
+          <span
+            data-testid="self-assessment-value"
+            className="w-14 text-center text-lg font-bold text-text-primary"
+          >
+            {selfAssessment !== null ? `${selfAssessment}%` : '—'}
+          </span>
+        </div>
       </div>
 
       {section.tasks.map((task) => {

--- a/apps/web/src/lib/examSession.ts
+++ b/apps/web/src/lib/examSession.ts
@@ -1,0 +1,72 @@
+import type { SectionScore } from '@telc/core';
+import type { Level } from '@telc/types';
+
+export interface SectionResult {
+  answers: Record<string, string>;
+  taskAnswers?: Record<number, Record<string, string>>;
+  score: SectionScore;
+  submittedAt: string;
+  selfAssessment?: number;
+}
+
+export interface ExamSessionState {
+  mockId: string;
+  level: Level;
+  startedAt: string;
+  sections: {
+    listening?: SectionResult;
+    reading?: SectionResult;
+    writing?: SectionResult;
+    speaking?: SectionResult;
+  };
+}
+
+type SectionKey = keyof ExamSessionState['sections'];
+
+function storageKey(mockId: string): string {
+  return `exam_session_${mockId}`;
+}
+
+export function getSession(mockId: string): ExamSessionState | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = sessionStorage.getItem(storageKey(mockId));
+    if (!raw) return null;
+    return JSON.parse(raw) as ExamSessionState;
+  } catch {
+    return null;
+  }
+}
+
+export function saveSection(
+  mockId: string,
+  level: Level,
+  section: SectionKey,
+  result: SectionResult,
+): void {
+  if (typeof window === 'undefined') return;
+  const existing = getSession(mockId);
+  const session: ExamSessionState = existing ?? {
+    mockId,
+    level,
+    startedAt: new Date().toISOString(),
+    sections: {},
+  };
+  session.sections[section] = result;
+  sessionStorage.setItem(storageKey(mockId), JSON.stringify(session));
+}
+
+export function clearSession(mockId: string): void {
+  if (typeof window === 'undefined') return;
+  sessionStorage.removeItem(storageKey(mockId));
+}
+
+export function isSessionComplete(session: ExamSessionState): boolean {
+  const { listening, reading, writing, speaking } = session.sections;
+  return !!(listening && reading && writing && speaking);
+}
+
+export function hasAnySection(session: ExamSessionState): boolean {
+  const { listening, reading, writing, speaking } = session.sections;
+  return !!(listening || reading || writing || speaking);
+}


### PR DESCRIPTION
## Summary

- **#15**: Add sessionStorage-based exam session persistence across sections with combined results page
- 6 new files, 5 modified files, 22 new unit tests (68 total passing)

### What's included
- `examSession.ts` — sessionStorage layer for persisting section results keyed by mockId
- All 4 section components (Listening, Reading, Writing, Speaking) save results on submit
- Writing and Speaking sections include self-assessment slider (0-100%)
- Combined results page at `/exam/[mockId]/results` with per-section scores, written/oral aggregates, and pass/fail verdict
- Mock detail page shows completion checkmarks and "Ergebnisse anzeigen" link
- Section buttons switch from "Starten" to "Wiederholen" after completion
- Empty state handling, incomplete exam indicator, restart button

## Quality Gates

| Gate | Result |
|------|--------|
| Typecheck | PASS — zero errors |
| Unit tests | PASS — 68/68 (22 new: 14 examSession + 8 ExamResults) |
| exam-tester | n/a (no content changes) |
| compliance-guardian | n/a (no auth/PII) |

## Test plan

- [ ] CI green (typecheck + tests)
- [ ] product-owner sign-off after merge