### PR TITLE
content(A1): pedagogy review pass — 40 rewrites across 8 mocks

### DIFF
--- a/apps/mobile/assets/content/A1/mock_01.json
+++ b/apps/mobile/assets/content/A1/mock_01.json
@@ -174,7 +174,7 @@
             {
               "id": "A1_m01_R1_text2",
               "type": "email",
-              "content": "Von: arzt.praxis.weber@praxis.de\nAn: thomas.klein@email.de\nBetreff: Ihr Termin\n\nSehr geehrter Herr Klein,\n\nwir möchten Sie an Ihren Termin erinnern: Dienstag, 18. März, um 10:30 Uhr. Bitte kommen Sie fünf Minuten früher. Bringen Sie Ihre Krankenversicherungskarte mit. Wenn Sie den Termin nicht wahrnehmen können, rufen Sie uns bitte an: 040 / 775 88 33.\n\nMit freundlichen Grüßen,\nArztpraxis Dr. Weber",
+              "content": "Von: arzt.praxis.weber@praxis.de\nAn: thomas.klein@email.de\nBetreff: Ihr Termin\n\nSehr geehrter Herr Klein,\n\nwir möchten Sie an Ihren Termin erinnern: Dienstag, 18. März, um 10:30 Uhr. Bitte kommen Sie fünf Minuten früher. Bringen Sie Ihre Versichertenkarte mit. Wenn Sie den Termin absagen möchten, rufen Sie uns bitte an: 040 / 775 88 33.\n\nMit freundlichen Grüßen,\nArztpraxis Dr. Weber",
               "source": "E-Mail der Arztpraxis"
             }
           ],
@@ -214,10 +214,10 @@
             {
               "id": "A1_m01_R1_q5",
               "type": "true_false",
-              "questionText": "Herr Klein soll die Krankenversicherungskarte mitbringen.",
+              "questionText": "Herr Klein soll seine Versichertenkarte mitbringen.",
               "relatedTextId": "A1_m01_R1_text2",
               "correctAnswer": "richtig",
-              "explanation": "Die Praxis schreibt: 'Bringen Sie Ihre Krankenversicherungskarte mit.' Diese Aufforderung steht direkt im Text. Die Aussage ist richtig."
+              "explanation": "Die Praxis schreibt: 'Bringen Sie Ihre Versichertenkarte mit.' Diese Aufforderung steht direkt im Text. Die Aussage ist richtig."
             }
           ]
         },
@@ -378,7 +378,7 @@
             {
               "id": "A1_m01_R3_notice4",
               "type": "notice",
-              "content": "Parkplatz nur für Kunden.\nMaximal 2 Stunden.\nNicht-Kunden werden kostenpflichtig abgeschleppt."
+              "content": "Parkplatz nur für Kunden.\nMaximal 2 Stunden.\nAndere Autos werden abgeschleppt."
             },
             {
               "id": "A1_m01_R3_notice5",
@@ -417,7 +417,7 @@
               "questionText": "Alle Personen können hier drei Stunden parken.",
               "relatedTextId": "A1_m01_R3_notice4",
               "correctAnswer": "falsch",
-              "explanation": "Das Schild sagt: 'Parkplatz nur für Kunden. Maximal 2 Stunden.' Erstens: Nur Kunden dürfen hier parken, nicht alle Personen. Zweitens: Das Maximum sind 2 Stunden, nicht drei. Die Aussage ist in beiden Teilen falsch."
+              "explanation": "Das Schild sagt: 'Parkplatz nur für Kunden. Maximal 2 Stunden.' Nur Kunden dürfen hier parken, nicht alle Personen. Und das Maximum sind 2 Stunden, nicht drei. Die Aussage ist falsch."
             },
             {
               "id": "A1_m01_R3_q5",

--- a/apps/mobile/assets/content/A1/mock_02.json
+++ b/apps/mobile/assets/content/A1/mock_02.json
@@ -174,7 +174,7 @@
             {
               "id": "A1_m02_R1_text2",
               "type": "ad",
-              "content": "STELLENANZEIGE\n\nWir suchen: Kellner/Kellnerin (Teilzeit)\nRestaurant Zur alten Post, München\n\nArbeitszeit: Dienstag bis Samstag, abends\nGehalt: 14 Euro pro Stunde\n\nVoraussetzungen:\n— gute Deutschkenntnisse\n— freundlich und zuverlässig\n— Erfahrung im Service erwünscht\n\nBewerbung an: info@altepost-muenchen.de",
+              "content": "JOB IM RESTAURANT\n\nWir suchen: Kellner/Kellnerin (Teilzeit)\nRestaurant Zur alten Post, München\n\nArbeitszeit: Dienstag bis Samstag, abends\nGehalt: 14 Euro pro Stunde\n\nWas ist wichtig:\n— gute Deutschkenntnisse\n— freundlich und pünktlich\n\nSchreiben Sie an: info@altepost-muenchen.de",
               "source": "Stellenanzeige"
             }
           ],
@@ -209,7 +209,7 @@
               "questionText": "Der Job im Restaurant ist eine Vollzeitstelle.",
               "relatedTextId": "A1_m02_R1_text2",
               "correctAnswer": "falsch",
-              "explanation": "In der Stellenanzeige steht: 'Kellner/Kellnerin (Teilzeit).' Es ist eine Teilzeitstelle, keine Vollzeitstelle. Die Aussage ist falsch."
+              "explanation": "Im Text steht: 'Kellner/Kellnerin (Teilzeit).' Es ist eine Teilzeitstelle, keine Vollzeitstelle. Die Aussage ist falsch."
             },
             {
               "id": "A1_m02_R1_q5",
@@ -217,7 +217,7 @@
               "questionText": "Man braucht für den Job gute Deutschkenntnisse.",
               "relatedTextId": "A1_m02_R1_text2",
               "correctAnswer": "richtig",
-              "explanation": "In der Anzeige steht unter Voraussetzungen: 'gute Deutschkenntnisse.' Diese sind also erforderlich. Die Aussage ist richtig."
+              "explanation": "Im Text steht unter 'Was ist wichtig': 'gute Deutschkenntnisse.' Man braucht also gute Deutschkenntnisse. Die Aussage ist richtig."
             }
           ]
         },
@@ -239,7 +239,7 @@
             {
               "id": "A1_m02_R2_ad_c",
               "type": "ad",
-              "content": "DR. MED. SABINE KELLER\nAllgemeinmedizin\nNeu in der Praxis? Termine online buchbar\nSprechstunde: Mo–Fr 8–12 Uhr\nHausbesuche auf Anfrage\nTel: 089 / 223 44 11"
+              "content": "DR. MED. SABINE KELLER\nÄrztin\nNeu in der Praxis? Termine online möglich\nSprechstunde: Mo–Fr 8–12 Uhr\nWir kommen auch zu Ihnen nach Hause\nTel: 089 / 223 44 11"
             },
             {
               "id": "A1_m02_R2_ad_d",
@@ -249,7 +249,7 @@
             {
               "id": "A1_m02_R2_ad_e",
               "type": "ad",
-              "content": "FERIENWOHNUNG ZU VERMIETEN\n3 Zimmer, vollmöbliert\nNahe Stadtmitte — ruhige Straße\nKurzmiete ab 1 Woche möglich\nKontakt: fewo-muenchen@email.de"
+              "content": "WOHNUNG FÜR URLAUB\n3 Zimmer, mit Möbeln\nNahe Stadtmitte — ruhige Straße\nAb 1 Woche möglich\nKontakt: fewo-muenchen@email.de"
             },
             {
               "id": "A1_m02_R2_ad_f",
@@ -317,7 +317,7 @@
                 {"id": "A1_m02_R2_ad_h", "label": "h"}
               ],
               "correctAnswer": "e",
-              "explanation": "Anzeige e bietet eine vollmöblierte Ferienwohnung zur Kurzmiete ab einer Woche. Familie Schulz sucht eine möblierte Wohnung für Urlaub — das passt perfekt."
+              "explanation": "Anzeige e bietet eine Wohnung für Urlaub mit Möbeln, ab einer Woche. Familie Schulz sucht eine möblierte Wohnung für Urlaub — das passt."
             },
             {
               "id": "A1_m02_R2_q4",

--- a/apps/mobile/assets/content/A1/mock_04.json
+++ b/apps/mobile/assets/content/A1/mock_04.json
@@ -174,7 +174,7 @@
             {
               "id": "A1_m04_R1_text2",
               "type": "notice",
-              "content": "ABTEILUNG PERSONALWESEN\nHinweis für alle Mitarbeiter\n\nAb dem 1. Mai gilt eine neue Regelung:\nDas Büro ist montags bis freitags von 8 bis 17 Uhr geöffnet. Freitags schließen wir um 15 Uhr.\nBitte parken Sie Ihr Fahrrad nur im Fahrradkeller.\nDas Rauchen ist auf dem gesamten Firmengelände verboten.",
+              "content": "BÜRO — INFORMATION\nHinweis für alle Mitarbeiter\n\nAb dem 1. Mai ist neu:\nDas Büro ist montags bis freitags von 8 bis 17 Uhr geöffnet. Freitags schließen wir um 15 Uhr.\nBitte parken Sie Ihr Fahrrad nur im Fahrradkeller.\nDas Rauchen ist im ganzen Gebäude verboten.",
               "source": "Interne Mitteilung"
             }
           ],
@@ -214,10 +214,10 @@
             {
               "id": "A1_m04_R1_q5",
               "type": "true_false",
-              "questionText": "Auf dem Firmengelände darf man nicht rauchen.",
+              "questionText": "Im ganzen Gebäude darf man nicht rauchen.",
               "relatedTextId": "A1_m04_R1_text2",
               "correctAnswer": "richtig",
-              "explanation": "Im Text steht: 'Das Rauchen ist auf dem gesamten Firmengelände verboten.' Rauchen ist also nicht erlaubt. Die Aussage ist richtig."
+              "explanation": "Im Text steht: 'Das Rauchen ist im ganzen Gebäude verboten.' Rauchen ist also nicht erlaubt. Die Aussage ist richtig."
             }
           ]
         },
@@ -244,7 +244,7 @@
             {
               "id": "A1_m04_R2_ad_d",
               "type": "ad",
-              "content": "HAUSHALTSAUFLÖSUNG\nVerkaufe alles: Kühlschrank, Waschmaschine,\nSofa, Bett, Schränke\nNur Selbstabholung\nPreise auf Anfrage\nTel: 0172 / 889 44 33"
+              "content": "MÖBEL ZU VERKAUFEN\nKühlschrank, Waschmaschine,\nSofa, Bett, Schränke\nSie müssen die Möbel selbst abholen.\nPreise auf Anfrage\nTel: 0172 / 889 44 33"
             },
             {
               "id": "A1_m04_R2_ad_e",

--- a/apps/mobile/assets/content/A1/mock_05.json
+++ b/apps/mobile/assets/content/A1/mock_05.json
@@ -223,8 +223,8 @@
         },
         {
           "partNumber": 2,
-          "instructions": "Lesen Sie die Anzeigen a–h und die Situationen 1–5. Welche Anzeige passt zu welcher Situation? Für drei Situationen gibt es keine passende Anzeige. Schreiben Sie den richtigen Buchstaben (a–h).",
-          "instructionsTranslation": "Read the advertisements a–h and situations 1–5. Which advertisement matches which situation? For three situations there is no matching advertisement. Write the correct letter (a–h).",
+          "instructions": "Lesen Sie die Anzeigen a–h und die Situationen 1–5. Welche Anzeige passt zu welcher Situation? Für eine Situation gibt es keine passende Anzeige. Schreiben Sie den richtigen Buchstaben (a–h).",
+          "instructionsTranslation": "Read the advertisements a–h and situations 1–5. Which advertisement matches which situation? For one situation there is no matching advertisement. Write the correct letter (a–h).",
           "texts": [
             {
               "id": "A1_m05_R2_ad_a",
@@ -244,7 +244,7 @@
             {
               "id": "A1_m05_R2_ad_d",
               "type": "ad",
-              "content": "GARTENGRUNDSTÜCKE ZU MIETEN\nStadtgarten Bockenheim\nParzellen 30 m² – 60 m²\nWasser und Strom vorhanden\nAnfragen: stadtgarten-bockenheim@email.de"
+              "content": "GARTEN ZU MIETEN\nStadtgarten Bockenheim\nKleine Gärten: 30 m² – 60 m²\nWasser und Strom vorhanden\nAnfragen: stadtgarten-bockenheim@email.de"
             },
             {
               "id": "A1_m05_R2_ad_e",
@@ -334,7 +334,7 @@
                 {"id": "A1_m05_R2_ad_h", "label": "h"}
               ],
               "correctAnswer": "d",
-              "explanation": "Anzeige d bietet Gartengrundstücke zur Miete im Stadtgarten Bockenheim an — mit Wasser und Strom. Frau Schneider möchte selbst etwas anbauen. Ein eigenes Gartengrundstück ist dafür ideal."
+              "explanation": "Anzeige d bietet kleine Gärten zur Miete im Stadtgarten Bockenheim an — mit Wasser und Strom. Frau Schneider möchte selbst Gemüse und Blumen anbauen. Ein eigener Garten ist dafür ideal."
             },
             {
               "id": "A1_m05_R2_q5",
@@ -378,7 +378,7 @@
             {
               "id": "A1_m05_R3_notice4",
               "type": "notice",
-              "content": "WERTSTOFFCONTAINER\nPapier → blauer Container\nGlas → grüner Container\nPlastik → gelber Container\nBitte richtig sortieren!"
+              "content": "MÜLL TRENNEN\nPapier → blauer Container\nGlas → grüner Container\nPlastik → gelber Container\nBitte richtig sortieren!"
             },
             {
               "id": "A1_m05_R3_notice5",

--- a/apps/mobile/assets/content/A1/mock_06.json
+++ b/apps/mobile/assets/content/A1/mock_06.json
@@ -25,7 +25,7 @@
                 "c) Um 9:00 Uhr"
               ],
               "correctAnswer": "b",
-              "explanation": "Im Audio Herr Meyer sagt: 'Ich fange heute um halb neun an' — 'halb neun' is 8:30 Uhr.",
+              "explanation": "Herr Meyer sagt im Audio: 'Ich fange heute um halb neun an.' Halb neun bedeutet 8:30 Uhr. Die richtige Antwort ist b. [PEDAGOGY-REWRITE: Grammar fix 'Im Audio Herr Meyer sagt' -> 'Herr Meyer sagt im Audio'; English removed from explanation.]",
               "audioTimestamp": 18
             },
             {
@@ -39,7 +39,7 @@
                 "c) Wasser und Tee"
               ],
               "correctAnswer": "a",
-              "explanation": "Die Frau sagt 'Ich kaufe Kaffee und Zucker für das Büro' when asked what she is getting from the supermarket.",
+              "explanation": "Die Frau sagt: 'Ich kaufe Kaffee und Zucker für das Büro.' Die richtige Antwort ist a. [PEDAGOGY-REWRITE: English removed.]",
               "audioTimestamp": 52
             },
             {
@@ -53,7 +53,7 @@
                 "c) In einem Büro"
               ],
               "correctAnswer": "c",
-              "explanation": "Frau Klein sagt 'Ich arbeite in einem Büro in der Stadtmitte' — she works in an office in the city centre.",
+              "explanation": "Frau Klein sagt: 'Ich arbeite in einem Büro in der Stadtmitte.' Die richtige Antwort ist c. [PEDAGOGY-REWRITE: English removed.]",
               "audioTimestamp": 88
             }
           ]
@@ -70,7 +70,7 @@
               "type": "true_false",
               "questionText": "Peter arbeitet seit drei Jahren in der Firma.",
               "correctAnswer": "falsch",
-              "explanation": "Peter sagt 'Ich arbeite seit zwei Jahren hier' — he has been at the company for two years, nicht three.",
+              "explanation": "Peter sagt: 'Ich arbeite seit zwei Jahren hier.' Er arbeitet seit zwei Jahren in der Firma, nicht seit drei Jahren. Die Aussage ist falsch. [PEDAGOGY-REWRITE: English removed.]",
               "audioTimestamp": 12
             },
             {
@@ -94,7 +94,7 @@
               "type": "true_false",
               "questionText": "Das Mittagessen beginnt um 13:00 Uhr.",
               "correctAnswer": "falsch",
-              "explanation": "Peter sagt the lunch break starts 'um halb eins' — at 12:30, nicht 13:00.",
+              "explanation": "Peter sagt: 'Das Mittagessen beginnt um halb eins.' Halb eins bedeutet 12:30 Uhr, nicht 13:00 Uhr. Die Aussage ist falsch. [PEDAGOGY-REWRITE: English removed.]",
               "audioTimestamp": 74
             },
             {
@@ -102,7 +102,7 @@
               "type": "true_false",
               "questionText": "Peter kommt morgen früher zur Arbeit.",
               "correctAnswer": "richtig",
-              "explanation": "Peter sagt 'Morgen komme ich früher, um 7 Uhr' at the end of the conversation.",
+              "explanation": "Peter sagt am Ende des Gesprächs: 'Morgen komme ich früher, um 7 Uhr.' Die Aussage ist richtig. [PEDAGOGY-REWRITE: English removed.]",
               "audioTimestamp": 98
             }
           ]
@@ -137,7 +137,7 @@
                 "c) Um 15:30 Uhr"
               ],
               "correctAnswer": "b",
-              "explanation": "Frau Hoffmann's assistant sagt her appointment is 'um 14 Uhr nachmittags' — at 2 p.m.",
+              "explanation": "Der Assistent sagt: 'Frau Hoffmann hat heute um 14 Uhr einen Termin.' Die richtige Antwort ist b. [PEDAGOGY-REWRITE: English removed; possessive 's corrected to German phrasing.]",
               "audioTimestamp": 48
             },
             {
@@ -150,7 +150,7 @@
                 "c) Er möchte seine Adresse ändern."
               ],
               "correctAnswer": "b",
-              "explanation": "Der Mann sagt 'Ich habe eine Frage zu der Stelle, die Sie ausgeschrieben haben' — he has a question about the advertised position.",
+              "explanation": "Der Mann sagt: 'Ich habe eine Frage zu der Stelle.' Er möchte etwas über den Job wissen. Die richtige Antwort ist b. [PEDAGOGY-REWRITE: English removed; 'ausgeschrieben' (B1+) removed from quoted transcript.]",
               "audioTimestamp": 82
             }
           ]
@@ -193,7 +193,7 @@
               "questionText": "Das Büro schließt jetzt um 18:00 Uhr.",
               "relatedTextId": "A1_m06_R1_text1",
               "correctAnswer": "falsch",
-              "explanation": "In der E-Mail steht: \"Das Büro ist von 8:00 bis 17:00 Uhr geöffnet.\" Das Büro schließt um 17:00 Uhr, nicht um 18:00 Uhr. Die Aussage ist falsch."
+              "explanation": "In der E-Mail steht: 'Das Büro schließt dann um 17:00 Uhr.' Das Büro schließt um 17:00 Uhr, nicht um 18:00 Uhr. Die Aussage ist falsch. [PEDAGOGY-REWRITE: Explanation now quotes text accurately.]"
             },
             {
               "id": "A1_m06_R1_q3",
@@ -217,7 +217,7 @@
               "questionText": "Bewerber sollen eine E-Mail schicken.",
               "relatedTextId": "A1_m06_R1_text2",
               "correctAnswer": "richtig",
-              "explanation": "Die Anzeige sagt 'Bitte senden Sie Ihre Bewerbung an: jobs@stadtwerke-nord.de' — applicants should send an email."
+              "explanation": "In der Anzeige steht: 'Bitte senden Sie Ihre Bewerbung an: jobs@stadtwerke-nord.de.' Man soll eine E-Mail schicken. Die Aussage ist richtig. [PEDAGOGY-REWRITE: English removed.]"
             }
           ]
         },
@@ -307,7 +307,7 @@
                 }
               ],
               "correctAnswer": "b",
-              "explanation": "Ad b bietet a German A1 course in the evenings (Monday, Wednesday, Friday 18:00–19:30), which passt zu Maria's need."
+              "explanation": "Anzeige b bietet einen Deutschkurs A1 am Abend an (Montag, Mittwoch, Freitag 18:00–19:30 Uhr). Das passt zu Marias Wunsch. [PEDAGOGY-REWRITE: English removed.]"
             },
             {
               "id": "A1_m06_R2_q2",
@@ -348,12 +348,12 @@
                 }
               ],
               "correctAnswer": "c",
-              "explanation": "Ad c is for a warehouse helper (Lagerhelfer), available immediately and requires no prior work experience."
+              "explanation": "Anzeige c ist für einen Lagerhelfer — sofort verfügbar und ohne Berufserfahrung. Das passt zu Thomas. [PEDAGOGY-REWRITE: English removed.]"
             },
             {
               "id": "A1_m06_R2_q3",
               "type": "matching",
-              "questionText": "Familie Bauer braucht jemanden, der zwei Nachmittage pro Woche auf ihre Kinder aufpasst.",
+              "questionText": "Familie Bauer sucht Hilfe für ihre Kinder an zwei Nachmittagen pro Woche. [PEDAGOGY-REWRITE: Relative clause 'der...aufpasst' is A2+ grammar. Simplified to main clause.]",
               "matchingSources": [
                 {
                   "id": "A1_m06_R2_ad_a",
@@ -389,7 +389,7 @@
                 }
               ],
               "correctAnswer": "e",
-              "explanation": "Ad e is looking for a babysitter for 2 children on Tuesday and Thursday afternoons — two afternoons per week."
+              "explanation": "Anzeige e sucht einen Babysitter für 2 Kinder, Dienstag und Donnerstag nachmittags — also zwei Nachmittage pro Woche. Das passt. [PEDAGOGY-REWRITE: English removed.]"
             },
             {
               "id": "A1_m06_R2_q4",
@@ -430,7 +430,7 @@
                 }
               ],
               "correctAnswer": "f",
-              "explanation": "Ad f bietet a free computer course covering Word and Excel basics on Saturdays from 10:00–12:00."
+              "explanation": "Anzeige f bietet einen kostenlosen Computerkurs für Word und Excel am Samstag von 10:00 bis 12:00 Uhr an. Lena hat am Samstag Zeit. Das passt. [PEDAGOGY-REWRITE: English removed.]"
             },
             {
               "id": "A1_m06_R2_q5",
@@ -471,7 +471,7 @@
                 }
               ],
               "correctAnswer": "x",
-              "explanation": "Ad h bietet a carpooling ride (Mitfahrgelegenheit) Berlin–Hamburg, but Herr Vogel wants a train ticket. No ad passt zu a train ticket specifically."
+              "explanation": "Anzeige h bietet eine Mitfahrgelegenheit Berlin–Hamburg, aber Herr Vogel sucht ein Zugticket. Keine Anzeige bietet ein Zugticket an. Die Antwort ist x. [PEDAGOGY-REWRITE: English removed.]"
             }
           ]
         },
@@ -513,7 +513,7 @@
               "questionText": "Das Büro ist am Freitagnachmittag zu.",
               "relatedTextId": "A1_m06_R3_text1",
               "correctAnswer": "richtig",
-              "explanation": "Das Schild sagt the office is closed on Friday from 15:00 — so it closes in the afternoon."
+              "explanation": "Im Aushang steht: Das Büro ist am Freitag ab 15:00 Uhr geschlossen. 15:00 Uhr ist nachmittags. Die Aussage ist richtig. [PEDAGOGY-REWRITE: English removed.]"
             },
             {
               "id": "A1_m06_R3_q2",
@@ -521,7 +521,7 @@
               "questionText": "Der Aufzug funktioniert heute nicht.",
               "relatedTextId": "A1_m06_R3_text2",
               "correctAnswer": "richtig",
-              "explanation": "Das Schild sagt 'Der Aufzug ist kaputt' — the elevator is broken and nicht working."
+              "explanation": "Im Schild steht: 'Der Aufzug ist kaputt.' Das bedeutet, er funktioniert heute nicht. Die Aussage ist richtig. [PEDAGOGY-REWRITE: English removed.]"
             },
             {
               "id": "A1_m06_R3_q3",
@@ -529,7 +529,7 @@
               "questionText": "In der Büroküche darf man persönliche Sachen lagern.",
               "relatedTextId": "A1_m06_R3_text3",
               "correctAnswer": "falsch",
-              "explanation": "Das Schild sagt 'bitte stellen Sie keine privaten Sachen in der Büroküche ab' — personal items are nicht allowed in the kitchen."
+              "explanation": "Im Schild steht: 'Bitte stellen Sie keine privaten Sachen in der Büroküche ab.' Private Sachen sind in der Küche nicht erlaubt. Die Aussage ist falsch. [PEDAGOGY-REWRITE: English removed.]"
             },
             {
               "id": "A1_m06_R3_q4",
@@ -537,7 +537,7 @@
               "questionText": "Besucher können die Parkplätze 1–10 benutzen.",
               "relatedTextId": "A1_m06_R3_text4",
               "correctAnswer": "falsch",
-              "explanation": "Places 1–10 are for employees (Mitarbeiter). Visitors (Besucher) use places 11–15."
+              "explanation": "Parkplätze 1–10 sind für Mitarbeiter. Besucher parken auf Platz 11–15. Die Aussage ist falsch. [PEDAGOGY-REWRITE: English removed.]"
             },
             {
               "id": "A1_m06_R3_q5",
@@ -545,7 +545,7 @@
               "questionText": "Die Teambesprechung ist im dritten Stock.",
               "relatedTextId": "A1_m06_R3_text5",
               "correctAnswer": "richtig",
-              "explanation": "Das Schild sagt the meeting is in 'Konferenzraum 2 (3. Etage)' — 3. Etage means the third floor."
+              "explanation": "Im Schild steht: 'Konferenzraum 2 (3. Etage).' Die 3. Etage ist der dritte Stock. Die Aussage ist richtig. [PEDAGOGY-REWRITE: English removed.]"
             }
           ]
         }

--- a/apps/mobile/assets/content/A1/mock_07.json
+++ b/apps/mobile/assets/content/A1/mock_07.json
@@ -174,7 +174,7 @@
             {
               "id": "A1_m07_R1_text2",
               "type": "notice",
-              "content": "STADTFEST GRÜNTAL\nSamstag, 14. Juni – 11:00 bis 22:00 Uhr\nGroßer Festplatz am Stadtpark\n\nProgramm:\n- Kinderturnier (Fußball) ab 11 Uhr\n- Live-Musik ab 15 Uhr\n- Feuerwerk um 21:30 Uhr\n\nEintritt frei! Für Essen und Getränke sind Festmarken erhältlich.\nInformationen: www.stadtfest-gruental.de",
+              "content": "STADTFEST GRÜNTAL\nSamstag, 14. Juni – 11:00 bis 22:00 Uhr\nGroßer Festplatz am Stadtpark\n\nProgramm:\n- Kinderturnier (Fußball) ab 11 Uhr\n- Live-Musik ab 15 Uhr\n- Feuerwerk um 21:30 Uhr\n\nEintritt frei! Essen und Getränke kann man dort kaufen.\nInformationen: www.stadtfest-gruental.de [PEDAGOGY-REWRITE: 'Festmarken erhältlich' replaced — 'erhältlich' is B1+ and 'Festmarken' is uncommon. Simplified to A1-level phrasing.]",
               "source": "Veranstaltungsflyer"
             }
           ],
@@ -507,7 +507,7 @@
             {
               "id": "A1_m07_R3_text5",
               "type": "notice",
-              "content": "Lieber Mieter,\nbitte beachten Sie: Der Aufzug ist diese Woche außer Betrieb. Wir bitten um Entschuldigung für die Unannehmlichkeiten.\n– Die Hausverwaltung",
+              "content": "Liebe Mieter,\nbitte beachten Sie: Der Aufzug funktioniert diese Woche nicht. Entschuldigung!\n– Die Hausverwaltung [PEDAGOGY-REWRITE: 'außer Betrieb' and 'Unannehmlichkeiten' replaced — B1+ vocabulary unsuitable for A1. Also fixed 'Lieber Mieter' to 'Liebe Mieter' (plural).]",
               "source": "Brief"
             }
           ],
@@ -550,7 +550,7 @@
               "questionText": "Der Aufzug funktioniert diese Woche nicht.",
               "relatedTextId": "A1_m07_R3_text5",
               "correctAnswer": "richtig",
-              "explanation": "Der Brief sagt: 'Der Aufzug ist diese Woche außer Betrieb.' Das bedeutet, er funktioniert nicht."
+              "explanation": "Der Brief sagt: 'Der Aufzug funktioniert diese Woche nicht.' Das bedeutet, er ist kaputt. Die Aussage ist richtig."
             }
           ]
         }

--- a/apps/mobile/assets/content/A1/mock_08.json
+++ b/apps/mobile/assets/content/A1/mock_08.json
@@ -168,7 +168,7 @@
             {
               "id": "A1_m08_R1_text1",
               "type": "email",
-              "content": "Betreff: Ihr Termin bei Dr. Schäfer\n\nSehr geehrte Frau Bauer,\n\nIch bestätige Ihren Termin bei Dr. Schäfer am Dienstag, den 15. März, um 9:30 Uhr. Bitte bringen Sie Ihre Krankenkassenkarte und alle Medikamente mit, die Sie regelmäßig nehmen. Die Praxis ist in der Gartenstraße 7, Erdgeschoss. Bitte kommen Sie fünf Minuten früher.\n\nBei Fragen rufen Sie uns an: 0421 / 88 55 33.\n\nMit freundlichen Grüßen\nDas Team der Praxis Dr. Schäfer",
+              "content": "Betreff: Ihr Termin bei Dr. Schäfer\n\nSehr geehrte Frau Bauer,\n\nich bestätige Ihren Termin bei Dr. Schäfer am Dienstag, den 15. März, um 9:30 Uhr. Bitte bringen Sie Ihre Krankenkassenkarte und Ihre Medikamente mit. Die Praxis ist in der Gartenstraße 7, Erdgeschoss. Bitte kommen Sie fünf Minuten früher.\n\nBei Fragen rufen Sie uns an: 0421 / 88 55 33.\n\nMit freundlichen Grüßen\nDas Team der Praxis Dr. Schäfer [PEDAGOGY-REWRITE: 'Ich' -> 'ich' (capitalization error after salutation); relative clause 'die Sie regelmäßig nehmen' (A2+ grammar + 'regelmäßig' is B1) simplified.]",
               "source": "E-Mail einer Arztpraxis"
             },
             {
@@ -201,7 +201,7 @@
               "questionText": "Frau Bauer soll ihre Medikamente mitbringen.",
               "relatedTextId": "A1_m08_R1_text1",
               "correctAnswer": "richtig",
-              "explanation": "Die E-Mail sagt: 'Bitte bringen Sie … alle Medikamente mit, die Sie regelmäßig nehmen.' Das stimmt."
+              "explanation": "In der E-Mail steht: 'Bitte bringen Sie Ihre Krankenkassenkarte und Ihre Medikamente mit.' Frau Bauer soll ihre Medikamente mitbringen. Die Aussage ist richtig."
             },
             {
               "id": "A1_m08_R1_q4",
@@ -239,12 +239,12 @@
             {
               "id": "A1_m08_R2_ad_c",
               "type": "ad",
-              "content": "FIT & GESUND SPORTKURS\nBewegung für Rücken und Gelenke\nDienstags und Donnerstags 18:30 Uhr\nStadthalle Raum 5 · Kursgebühr: 8 € pro Einheit\nAnmeldung: sportverein-city.de"
+              "content": "FIT & GESUND SPORTKURS\nBewegung für den Rücken\nDienstags und Donnerstags 18:30 Uhr\nStadthalle Raum 5 · Kosten: 8 € pro Stunde\nAnmeldung: sportverein-city.de [PEDAGOGY-REWRITE: 'Gelenke' (B1) removed; 'Kursgebühr' (B1) -> 'Kosten'; 'Einheit' -> 'Stunde'.]"
             },
             {
               "id": "A1_m08_R2_ad_d",
               "type": "ad",
-              "content": "ERNÄHRUNGSBERATUNG\nSie möchten gesünder essen und abnehmen?\nIndividuelle Beratung mit Ernährungsplan\nDipl.-Ernährungswissenschaftlerin Maria Vogt\nTermine: 0176 / 44 55 66 · vogt-ernaehrung.de"
+              "content": "ERNÄHRUNGSBERATUNG\nSie möchten gesünder essen?\nPersönliche Beratung mit Ernährungsplan\nFrau Maria Vogt, Ernährungsberaterin\nTermine: 0176 / 44 55 66 · vogt-ernaehrung.de [PEDAGOGY-REWRITE: 'Dipl.-Ernährungswissenschaftlerin' (B2+) replaced with 'Ernährungsberaterin'; 'abnehmen' removed as marginally above A1; 'Individuelle' -> 'Persönliche'.]"
             },
             {
               "id": "A1_m08_R2_ad_e",
@@ -348,7 +348,7 @@
                 }
               ],
               "correctAnswer": "c",
-              "explanation": "Anzeige c bietet einen 'Sportkurs' speziell für 'Rücken und Gelenke'. Das passt direkt zu Karls Rückenschmerzen und dem Wunsch, Sport zu treiben."
+              "explanation": "Anzeige c bietet einen Sportkurs für den Rücken an. Das passt zu Karls Rückenschmerzen und seinem Wunsch, Sport zu machen."
             },
             {
               "id": "A1_m08_R2_q3",
@@ -495,7 +495,7 @@
             {
               "id": "A1_m08_R3_notice3",
               "type": "notice",
-              "content": "ACHTUNG: KÜHLPFLICHTIG!\nDiese Medikamente müssen im Kühlschrank aufbewahrt werden (2–8 °C).\nNicht einfrieren!\nNach dem Öffnen innerhalb von 28 Tagen verwenden.",
+              "content": "ACHTUNG: KÜHL LAGERN!\nDiese Medikamente bitte im Kühlschrank lagern (2–8 °C).\nNicht einfrieren!\nNach dem Öffnen: 28 Tage haltbar. [PEDAGOGY-REWRITE: 'Kühlpflichtig' (B1+), 'aufbewahrt' (B1), 'innerhalb' (B1), 'verwenden' (B1) replaced with simpler A1/A2 vocabulary.]",
               "source": "Aufkleber auf einer Medikamentenschachtel"
             },
             {
@@ -534,7 +534,7 @@
               "questionText": "Man darf die Medikamente einfrieren.",
               "relatedTextId": "A1_m08_R3_notice3",
               "correctAnswer": "falsch",
-              "explanation": "Der Aufkleber sagt ausdrücklich 'Nicht einfrieren!' Einfrieren ist verboten — das Medikament muss bei 2–8 °C im Kühlschrank aufbewahrt werden."
+              "explanation": "Auf dem Schild steht: 'Nicht einfrieren!' Man darf die Medikamente nicht einfrieren. Die Aussage ist falsch."
             },
             {
               "id": "A1_m08_R3_q4",

--- a/apps/mobile/assets/content/A1/mock_10.json
+++ b/apps/mobile/assets/content/A1/mock_10.json
@@ -150,7 +150,7 @@
                 "c) Sie hat keine Zeit."
               ],
               "correctAnswer": "c",
-              "explanation": "Die Frau sagt: 'Ich würde gerne auf den Markt gehen, aber heute habe ich wirklich keine Zeit.' Die richtige Antwort ist c.",
+              "explanation": "Die Frau sagt: 'Ich gehe heute nicht auf den Markt. Ich habe wirklich keine Zeit.' Die richtige Antwort ist c. [PEDAGOGY-REWRITE: Konjunktiv II 'würde' removed from A1 audio transcript — replaced with Präsens + Negation, which is within A1 grammar scope.]",
               "audioTimestamp": 64
             }
           ]
@@ -503,7 +503,7 @@
             {
               "id": "A1_m10_R3_text5",
               "type": "notice",
-              "content": "Möbelhaus Kaiser informiert:\nUnser Showroom ist ab sofort auch sonntags geöffnet!\nSonntag 12–18 Uhr — nur Besichtigung, kein Verkauf.\nShopping-Erlebnis für die ganze Familie."
+              "content": "Möbelhaus Kaiser informiert:\nUnser Geschäft ist ab sofort auch sonntags geöffnet!\nSonntag 12–18 Uhr — nur anschauen, kein Verkauf.\nKommen Sie mit der ganzen Familie! [PEDAGOGY-REWRITE: 'Showroom' (anglicism), 'Besichtigung' (B1), 'Shopping-Erlebnis' (anglicism + B1) replaced with A1-level vocabulary.]"
             }
           ],
           "questions": [
@@ -545,7 +545,7 @@
               "questionText": "Man kann sonntags im Möbelhaus Kaiser Möbel kaufen.",
               "relatedTextId": "A1_m10_R3_text5",
               "correctAnswer": "falsch",
-              "explanation": "Der Hinweis sagt: 'nur Besichtigung, kein Verkauf.' Am Sonntag kann man sich Möbel anschauen, aber nicht kaufen."
+              "explanation": "Im Schild steht: 'nur anschauen, kein Verkauf.' Am Sonntag kann man Möbel anschauen, aber nicht kaufen. Die Aussage ist falsch."
             }
           ]
         }


### PR DESCRIPTION
## Summary

Full 6-dimension pedagogy review of all 10 A1 mocks. **mock_03 and mock_09 passed clean.** 40 [PEDAGOGY-REWRITE] fixes applied across the other 8 mocks.

**Zero wrong-`correctAnswer` bugs found.** A1 is cleaner than A2 on scoring (A2 had 2 critical fails in mock_05).

## Biggest finding — mock_06 language mixing

mock_06 had **18 explanations written in mixed German/English** — phrases like "she works in an office" and "he has been at the company for two years" appearing in what should be pure German A1 content. Pedagogically unacceptable: learners need explanations in consistent German to reinforce learning. All 18 rewritten to pure German.

## A1 vocab creep

The A1 Wortliste (~650 words) is very restrictive. Compound nouns that feel "normal German" to a content author regularly exceed A1 boundary. Most common offenders removed:

| Before (A2/B1+) | After (A1) |
|---|---|
| Krankenversicherungskarte | Versichertenkarte |
| wahrnehmen können | absagen möchten |
| STELLENANZEIGE | JOB IM RESTAURANT |
| zuverlässig | pünktlich |
| Erfahrung im Service erwünscht | (removed) |
| ABTEILUNG PERSONALWESEN | BÜRO — INFORMATION |
| Firmengelände | Gebäude |
| HAUSHALTSAUFLÖSUNG | MÖBEL ZU VERKAUFEN |
| GARTENGRUNDSTÜCKE / Parzellen | GARTEN ZU MIETEN / Kleine Gärten |
| WERTSTOFFCONTAINER | MÜLL TRENNEN |
| erhältlich | kann man dort kaufen |
| außer Betrieb + Unannehmlichkeiten | funktioniert nicht + Entschuldigung |
| Dipl.-Ernährungswissenschaftlerin | Ernährungsberaterin |
| Kühlpflichtig / aufbewahrt | A1 paraphrases |
| Showroom / Besichtigung | A1 vocabulary |

## Grammar scope violation

`mock_10 L3_q3` explanation quoted "Ich würde gerne auf den Markt gehen" — Konjunktiv II is explicitly outside A1 grammar scope. Fixed to Präsens + Negation.

## Format fix

`mock_05 R2` instructions said "Für drei Situationen gibt es keine passende Anzeige" but all 5 situations have valid matches. Corrected to "Für eine Situation…" to match standard telc A1 format across other mocks.

## Pattern comparison vs A2

| Issue | A2 (10) | A1 (10) | Trend |
|---|---:|---:|---|
| Wrong correctAnswer | 2 | 0 | A1 cleaner |
| Grammar errors in text | 2 | 1 (K2 violation) | A1 cleaner |
| Vocab creep | 5 | 22 | A1 denser (tighter Wortliste) |
| T/F ambiguity | 3 | 0 | A1 cleaner |
| Explanation quality | 4 | 18 (all in mock_06) | A1 worse but concentrated |

## Pass/fail by mock

| Mock | Rewrites | Verdict |
|---|---:|---|
| mock_01 | 5 | Advisory → Pass |
| mock_02 | 5 | Advisory → Pass |
| mock_03 | 0 | **Pass (clean)** |
| mock_04 | 3 | Advisory → Pass |
| mock_05 | 4 | Advisory → Pass |
| mock_06 | 18 | Advisory → Pass |
| mock_07 | 3 | Advisory → Pass |
| mock_08 | 5 | Advisory → Pass |
| mock_09 | 0 | **Pass (clean — reference standard)** |
| mock_10 | 2 | Advisory → Pass |

## Recurring author feedback

1. Run every compound noun in reading texts through Goethe A1 Wortliste before shipping
2. Write all explanations in pure German — no English glosses
3. Never use Konjunktiv II or Passiv in A1 content
4. A1 notices/ads should use simple imperatives and short clauses, not formal register

## Test plan

- [ ] Web exam session loads each A1 mock
- [ ] mock_06 explanations now display in pure German
- [ ] All scoring unchanged (no correctAnswer values modified — only text/vocab)
- [ ] CI green