### PR TITLE
feat(web): grammar hub — topic list + exercise player (#19)

### DIFF
--- a/apps/web/src/__tests__/grammar/ExercisePlayer.test.tsx
+++ b/apps/web/src/__tests__/grammar/ExercisePlayer.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ExercisePlayer } from '../../components/grammar/ExercisePlayer';
+import type { GrammarExercise } from '@telc/types';
+
+const fillBlank: GrammarExercise = {
+  type: 'fill_blank',
+  prompt: 'Ich ___ (lernen) jeden Tag Deutsch.',
+  correctAnswer: 'lerne',
+  explanation: 'First person singular: stem + -e',
+};
+
+const mcq: GrammarExercise = {
+  type: 'mcq',
+  prompt: 'Wir ___ in einer kleinen Stadt.',
+  correctAnswer: 'wohnen',
+  explanation: 'First person plural takes infinitive form.',
+};
+
+const reorder: GrammarExercise = {
+  type: 'reorder',
+  prompt: 'Reorder: Deutsch / Ich / lerne',
+  correctAnswer: 'Ich lerne Deutsch',
+  explanation: 'Subject-Verb-Object order.',
+};
+
+const exercises = [fillBlank, mcq, reorder];
+
+describe('ExercisePlayer', () => {
+  it('renders the first exercise with counter and progress bar', () => {
+    render(<ExercisePlayer exercises={exercises} topicName="Test" />);
+
+    expect(screen.getByTestId('exercise-player')).toBeDefined();
+    expect(screen.getByTestId('exercise-counter')).toHaveTextContent('Übung 1 von 3');
+    expect(screen.getByTestId('exercise-prompt')).toHaveTextContent(fillBlank.prompt);
+  });
+
+  it('disables check button when no answer entered (fill_blank)', () => {
+    render(<ExercisePlayer exercises={[fillBlank]} topicName="Test" />);
+
+    const checkBtn = screen.getByTestId('check-button');
+    expect(checkBtn).toBeDisabled();
+  });
+
+  it('enables check button after typing in fill_blank', () => {
+    render(<ExercisePlayer exercises={[fillBlank]} topicName="Test" />);
+
+    const input = screen.getByTestId('exercise-input');
+    fireEvent.change(input, { target: { value: 'lerne' } });
+
+    expect(screen.getByTestId('check-button')).not.toBeDisabled();
+  });
+
+  it('shows correct feedback for correct fill_blank answer', () => {
+    render(<ExercisePlayer exercises={[fillBlank]} topicName="Test" />);
+
+    fireEvent.change(screen.getByTestId('exercise-input'), {
+      target: { value: 'lerne' },
+    });
+    fireEvent.click(screen.getByTestId('check-button'));
+
+    expect(screen.getByTestId('exercise-feedback-correct')).toBeDefined();
+    expect(screen.getByText('Richtig!')).toBeDefined();
+  });
+
+  it('shows incorrect feedback for wrong fill_blank answer', () => {
+    render(<ExercisePlayer exercises={[fillBlank]} topicName="Test" />);
+
+    fireEvent.change(screen.getByTestId('exercise-input'), {
+      target: { value: 'lernt' },
+    });
+    fireEvent.click(screen.getByTestId('check-button'));
+
+    expect(screen.getByTestId('exercise-feedback-incorrect')).toBeDefined();
+    expect(screen.getByText('Leider falsch')).toBeDefined();
+    expect(screen.getByText(fillBlank.explanation)).toBeDefined();
+  });
+
+  it('performs case-insensitive comparison', () => {
+    render(<ExercisePlayer exercises={[fillBlank]} topicName="Test" />);
+
+    fireEvent.change(screen.getByTestId('exercise-input'), {
+      target: { value: '  Lerne  ' },
+    });
+    fireEvent.click(screen.getByTestId('check-button'));
+
+    expect(screen.getByTestId('exercise-feedback-correct')).toBeDefined();
+  });
+
+  it('locks input after checking', () => {
+    render(<ExercisePlayer exercises={[fillBlank]} topicName="Test" />);
+
+    fireEvent.change(screen.getByTestId('exercise-input'), {
+      target: { value: 'lerne' },
+    });
+    fireEvent.click(screen.getByTestId('check-button'));
+
+    expect(screen.getByTestId('exercise-input')).toBeDisabled();
+  });
+
+  it('advances to next exercise on Next click', () => {
+    render(<ExercisePlayer exercises={exercises} topicName="Test" />);
+
+    // answer first exercise
+    fireEvent.change(screen.getByTestId('exercise-input'), {
+      target: { value: 'lerne' },
+    });
+    fireEvent.click(screen.getByTestId('check-button'));
+    fireEvent.click(screen.getByTestId('next-button'));
+
+    expect(screen.getByTestId('exercise-counter')).toHaveTextContent('Übung 2 von 3');
+  });
+
+  it('shows summary after completing all exercises', () => {
+    const onComplete = vi.fn();
+    render(
+      <ExercisePlayer exercises={[fillBlank]} topicName="Test Topic" onComplete={onComplete} />,
+    );
+
+    fireEvent.change(screen.getByTestId('exercise-input'), {
+      target: { value: 'lerne' },
+    });
+    fireEvent.click(screen.getByTestId('check-button'));
+
+    // last exercise — button should say "Ergebnis anzeigen"
+    const nextBtn = screen.getByTestId('next-button');
+    expect(nextBtn).toHaveTextContent('Ergebnis anzeigen');
+    fireEvent.click(nextBtn);
+
+    expect(screen.getByTestId('exercise-summary')).toBeDefined();
+    expect(screen.getByTestId('exercise-score')).toHaveTextContent('1 / 1 richtig (100%)');
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+  it('shows 0% when all answers are wrong', () => {
+    render(<ExercisePlayer exercises={[fillBlank]} topicName="Test" />);
+
+    fireEvent.change(screen.getByTestId('exercise-input'), {
+      target: { value: 'wrong' },
+    });
+    fireEvent.click(screen.getByTestId('check-button'));
+    fireEvent.click(screen.getByTestId('next-button'));
+
+    expect(screen.getByTestId('exercise-score')).toHaveTextContent('0 / 1 richtig (0%)');
+  });
+
+  it('resets exercises on retry', () => {
+    render(<ExercisePlayer exercises={[fillBlank]} topicName="Test" />);
+
+    // complete exercise
+    fireEvent.change(screen.getByTestId('exercise-input'), {
+      target: { value: 'lerne' },
+    });
+    fireEvent.click(screen.getByTestId('check-button'));
+    fireEvent.click(screen.getByTestId('next-button'));
+
+    // retry
+    fireEvent.click(screen.getByTestId('retry-button'));
+
+    expect(screen.getByTestId('exercise-player')).toBeDefined();
+    expect(screen.getByTestId('exercise-counter')).toHaveTextContent('Übung 1 von 1');
+  });
+
+  it('handles reorder type with text input', () => {
+    render(<ExercisePlayer exercises={[reorder]} topicName="Test" />);
+
+    expect(screen.getByTestId('exercise-input')).toBeDefined();
+    fireEvent.change(screen.getByTestId('exercise-input'), {
+      target: { value: 'Ich lerne Deutsch' },
+    });
+    fireEvent.click(screen.getByTestId('check-button'));
+
+    expect(screen.getByTestId('exercise-feedback-correct')).toBeDefined();
+  });
+});

--- a/apps/web/src/__tests__/grammar/TopicCard.test.tsx
+++ b/apps/web/src/__tests__/grammar/TopicCard.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TopicCard } from '../../components/grammar/TopicCard';
+import type { GrammarTopic } from '@telc/types';
+
+const mockTopic: GrammarTopic = {
+  id: 1,
+  level: 'A1',
+  topic: 'Präsens — regelmäßige Verben',
+  explanation: 'Regular verbs follow a predictable pattern.',
+  examples: ['Ich lerne Deutsch.', 'Du spielst Fußball.', 'Er kommt aus Berlin.'],
+  exercises: [
+    {
+      type: 'fill_blank',
+      prompt: 'Ich ___ (lernen) jeden Tag Deutsch.',
+      correctAnswer: 'lerne',
+      explanation: 'First person singular: stem + -e',
+    },
+    {
+      type: 'mcq',
+      prompt: 'Wir ___ in einer kleinen Stadt.',
+      correctAnswer: 'wohnen',
+      explanation: 'First person plural takes infinitive form.',
+    },
+  ],
+  orderIndex: 1,
+};
+
+const topicNoExercises: GrammarTopic = {
+  ...mockTopic,
+  id: 2,
+  exercises: undefined,
+  orderIndex: 2,
+  topic: 'Test topic without exercises',
+};
+
+describe('TopicCard', () => {
+  it('renders topic name, order number, and counts', () => {
+    render(<TopicCard topic={mockTopic} levelColor="#4caf50" />);
+
+    expect(screen.getByText('Präsens — regelmäßige Verben')).toBeDefined();
+    expect(screen.getByText('1')).toBeDefined();
+    expect(screen.getByText('3 Beispiele')).toBeDefined();
+    expect(screen.getByText('2 Übungen')).toBeDefined();
+  });
+
+  it('links to the topic detail page', () => {
+    render(<TopicCard topic={mockTopic} levelColor="#4caf50" />);
+
+    const link = screen.getByTestId('topic-card-1');
+    expect(link.getAttribute('href')).toBe('/grammar/1');
+  });
+
+  it('hides exercise count when no exercises', () => {
+    render(<TopicCard topic={topicNoExercises} levelColor="#4caf50" />);
+
+    expect(screen.getByText('3 Beispiele')).toBeDefined();
+    expect(screen.queryByText(/Übungen/)).toBeNull();
+  });
+
+  it('applies the level color to the order badge', () => {
+    render(<TopicCard topic={mockTopic} levelColor="#4caf50" />);
+
+    const badge = screen.getByText('1');
+    expect(badge.style.backgroundColor).toBe('rgb(76, 175, 80)');
+  });
+});

--- a/apps/web/src/app/grammar/GrammarPageClient.tsx
+++ b/apps/web/src/app/grammar/GrammarPageClient.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useState } from 'react';
+import type { Level, GrammarTopic } from '@telc/types';
+import { TopicCard } from '@/components/grammar/TopicCard';
+
+interface LevelConfig {
+  level: Level;
+  color: string;
+  label: string;
+  topicCount: number;
+  topics: GrammarTopic[];
+}
+
+interface GrammarPageClientProps {
+  levels: LevelConfig[];
+}
+
+export function GrammarPageClient({ levels }: GrammarPageClientProps) {
+  const [selectedLevel, setSelectedLevel] = useState<Level | null>(null);
+  const selected = levels.find((l) => l.level === selectedLevel);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-text-primary">Grammar</h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          Key grammar topics with explanations, examples, and exercises.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {levels.map(({ level, color, label, topicCount }) => {
+          const available = topicCount > 0;
+          const isSelected = selectedLevel === level;
+
+          return (
+            <div
+              key={level}
+              data-testid={`level-card-${level}`}
+              className={`rounded-xl border bg-white p-6 transition-shadow ${
+                isSelected ? 'border-2 shadow-md' : 'border-border'
+              }`}
+              style={isSelected ? { borderColor: color } : undefined}
+            >
+              <div className="flex items-center gap-3">
+                <span
+                  className="flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold text-white"
+                  style={{ backgroundColor: color }}
+                >
+                  {level}
+                </span>
+                <div>
+                  <div className="font-semibold text-text-primary">
+                    {level} Grammar
+                  </div>
+                  <div className="text-xs text-text-secondary">
+                    {available
+                      ? `${topicCount} topics available`
+                      : 'Coming soon'}
+                  </div>
+                </div>
+              </div>
+              <div className="mt-4">
+                <button
+                  data-testid={`browse-button-${level}`}
+                  className="w-full rounded-lg px-4 py-2.5 text-sm font-medium text-white transition-colors hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+                  style={{ backgroundColor: color }}
+                  disabled={!available}
+                  onClick={() =>
+                    setSelectedLevel(isSelected ? null : level)
+                  }
+                >
+                  {!available
+                    ? 'Coming Soon'
+                    : isSelected
+                      ? 'Hide Topics'
+                      : 'Browse Topics'}
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {selected && selected.topics.length > 0 && (
+        <section data-testid="topic-list">
+          <h2 className="mb-3 text-lg font-semibold text-text-primary">
+            {selected.level} Topics
+          </h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {selected.topics.map((topic) => (
+              <TopicCard
+                key={topic.id}
+                topic={topic}
+                levelColor={selected.color}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {selected && selected.topics.length === 0 && (
+        <div
+          data-testid="no-topics"
+          className="rounded-xl border border-border bg-white p-8 text-center text-text-secondary"
+        >
+          No grammar topics available for {selected.level}.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/grammar/[topicId]/TopicDetailPage.tsx
+++ b/apps/web/src/app/grammar/[topicId]/TopicDetailPage.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import type { GrammarTopic } from '@telc/types';
+import { TopicDetail } from '@/components/grammar/TopicDetail';
+import { ExercisePlayer } from '@/components/grammar/ExercisePlayer';
+
+interface TopicDetailPageProps {
+  topic: GrammarTopic;
+  orderIndex: number;
+  totalTopics: number;
+  hasPrev: boolean;
+  hasNext: boolean;
+}
+
+export function TopicDetailPage({
+  topic,
+  orderIndex,
+  totalTopics,
+  hasPrev,
+  hasNext,
+}: TopicDetailPageProps) {
+  const router = useRouter();
+  const exercises = topic.exercises ?? [];
+  const hasExercises = exercises.length > 0;
+
+  return (
+    <div className="space-y-6">
+      {/* header with back + nav */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Link
+          href="/grammar"
+          data-testid="back-to-overview"
+          className="inline-flex items-center gap-1 text-sm font-medium text-brand-primary hover:text-brand-primary-light transition-colors"
+        >
+          <span aria-hidden="true">&larr;</span> Übersicht
+        </Link>
+
+        <div className="flex items-center gap-2">
+          <button
+            data-testid="prev-topic"
+            disabled={!hasPrev}
+            onClick={() => router.push(`/grammar/${orderIndex - 1}`)}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-primary transition-colors hover:bg-surface-container disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            &larr; Zurück
+          </button>
+          <span
+            data-testid="topic-counter"
+            className="text-sm text-text-secondary"
+          >
+            {orderIndex} / {totalTopics}
+          </span>
+          <button
+            data-testid="next-topic"
+            disabled={!hasNext}
+            onClick={() => router.push(`/grammar/${orderIndex + 1}`)}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-primary transition-colors hover:bg-surface-container disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Weiter &rarr;
+          </button>
+        </div>
+      </div>
+
+      {/* topic title */}
+      <h1 className="text-2xl font-bold text-text-primary">{topic.topic}</h1>
+
+      {/* explanation + examples */}
+      <TopicDetail topic={topic} />
+
+      {/* exercise player */}
+      {hasExercises && (
+        <ExercisePlayer
+          exercises={exercises}
+          topicName={topic.topic}
+        />
+      )}
+
+      {/* bottom nav after exercises / when no exercises */}
+      <div className="flex flex-wrap items-center justify-between gap-3 pt-2">
+        {hasNext && (
+          <button
+            data-testid="next-topic-bottom"
+            onClick={() => router.push(`/grammar/${orderIndex + 1}`)}
+            className="rounded-lg bg-brand-primary px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-primary-light"
+          >
+            Nächstes Thema
+          </button>
+        )}
+        <Link
+          href="/grammar"
+          data-testid="back-to-overview-bottom"
+          className="rounded-lg border border-border px-4 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-surface-container"
+        >
+          Zur Übersicht
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/grammar/[topicId]/not-found.tsx
+++ b/apps/web/src/app/grammar/[topicId]/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+
+export default function TopicNotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <h1 className="text-2xl font-bold text-text-primary">
+        Topic not found
+      </h1>
+      <p className="mt-2 text-text-secondary">
+        The grammar topic you are looking for does not exist.
+      </p>
+      <Link
+        href="/grammar"
+        className="mt-6 rounded-lg bg-brand-primary px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-primary-light"
+      >
+        Back to Grammar
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/app/grammar/[topicId]/page.tsx
+++ b/apps/web/src/app/grammar/[topicId]/page.tsx
@@ -1,0 +1,37 @@
+import { notFound } from 'next/navigation';
+import { loadGrammar } from '@/lib/loadGrammar';
+import { TopicDetailPage } from './TopicDetailPage';
+
+interface Props {
+  params: Promise<{ topicId: string }>;
+}
+
+export default async function GrammarTopicPage({ params }: Props) {
+  const { topicId } = await params;
+  const orderIndex = parseInt(topicId, 10);
+
+  if (isNaN(orderIndex) || orderIndex < 1) {
+    notFound();
+  }
+
+  const topics = await loadGrammar('A1');
+
+  const topic = topics.find((t) => t.orderIndex === orderIndex);
+  if (!topic) {
+    notFound();
+  }
+
+  const totalTopics = topics.length;
+  const hasPrev = orderIndex > 1;
+  const hasNext = topics.some((t) => t.orderIndex === orderIndex + 1);
+
+  return (
+    <TopicDetailPage
+      topic={topic}
+      orderIndex={orderIndex}
+      totalTopics={totalTopics}
+      hasPrev={hasPrev}
+      hasNext={hasNext}
+    />
+  );
+}

--- a/apps/web/src/app/grammar/page.tsx
+++ b/apps/web/src/app/grammar/page.tsx
@@ -1,55 +1,24 @@
-import { LEVEL_CONFIG } from "@telc/config";
-import type { Level } from "@telc/types";
+import { LEVEL_CONFIG } from '@telc/config';
+import type { Level } from '@telc/types';
+import { loadGrammar } from '@/lib/loadGrammar';
+import { GrammarPageClient } from './GrammarPageClient';
 
-const levels: Level[] = ["A1", "A2", "B1", "B2", "C1"];
+const levels: Level[] = ['A1', 'A2', 'B1', 'B2', 'C1'];
 
-export default function GrammarPage() {
-  return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-text-primary">Grammar</h1>
-        <p className="mt-1 text-sm text-text-secondary">
-          Key grammar topics with explanations, examples, and exercises.
-        </p>
-      </div>
+export default async function GrammarPage() {
+  const topicsByLevel: Record<string, Awaited<ReturnType<typeof loadGrammar>>> = {};
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {levels.map((level) => {
-          const cfg = LEVEL_CONFIG[level];
-          return (
-            <div
-              key={level}
-              className="rounded-xl border border-[#e0e0e0] bg-white p-6"
-            >
-              <div className="flex items-center gap-3">
-                <span
-                  className="flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold text-white"
-                  style={{ backgroundColor: cfg.color }}
-                >
-                  {level}
-                </span>
-                <div>
-                  <div className="font-semibold text-text-primary">
-                    {level} Grammar
-                  </div>
-                  <div className="text-xs text-text-secondary">
-                    {level === "A1" ? "Topics available" : "Coming soon"}
-                  </div>
-                </div>
-              </div>
-              <div className="mt-4">
-                <button
-                  className="w-full rounded-lg px-4 py-2.5 text-sm font-medium text-white transition-colors hover:opacity-90 disabled:opacity-50"
-                  style={{ backgroundColor: cfg.color }}
-                  disabled={level !== "A1"}
-                >
-                  {level === "A1" ? "Browse Topics" : "Coming Soon"}
-                </button>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
+  for (const level of levels) {
+    topicsByLevel[level] = await loadGrammar(level);
+  }
+
+  const levelConfigs = levels.map((level) => ({
+    level,
+    color: LEVEL_CONFIG[level].color,
+    label: LEVEL_CONFIG[level].label,
+    topicCount: topicsByLevel[level].length,
+    topics: topicsByLevel[level],
+  }));
+
+  return <GrammarPageClient levels={levelConfigs} />;
 }

--- a/apps/web/src/components/grammar/ExercisePlayer.tsx
+++ b/apps/web/src/components/grammar/ExercisePlayer.tsx
@@ -1,0 +1,308 @@
+'use client';
+
+import { useState, useCallback, useMemo } from 'react';
+import type { GrammarExercise } from '@telc/types';
+
+interface ExercisePlayerProps {
+  exercises: GrammarExercise[];
+  topicName: string;
+  onComplete?: () => void;
+}
+
+type ExerciseState = 'idle' | 'answered' | 'checked';
+
+interface CheckedResult {
+  isCorrect: boolean;
+  userAnswer: string;
+}
+
+function normalize(s: string): string {
+  return s.trim().toLowerCase();
+}
+
+function buildMcqOptions(
+  exercise: GrammarExercise,
+  allExercises: GrammarExercise[],
+): string[] {
+  const correct = exercise.correctAnswer;
+  const pool = allExercises
+    .filter((e) => e.correctAnswer !== correct)
+    .map((e) => e.correctAnswer);
+
+  const uniquePool = Array.from(new Set(pool));
+  const distractors: string[] = [];
+
+  // pick up to 2 distractors from pool
+  const shuffled = uniquePool.sort(() => Math.random() - 0.5);
+  for (const d of shuffled) {
+    if (distractors.length >= 2) break;
+    distractors.push(d);
+  }
+
+  // fallback generic distractors
+  const fallbacks = ['ist', 'hat', 'kann'];
+  for (const f of fallbacks) {
+    if (distractors.length >= 2) break;
+    if (f !== correct && !distractors.includes(f)) {
+      distractors.push(f);
+    }
+  }
+
+  const options = [correct, ...distractors];
+  return options.sort(() => Math.random() - 0.5);
+}
+
+export function ExercisePlayer({
+  exercises,
+  topicName,
+  onComplete,
+}: ExercisePlayerProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [userAnswer, setUserAnswer] = useState('');
+  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+  const [state, setState] = useState<ExerciseState>('idle');
+  const [result, setResult] = useState<CheckedResult | null>(null);
+  const [results, setResults] = useState<CheckedResult[]>([]);
+  const [showSummary, setShowSummary] = useState(false);
+
+  const exercise = exercises[currentIndex];
+  const total = exercises.length;
+  const isLast = currentIndex === total - 1;
+
+  const mcqOptions = useMemo(() => {
+    if (exercise?.type === 'mcq') {
+      return buildMcqOptions(exercise, exercises);
+    }
+    return [];
+    // intentionally only recalculate when exercise index changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentIndex]);
+
+  const handleCheck = useCallback(() => {
+    if (!exercise) return;
+    const answer = exercise.type === 'mcq' ? (selectedOption ?? '') : userAnswer;
+    const isCorrect = normalize(answer) === normalize(exercise.correctAnswer);
+    const checked: CheckedResult = { isCorrect, userAnswer: answer };
+    setResult(checked);
+    setResults((prev) => [...prev, checked]);
+    setState('checked');
+  }, [exercise, selectedOption, userAnswer]);
+
+  const handleNext = useCallback(() => {
+    if (isLast) {
+      setShowSummary(true);
+      onComplete?.();
+      return;
+    }
+    setCurrentIndex((i) => i + 1);
+    setUserAnswer('');
+    setSelectedOption(null);
+    setState('idle');
+    setResult(null);
+  }, [isLast, onComplete]);
+
+  const handleRetry = useCallback(() => {
+    setCurrentIndex(0);
+    setUserAnswer('');
+    setSelectedOption(null);
+    setState('idle');
+    setResult(null);
+    setResults([]);
+    setShowSummary(false);
+  }, []);
+
+  if (showSummary) {
+    const correctCount = results.filter((r) => r.isCorrect).length;
+    const pct = Math.round((correctCount / total) * 100);
+
+    return (
+      <div
+        data-testid="exercise-summary"
+        className="rounded-xl border border-border bg-white p-6 text-center"
+      >
+        <h3 className="text-lg font-semibold text-text-primary">
+          Ergebnis — {topicName}
+        </h3>
+        <p
+          data-testid="exercise-score"
+          className="mt-3 text-2xl font-bold text-text-primary"
+        >
+          {correctCount} / {total} richtig ({pct}%)
+        </p>
+        <div className="mt-5 flex flex-wrap items-center justify-center gap-3">
+          <button
+            data-testid="retry-button"
+            onClick={handleRetry}
+            className="rounded-lg border border-border px-4 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-surface-container"
+          >
+            Nochmal üben
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!exercise) return null;
+
+  const hasAnswer =
+    exercise.type === 'mcq' ? selectedOption !== null : userAnswer.trim().length > 0;
+  const isChecked = state === 'checked';
+
+  return (
+    <div data-testid="exercise-player" className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-text-primary">Übungen</h2>
+        <span
+          data-testid="exercise-counter"
+          className="text-sm font-medium text-text-secondary"
+        >
+          Übung {currentIndex + 1} von {total}
+        </span>
+      </div>
+
+      {/* progress bar */}
+      <div className="h-1.5 w-full rounded-full bg-surface-container">
+        <div
+          data-testid="exercise-progress"
+          className="h-1.5 rounded-full bg-brand-primary transition-all"
+          style={{ width: `${((currentIndex + (isChecked ? 1 : 0)) / total) * 100}%` }}
+        />
+      </div>
+
+      {/* prompt */}
+      <div className="rounded-xl border border-border bg-white p-5">
+        <p
+          data-testid="exercise-prompt"
+          className="text-text-primary font-medium leading-relaxed"
+        >
+          {exercise.prompt}
+        </p>
+
+        {/* input area */}
+        <div className="mt-4">
+          {exercise.type === 'mcq' ? (
+            <div className="space-y-2" role="radiogroup" aria-label="Answer options">
+              {mcqOptions.map((option) => {
+                const isSelected = selectedOption === option;
+                const showCorrect = isChecked && option === exercise.correctAnswer;
+                const showWrong =
+                  isChecked && isSelected && option !== exercise.correctAnswer;
+
+                let borderClass = 'border-border';
+                let bgClass = 'bg-white';
+                if (showCorrect) {
+                  borderClass = 'border-success';
+                  bgClass = 'bg-success-light';
+                } else if (showWrong) {
+                  borderClass = 'border-error';
+                  bgClass = 'bg-error-light';
+                } else if (isSelected && !isChecked) {
+                  borderClass = 'border-brand-primary';
+                  bgClass = 'bg-brand-primary-surface';
+                }
+
+                return (
+                  <button
+                    key={option}
+                    data-testid={`mcq-option-${option}`}
+                    disabled={isChecked}
+                    onClick={() => {
+                      setSelectedOption(option);
+                      setState('answered');
+                    }}
+                    className={`flex w-full items-center gap-3 rounded-lg border-2 px-4 py-3 text-left text-sm font-medium text-text-primary transition-colors ${borderClass} ${bgClass} disabled:cursor-default`}
+                    role="radio"
+                    aria-checked={isSelected}
+                  >
+                    <span
+                      className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 text-xs ${
+                        isSelected
+                          ? 'border-brand-primary bg-brand-primary text-white'
+                          : 'border-border bg-white'
+                      }`}
+                    >
+                      {showCorrect && '✓'}
+                      {showWrong && '✗'}
+                    </span>
+                    {option}
+                  </button>
+                );
+              })}
+            </div>
+          ) : (
+            <input
+              data-testid="exercise-input"
+              type="text"
+              value={userAnswer}
+              onChange={(e) => {
+                setUserAnswer(e.target.value);
+                if (state === 'idle') setState('answered');
+              }}
+              disabled={isChecked}
+              placeholder="Antwort eingeben..."
+              className="w-full rounded-lg border border-border px-4 py-2.5 text-sm text-text-primary placeholder:text-text-disabled focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/20 disabled:bg-surface-container disabled:cursor-default"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && hasAnswer && !isChecked) handleCheck();
+              }}
+            />
+          )}
+        </div>
+
+        {/* feedback */}
+        {isChecked && result && (
+          <div
+            data-testid={`exercise-feedback-${result.isCorrect ? 'correct' : 'incorrect'}`}
+            className={`mt-4 rounded-lg p-4 ${
+              result.isCorrect
+                ? 'bg-success-light'
+                : 'bg-error-light'
+            }`}
+          >
+            <div className="flex items-center gap-2">
+              <span className="text-lg" aria-hidden="true">
+                {result.isCorrect ? '✓' : '✗'}
+              </span>
+              <span
+                className={`font-semibold ${
+                  result.isCorrect ? 'text-success' : 'text-error'
+                }`}
+              >
+                {result.isCorrect ? 'Richtig!' : 'Leider falsch'}
+              </span>
+            </div>
+            {!result.isCorrect && (
+              <p className="mt-1 text-sm text-text-primary">
+                Richtige Antwort: <strong>{exercise.correctAnswer}</strong>
+              </p>
+            )}
+            <p className="mt-1 text-sm text-text-secondary">
+              {exercise.explanation}
+            </p>
+          </div>
+        )}
+
+        {/* action buttons */}
+        <div className="mt-4 flex gap-3">
+          {!isChecked ? (
+            <button
+              data-testid="check-button"
+              onClick={handleCheck}
+              disabled={!hasAnswer}
+              className="rounded-lg bg-brand-primary px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-primary-light disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Prüfen
+            </button>
+          ) : (
+            <button
+              data-testid="next-button"
+              onClick={handleNext}
+              className="rounded-lg bg-brand-primary px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-primary-light"
+            >
+              {isLast ? 'Ergebnis anzeigen' : 'Weiter'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/grammar/TopicCard.tsx
+++ b/apps/web/src/components/grammar/TopicCard.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import Link from 'next/link';
+import type { GrammarTopic } from '@telc/types';
+
+interface TopicCardProps {
+  topic: GrammarTopic;
+  levelColor: string;
+}
+
+export function TopicCard({ topic, levelColor }: TopicCardProps) {
+  const exerciseCount = topic.exercises?.length ?? 0;
+  const exampleCount = topic.examples.length;
+
+  return (
+    <Link
+      href={`/grammar/${topic.orderIndex}`}
+      data-testid={`topic-card-${topic.orderIndex}`}
+      className="block rounded-xl border border-border bg-white p-5 transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-brand-primary"
+    >
+      <div className="flex items-start gap-3">
+        <span
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white"
+          style={{ backgroundColor: levelColor }}
+        >
+          {topic.orderIndex}
+        </span>
+        <div className="min-w-0">
+          <h3 className="font-semibold text-text-primary leading-snug">
+            {topic.topic}
+          </h3>
+          <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 text-xs text-text-secondary">
+            <span>{exampleCount} Beispiele</span>
+            {exerciseCount > 0 && <span>{exerciseCount} Übungen</span>}
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/src/components/grammar/TopicDetail.tsx
+++ b/apps/web/src/components/grammar/TopicDetail.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import type { GrammarTopic } from '@telc/types';
+
+interface TopicDetailProps {
+  topic: GrammarTopic;
+}
+
+export function TopicDetail({ topic }: TopicDetailProps) {
+  return (
+    <div className="space-y-6">
+      <section data-testid="explanation-section">
+        <h2 className="text-lg font-semibold text-text-primary">Erklärung</h2>
+        <div className="mt-2 rounded-xl border border-border bg-white p-5">
+          <p className="text-text-primary leading-relaxed whitespace-pre-line">
+            {topic.explanation}
+          </p>
+        </div>
+      </section>
+
+      <section data-testid="examples-section">
+        <h2 className="text-lg font-semibold text-text-primary">Beispiele</h2>
+        <ul className="mt-2 space-y-2 rounded-xl border border-border bg-white p-5">
+          {topic.examples.map((example, i) => (
+            <li
+              key={i}
+              className="flex items-start gap-2 text-text-primary"
+            >
+              <span className="mt-0.5 text-text-secondary select-none">•</span>
+              <span>{example}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/lib/loadGrammar.ts
+++ b/apps/web/src/lib/loadGrammar.ts
@@ -1,0 +1,20 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+import type { GrammarTopic } from '@telc/types';
+
+const GRAMMAR_DIR =
+  process.env.GRAMMAR_DIR ??
+  path.resolve(process.cwd(), '../mobile/src/data/grammar');
+
+export async function loadGrammar(level: string): Promise<GrammarTopic[]> {
+  const filePath = path.join(GRAMMAR_DIR, `${level}_grammar.json`);
+
+  try {
+    const raw = await readFile(filePath, 'utf-8');
+    const data = JSON.parse(raw) as unknown;
+    if (!Array.isArray(data)) return [];
+    return (data as GrammarTopic[]).sort((a, b) => a.orderIndex - b.orderIndex);
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary

- **#19**: Grammar hub with level selector, 12-topic grid, topic detail pages with explanation/examples, and interactive exercise player supporting fill_blank, mcq, and reorder types
- 16 new unit tests (TopicCard: 4, ExercisePlayer: 12), 102 total passing

## Quality Gates

| Gate | Result |
|------|--------|
| typecheck | PASS — zero errors |
| vitest | PASS — 102/102 tests (12 files) |
| exam-tester | n/a (no content changes) |
| pedagogy-director | n/a |
| compliance-guardian | n/a |
| language-checker | n/a |

## Test plan

- [ ] CI green (typecheck + tests)
- [ ] product-owner sign-off after merge