### PR TITLE
content(A2): pedagogy review pass — 17 rewrites across 9 mocks

### DIFF
--- a/apps/mobile/assets/content/A2/mock_02.json
+++ b/apps/mobile/assets/content/A2/mock_02.json
@@ -137,7 +137,7 @@
                 "c) Sprachkurse für Kinder"
               ],
               "correctAnswer": "a",
-              "explanation": "Die Durchsage informiert: 'Das Familienzentrum Neustadtbietet ab Oktober Kurse für werdende Eltern an — Anmeldung unter Tel. 0521 889 22.' Beratung und Sprachkurse werden nicht als neues Angebot genannt.",
+              "explanation": "Die Durchsage informiert: 'Das Familienzentrum Neustadt bietet ab Oktober Kurse für werdende Eltern an — Anmeldung unter Tel. 0521 889 22.' Beratung und Sprachkurse werden nicht als neues Angebot genannt.",
               "audioTimestamp": 8
             },
             {
@@ -297,7 +297,7 @@
             {
               "id": "A2_m02_R1_q3",
               "type": "matching",
-              "questionText": "Petra hat zwei Kinder und sucht günstige Kleidung für ihr Baby und ihren Kleinkind.",
+              "questionText": "Petra hat zwei Kinder und sucht günstige Kleidung für ihr Baby und ihr Kleinkind.",
               "matchingSources": [
                 { "id": "A2_m02_R1_text_a", "label": "A" },
                 { "id": "A2_m02_R1_text_b", "label": "B" },
@@ -306,7 +306,7 @@
                 { "id": "A2_m02_R1_text_e", "label": "E" }
               ],
               "correctAnswer": "C",
-              "explanation": "Text C bietet gut erhaltene Kinderkleidung in kleinen Größen (86–128) an — das passt für Petras Baby und Kleinkind. Die anderen Texte bieten keine Kinderkleidung an."
+              "explanation": "[PEDAGOGY-REWRITE] Grammatikfehler in der Aufgabenstellung korrigiert: 'ihren Kleinkind' → 'ihr Kleinkind' (Kleinkind ist Neutrum). Text C bietet gut erhaltene Kinderkleidung in kleinen Größen (86–128) an — das passt für Petras Baby und Kleinkind. Die anderen Texte bieten keine Kinderkleidung an."
             },
             {
               "id": "A2_m02_R1_q4",
@@ -354,10 +354,10 @@
             {
               "id": "A2_m02_R2_q1",
               "type": "true_false",
-              "questionText": "Früher lebten Familien immer in der klassischen Form mit Mutter, Vater und Kindern.",
+              "questionText": "Früher lebten Familien meistens in der klassischen Form mit Mutter, Vater und Kindern.",
               "relatedTextId": "A2_m02_R2_text1",
               "correctAnswer": "richtig",
-              "explanation": "Der Text sagt: 'Früher lebten meistens Vater, Mutter und Kinder zusammen — das war die klassische Familie.' Die Aussage gibt das korrekt wieder."
+              "explanation": "[PEDAGOGY-REWRITE] Original verwendete 'immer' statt 'meistens' — das widersprach dem Text ('meistens') und machte die korrekte Antwort 'richtig' falsch. Korrigiert: Der Text sagt: 'Früher lebten meistens Vater, Mutter und Kinder zusammen — das war die klassische Familie.' Die Aussage gibt das jetzt korrekt wieder."
             },
             {
               "id": "A2_m02_R2_q2",

--- a/apps/mobile/assets/content/A2/mock_03.json
+++ b/apps/mobile/assets/content/A2/mock_03.json
@@ -354,10 +354,10 @@
             {
               "id": "A2_m03_R2_q1",
               "type": "true_false",
-              "questionText": "Die Mieten in Großstädten sind in zehn Jahren um die Hälfte gestiegen.",
+              "questionText": "Die Mieten in Großstädten sind in zehn Jahren stark gestiegen.",
               "relatedTextId": "A2_m03_R2_text1",
               "correctAnswer": "richtig",
-              "explanation": "Im Text steht: 'Die Mieten sind in vielen Großstädten um mehr als 50 Prozent gestiegen.' Mehr als 50 Prozent bedeutet mehr als die Hälfte — die Aussage ist inhaltlich korrekt."
+              "explanation": "[PEDAGOGY-REWRITE] Original fragte 'um die Hälfte gestiegen', aber der Text sagt 'um mehr als 50 Prozent' — die Unterscheidung zwischen 'genau die Hälfte' und 'mehr als die Hälfte' ist auf A2 unfair und führt zu Ambiguität. Vereinfacht: Der Text bestätigt, dass die Mieten 'um mehr als 50 Prozent gestiegen' sind — das ist eindeutig ein starker Anstieg."
             },
             {
               "id": "A2_m03_R2_q2",

--- a/apps/mobile/assets/content/A2/mock_04.json
+++ b/apps/mobile/assets/content/A2/mock_04.json
@@ -370,10 +370,10 @@
             {
               "id": "A2_m04_R2_q3",
               "type": "true_false",
-              "questionText": "Kurse für chinesische Küche sind am beliebtesten.",
+              "questionText": "Kochkurse für französische Küche sind am beliebtesten.",
               "relatedTextId": "A2_m04_R2_text1",
               "correctAnswer": "falsch",
-              "explanation": "Im Text steht: 'Beliebt sind vor allem Kurse für asiatische und italienische Küche.' Chinesisch wird nicht separat genannt — die Aussage ist zu spezifisch und daher falsch."
+              "explanation": "Im Text steht: 'Beliebt sind vor allem Kurse für asiatische und italienische Küche.' Französische Küche wird nicht erwähnt — die Aussage ist falsch. [PEDAGOGY-REWRITE: 'chinesisch vs asiatisch' war mehrdeutig, da chinesisch eine Unterkategorie von asiatisch ist. Ersetzt durch 'französisch', das klar nicht im Text steht.]"
             },
             {
               "id": "A2_m04_R2_q4",
@@ -386,10 +386,10 @@
             {
               "id": "A2_m04_R2_q5",
               "type": "true_false",
-              "questionText": "Mehr als die Hälfte der Deutschen kocht unter der Woche weniger als 30 Minuten täglich.",
+              "questionText": "Alle Deutschen kochen unter der Woche weniger als 30 Minuten täglich.",
               "relatedTextId": "A2_m04_R2_text1",
               "correctAnswer": "falsch",
-              "explanation": "Der Text sagt: '42 Prozent der Deutschen haben weniger als 30 Minuten.' 42 Prozent ist weniger als die Hälfte (50 Prozent) — die Aussage ist falsch."
+              "explanation": "Der Text sagt: '42 Prozent der Deutschen haben weniger als 30 Minuten.' Es sind also nicht alle, sondern nur ein Teil — die Aussage ist falsch. [PEDAGOGY-REWRITE: Vorherige Frage testete '50% vs 42%'-Unterscheidung, was zu feingranular fuer A2 ist. Vereinfacht auf klaren Hauptaussage-Test.]"
             }
           ]
         },

--- a/apps/mobile/assets/content/A2/mock_05.json
+++ b/apps/mobile/assets/content/A2/mock_05.json
@@ -356,8 +356,8 @@
               "type": "true_false",
               "questionText": "Auf einen Facharzttermin muss man im Durchschnitt über drei Wochen warten.",
               "relatedTextId": "A2_m05_R2_text1",
-              "correctAnswer": "richtig",
-              "explanation": "Der Text sagt: 'Patienten warten durchschnittlich 21 Tage auf einen Facharzttermin.' 21 Tage sind genau drei Wochen — die Aussage 'über drei Wochen' ist also nicht korrekt. Genau drei Wochen."
+              "correctAnswer": "falsch",
+              "explanation": "Der Text sagt: 'Patienten warten durchschnittlich 21 Tage auf einen Facharzttermin.' 21 Tage sind genau drei Wochen, nicht über drei Wochen — die Aussage ist daher falsch. [PEDAGOGY-REWRITE: correctAnswer war 'richtig', aber 21 Tage = exakt 3 Wochen, nicht 'über 3 Wochen'. Erklärung widersprach bereits dem correctAnswer.]"
             },
             {
               "id": "A2_m05_R2_q2",
@@ -372,8 +372,8 @@
               "type": "true_false",
               "questionText": "Die meisten Deutschen buchen Arzttermine noch telefonisch.",
               "relatedTextId": "A2_m05_R2_text1",
-              "correctAnswer": "falsch",
-              "explanation": "Der Text sagt: 'Fast 40 Prozent buchen ihren Termin nicht mehr telefonisch.' Das bedeutet, dass 60 Prozent noch telefonisch buchen — die Mehrheit, aber der Satz ist irreführend angesichts des wachsenden Online-Trends."
+              "correctAnswer": "richtig",
+              "explanation": "Der Text sagt: 'Fast 40 Prozent buchen ihren Termin nicht mehr telefonisch.' Das bedeutet, dass etwa 60 Prozent noch telefonisch buchen. 60 Prozent ist die Mehrheit — also buchen die meisten Deutschen tatsächlich noch telefonisch. Die Aussage ist richtig. [PEDAGOGY-REWRITE: correctAnswer war 'falsch', aber 60% = 'die meisten'. Die eigene Erklärung bestätigte bereits, dass die Mehrheit telefonisch bucht.]"
             },
             {
               "id": "A2_m05_R2_q4",

--- a/apps/mobile/assets/content/A2/mock_06.json
+++ b/apps/mobile/assets/content/A2/mock_06.json
@@ -354,10 +354,10 @@
             {
               "id": "A2_m06_R2_q1",
               "type": "true_false",
-              "questionText": "Mehr als ein Drittel der deutschen Arbeitnehmer arbeitet mindestens zweimal pro Woche von zu Hause.",
+              "questionText": "Viele deutsche Arbeitnehmer arbeiten mindestens zweimal pro Woche von zu Hause.",
               "relatedTextId": "A2_m06_R2_text1",
               "correctAnswer": "richtig",
-              "explanation": "Der Text sagt: '34 Prozent der Beschäftigten arbeiten mindestens zwei Tage im Homeoffice.' 34 Prozent ist etwas mehr als ein Drittel (33%) — die Aussage ist richtig."
+              "explanation": "Der Text sagt: '34 Prozent der Beschäftigten arbeiten mindestens zwei Tage im Homeoffice.' 34 Prozent ist ein großer Anteil — die Aussage ist richtig. [PEDAGOGY-REWRITE: Vorherige Frage testete '34% vs ein Drittel'-Unterscheidung. Zu feingranular fuer A2. Vereinfacht auf Hauptaussage-Verstaendnis.]"
             },
             {
               "id": "A2_m06_R2_q2",
@@ -370,10 +370,10 @@
             {
               "id": "A2_m06_R2_q3",
               "type": "true_false",
-              "questionText": "Fast ein Drittel der Befragten fühlt sich zu Hause weniger produktiv.",
+              "questionText": "Einige Beschäftigte fühlen sich zu Hause weniger produktiv als im Büro.",
               "relatedTextId": "A2_m06_R2_text1",
               "correctAnswer": "richtig",
-              "explanation": "Der Text sagt: '28 Prozent sagen, sie fühlen sich im Homeoffice weniger produktiv.' 28 Prozent ist knapp unter einem Drittel — die Aussage 'fast ein Drittel' ist sinngemäß korrekt."
+              "explanation": "Der Text sagt: '28 Prozent sagen, sie fühlen sich im Homeoffice weniger produktiv als im Büro.' Es gibt also einige, die sich weniger produktiv fühlen — die Aussage ist richtig. [PEDAGOGY-REWRITE: '28% vs fast ein Drittel' ist zu feingranulare Quantifizierer-Unterscheidung fuer A2.]"
             },
             {
               "id": "A2_m06_R2_q4",

--- a/apps/mobile/assets/content/A2/mock_07.json
+++ b/apps/mobile/assets/content/A2/mock_07.json
@@ -242,7 +242,7 @@
             {
               "id": "A2_m07_R1_text_a",
               "type": "ad",
-              "content": "ANZEIGE A — Bogenschießen für Anfänger\nHaben Sie Interesse an einem besonderen Hobby? Wir bieten Schnupperkurse im Bogenschießen an — kein Vorkenntnisse nötig! Jeden Samstag um 10 Uhr. Preis: 25 Euro inkl. Ausrüstung. Sportbogen-Verein, Feldweg 3."
+              "content": "ANZEIGE A — Bogenschießen für Anfänger\nHaben Sie Interesse an einem besonderen Hobby? Wir bieten Schnupperkurse im Bogenschießen an — keine Vorkenntnisse nötig! Jeden Samstag um 10 Uhr. Preis: 25 Euro inkl. Ausrüstung. Sportbogen-Verein, Feldweg 3."
             },
             {
               "id": "A2_m07_R1_text_b",
@@ -346,7 +346,7 @@
             {
               "id": "A2_m07_R2_text1",
               "type": "article",
-              "content": "Sport in der Freizeit: Was machen die Deutschen? Laut einer aktuellen Befragung ist Spazierengehen das beliebteste Freizeitaktivität in Deutschland — 62 Prozent der Erwachsenen gehen mindestens einmal pro Woche spazieren. An zweiter Stelle steht das Fahrradfahren mit 41 Prozent, gefolgt von Schwimmen (35 Prozent). Fußball ist vor allem bei Männern und Jugendlichen beliebt — nur 18 Prozent der Erwachsenen spielen regelmäßig. Interessant: Yoga und Pilates werden immer beliebter und haben in den letzten fünf Jahren stark zugenommen. Nur 12 Prozent der Deutschen treiben gar keinen Sport.",
+              "content": "Sport in der Freizeit: Was machen die Deutschen? Laut einer aktuellen Befragung ist Spazierengehen die beliebteste Freizeitaktivität in Deutschland — 62 Prozent der Erwachsenen gehen mindestens einmal pro Woche spazieren. An zweiter Stelle steht das Fahrradfahren mit 41 Prozent, gefolgt von Schwimmen (35 Prozent). Fußball ist vor allem bei Männern und Jugendlichen beliebt — nur 18 Prozent der Erwachsenen spielen regelmäßig. Interessant: Yoga und Pilates werden immer beliebter und haben in den letzten fünf Jahren stark zugenommen. Nur 12 Prozent der Deutschen treiben gar keinen Sport.",
               "source": "Sportmagazin, Januar 2026"
             }
           ],
@@ -506,12 +506,12 @@
             {
               "label": "Vorname",
               "correctAnswer": "Mia",
-              "hint": "Vorname der neuen Mitglied"
+              "hint": "Vorname des neuen Mitglieds"
             },
             {
               "label": "Nachname",
               "correctAnswer": "Schulz",
-              "hint": "Nachname der neuen Mitglied"
+              "hint": "Nachname des neuen Mitglieds"
             },
             {
               "label": "Geburtsdatum",

--- a/apps/mobile/assets/content/A2/mock_08.json
+++ b/apps/mobile/assets/content/A2/mock_08.json
@@ -362,7 +362,7 @@
             {
               "id": "A2_m08_R2_q2",
               "type": "true_false",
-              "questionText": "Vor zehn Jahren hat genauso viele Menschen die Vorsorge genutzt wie heute.",
+              "questionText": "Vor zehn Jahren haben genauso viele Menschen die Vorsorge genutzt wie heute.",
               "relatedTextId": "A2_m08_R2_text1",
               "correctAnswer": "falsch",
               "explanation": "Der Text sagt: 'Vor zehn Jahren war es nur die Hälfte.' Heute sind es 62 Prozent — die Zahl ist also gestiegen, nicht gleich geblieben. Die Aussage ist falsch."

--- a/apps/mobile/assets/content/A2/mock_09.json
+++ b/apps/mobile/assets/content/A2/mock_09.json
@@ -56,7 +56,7 @@
             {
               "id": "A2_m09_L1_q4",
               "type": "mcq",
-              "questionText": "Was soll Pedro beim Reisebüro anrufen wegen?",
+              "questionText": "Warum soll Pedro beim Reisebüro anrufen?",
               "options": [
                 "a) um einen Reisepass zu beantragen",
                 "b) um sein Ticket zu bestätigen",
@@ -378,10 +378,10 @@
             {
               "id": "A2_m09_R2_q4",
               "type": "true_false",
-              "questionText": "Mehr als drei Viertel aller Fernzüge kamen im letzten Jahr pünktlich an.",
+              "questionText": "Fast alle Fernzüge kamen im letzten Jahr pünktlich an.",
               "relatedTextId": "A2_m09_R2_text1",
               "correctAnswer": "falsch",
-              "explanation": "Der Text sagt: 'nur 72 Prozent der Fernzüge kamen pünktlich an.' 72 Prozent sind weniger als drei Viertel (75 Prozent). Die Aussage ist falsch."
+              "explanation": "Der Text sagt: 'nur 72 Prozent der Fernzüge kamen pünktlich an.' Das bedeutet, dass fast ein Drittel nicht pünktlich war. Die Aussage ist falsch."
             },
             {
               "id": "A2_m09_R2_q5",
@@ -567,7 +567,7 @@
           ],
           "wordCountMin": 30,
           "wordCountMax": 50,
-          "sampleAnswer": "Hallo David,\nichbin gerade in Wien — das Wetter ist super, sonnig und warm! Gestern habe ich das Kunsthistorische Museum besucht, das war wirklich beeindruckend. Heute gehe ich eine Schiffstour auf der Donau machen. Hast du Lust, nächsten Sommer mitzukommen?\nViele Grüße, Ali",
+          "sampleAnswer": "Hallo David,\nich bin gerade in Wien — das Wetter ist super, sonnig und warm! Gestern habe ich das Kunsthistorische Museum besucht, das war wirklich beeindruckend. Heute gehe ich eine Schiffstour auf der Donau machen. Hast du Lust, nächsten Sommer mitzukommen?\nViele Grüße, Ali",
           "scoringCriteria": [
             {
               "criterion": "Inhalt",

--- a/apps/mobile/assets/content/A2/mock_10.json
+++ b/apps/mobile/assets/content/A2/mock_10.json
@@ -362,10 +362,10 @@
             {
               "id": "A2_m10_R2_q2",
               "type": "true_false",
-              "questionText": "Vor fünf Jahren haben mehr als 60 Prozent online eingekauft.",
+              "questionText": "Vor fünf Jahren haben schon die meisten Deutschen online eingekauft.",
               "relatedTextId": "A2_m10_R2_text1",
               "correctAnswer": "falsch",
-              "explanation": "Der Text sagt: 'vor fünf Jahren waren es nur 55 Prozent.' Das ist weniger als 60 Prozent. Die Aussage ist falsch."
+              "explanation": "Der Text sagt: 'vor fünf Jahren waren es nur 55 Prozent.' Etwas mehr als die Hälfte ist nicht 'die meisten'. Die Aussage ist falsch."
             },
             {
               "id": "A2_m10_R2_q3",


### PR DESCRIPTION
## Summary

Full 6-dimension pedagogy review of all 10 A2 mocks. 17 [PEDAGOGY-REWRITE] fixes applied across 9 mocks (mock_01 passed clean).

## ⚠️ Critical scoring bugs (would have shipped broken)

Two T/F questions in `mock_05` had `correctAnswer` values that contradicted their own `explanation` field — test-takers with correct comprehension would have been marked wrong.

| Question | Was | Fixed to | Why |
|---|---|---|---|
| R2_q1 | `richtig` | `falsch` | 21 Tage = exactly 3 weeks, not "über 3 Wochen" |
| R2_q3 | `falsch` | `richtig` | 60% phone booking IS "die meisten" |

## Grammar / content fixes (9)

| Mock | Where | Fix |
|---|---|---|
| 02 | R1_q3 | "ihren Kleinkind" → "ihr Kleinkind" (neuter acc) |
| 02 | L2_q4 | "Neustadtbietet" → "Neustadt bietet" |
| 02 | R2_q1 | "immer" → "meistens" (aligned Q with source text) |
| 07 | reading | "das beliebteste Freizeitaktivität" → "die" |
| 07 | R1 ad | "kein Vorkenntnisse" → "keine" |
| 07 | writing hint | "der neuen Mitglied" → "des neuen Mitglieds" |
| 08 | R2_q2 | "hat viele Menschen" → "haben" (subj-verb) |
| 09 | L1_q4 | "Was soll Pedro anrufen wegen?" → "Warum soll Pedro…" |
| 09 | writing | "ichbin" → "ich bin" |

## T/F quantifier simplifications (7)

At A2, T/F should test main-point comprehension — not whether a learner converts 72% → 3/4. Replaced precise-fraction statements with lexical generalizations (viele / die meisten / fast alle / einige / stark).

- mock_03 R2_q1 (Hälfte → stark)
- mock_04 R2_q3 (chinesische → französische), R2_q5 (mehr als Hälfte → alle)
- mock_06 R2_q1 (mehr als ein Drittel → viele), R2_q3 (fast ein Drittel → einige)
- mock_09 R2_q4 (mehr als drei Viertel → fast alle)
- mock_10 R2_q2 (mehr als 60% → die meisten)

## Recurring author-feedback patterns

1. **B1+ vocabulary creep** in domain-specific reading texts (Gesundheit, Reisen, Arbeit themes naturally pull compounds like *Kassenärztliche Vereinigung*, *Schienenersatzverkehr*, *Quereinsteiger*). Not blocking because questions don't hinge on those specific terms.
2. **Fine-grained T/F quantifier traps** keep recurring (simplified this pass).
3. **Subject-verb agreement** errors with inverted word order — worth a targeted proofread pass.

## Format fidelity note

All A2 mocks use MCQ for Listening Teil 1 + Reading Teil 3 instead of telc's "fill-in" / "matching" formats. This is a consistent design decision across all mocks, not fixable in review. Flagging for awareness.

## Test plan

- [ ] Web exam session loads each A2 mock
- [ ] mock_05 R2 scoring now correct — verify score report matches new answers
- [ ] CI: typecheck + tests + Playwright + Vercel green