### PR TITLE
feat(web): Sprachbausteine exam section for B1/B2 mocks

### DIFF
--- a/apps/web/src/__tests__/exam/SprachbausteineExam.test.tsx
+++ b/apps/web/src/__tests__/exam/SprachbausteineExam.test.tsx
@@ -1,0 +1,401 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  SprachbausteineExam,
+  parseTextSegments,
+  answerKey,
+} from '../../components/exam/SprachbausteineExam';
+import type {
+  SprachbausteineSection,
+  SprachbausteinePart,
+  SprachbausteineQuestion,
+} from '@telc/types';
+
+vi.mock('@telc/core', () => ({
+  SECTION_DURATIONS: {
+    B1: { sprachbausteine: 15 * 60, reading: 75 * 60 },
+    A1: { reading: 25 * 60 },
+  },
+  scoreSprachbausteine: vi.fn((answers: Record<string, string>, section: SprachbausteineSection) => {
+    let earned = 0;
+    let max = 0;
+    for (const part of section.parts) {
+      for (const q of part.questions) {
+        max += 1;
+        const key = `sprachbausteine_${part.partNumber}_${q.blankNumber}`;
+        if (answers[key]?.trim().toLowerCase() === q.correctAnswer.trim().toLowerCase()) {
+          earned += 1;
+        }
+      }
+    }
+    const percentage = max > 0 ? earned / max : 0;
+    return { earned, max, percentage, passed: percentage >= 0.6 };
+  }),
+  formatTime: (s: number) => `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`,
+  createTimerState: vi.fn(),
+  tickTimer: vi.fn(),
+}));
+
+function makeQuestion(
+  blankNumber: number,
+  type: 'mcq' | 'word_bank',
+  options: string[],
+  correctAnswer: string,
+  explanation = `Explanation for blank ${blankNumber}.`,
+): SprachbausteineQuestion {
+  return { blankNumber, type, options, correctAnswer, explanation };
+}
+
+// Teil 1: 10 MCQ gaps with 3 options each.
+const teil1Options = ['a) in', 'b) an', 'c) bei'];
+const teil1Text = Array.from({ length: 10 }, (_, i) => `Word ${i + 1} __(${i + 1})__`).join(' ');
+const teil1Part: SprachbausteinePart = {
+  partNumber: 1,
+  instructions: 'Wählen Sie a, b oder c.',
+  text: teil1Text,
+  questions: Array.from({ length: 10 }, (_, i) =>
+    makeQuestion(i + 1, 'mcq', teil1Options, 'c'),
+  ),
+};
+
+// Teil 2: 10 word-bank gaps sharing 15 options.
+const teil2Options = [
+  'a) Dank',
+  'b) trotzdem',
+  'c) gesprochen',
+  'd) funktioniert',
+  'e) für',
+  'f) In',
+  'g) erhöht',
+  'h) auf',
+  'i) wahrscheinlich',
+  'j) Vielleicht',
+  'k) herzlichen',
+  'l) nachgedacht',
+  'm) reicht',
+  'n) zu',
+  'o) damit',
+];
+const teil2CorrectByBlank: Record<number, string> = {
+  11: 'a',
+  12: 'b',
+  13: 'c',
+  14: 'd',
+  15: 'e',
+  16: 'f',
+  17: 'g',
+  18: 'h',
+  19: 'i',
+  20: 'j',
+};
+const teil2Text = Array.from(
+  { length: 10 },
+  (_, i) => `Slot ${i + 11} __(${i + 11})__`,
+).join(' ');
+const teil2Part: SprachbausteinePart = {
+  partNumber: 2,
+  instructions: 'Jedes Wort passt nur einmal.',
+  text: teil2Text,
+  questions: Array.from({ length: 10 }, (_, i) => {
+    const blank = i + 11;
+    return makeQuestion(blank, 'word_bank', teil2Options, teil2CorrectByBlank[blank]);
+  }),
+};
+
+function buildSection(parts: SprachbausteinePart[]): SprachbausteineSection {
+  return { parts };
+}
+
+async function startExam() {
+  await userEvent.click(screen.getByTestId('section-start-btn'));
+}
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+});
+
+describe('parseTextSegments', () => {
+  it('splits mixed text and blanks in order', () => {
+    const segments = parseTextSegments('Hello __(1)__ world __(2)__.');
+    expect(segments).toEqual([
+      { kind: 'text', content: 'Hello ' },
+      { kind: 'blank', blankNumber: 1 },
+      { kind: 'text', content: ' world ' },
+      { kind: 'blank', blankNumber: 2 },
+      { kind: 'text', content: '.' },
+    ]);
+  });
+
+  it('returns only text for plain input', () => {
+    expect(parseTextSegments('No gaps here.')).toEqual([
+      { kind: 'text', content: 'No gaps here.' },
+    ]);
+  });
+
+  it('returns only blanks for back-to-back markers', () => {
+    expect(parseTextSegments('__(1)____(2)__')).toEqual([
+      { kind: 'blank', blankNumber: 1 },
+      { kind: 'blank', blankNumber: 2 },
+    ]);
+  });
+});
+
+describe('answerKey', () => {
+  it('formats as sprachbausteine_{part}_{blank}', () => {
+    expect(answerKey(1, 5)).toBe('sprachbausteine_1_5');
+    expect(answerKey(2, 11)).toBe('sprachbausteine_2_11');
+  });
+});
+
+describe('SprachbausteineExam — Teil 1 (MCQ cloze)', () => {
+  it('renders all 10 MCQ gaps with 3 options each after starting', async () => {
+    render(
+      <SprachbausteineExam
+        mockId="B1_mock_01"
+        level="B1"
+        section={buildSection([teil1Part])}
+      />,
+    );
+    await startExam();
+
+    for (let i = 1; i <= 10; i++) {
+      const gap = screen.getByTestId(`gap-1-${i}`) as HTMLSelectElement;
+      // The blank options include the 3 MCQ options plus the placeholder.
+      const valueOpts = Array.from(gap.options).map((o) => o.value);
+      expect(valueOpts).toEqual(['', 'a', 'b', 'c']);
+    }
+  });
+});
+
+describe('SprachbausteineExam — Teil 2 (word bank)', () => {
+  it('renders 10 word-bank gaps with 15 options each', async () => {
+    render(
+      <SprachbausteineExam
+        mockId="B1_mock_01"
+        level="B1"
+        section={buildSection([teil2Part])}
+      />,
+    );
+    await startExam();
+
+    for (let i = 11; i <= 20; i++) {
+      const gap = screen.getByTestId(`gap-2-${i}`) as HTMLSelectElement;
+      // 15 word-bank options plus the empty placeholder = 16 total.
+      expect(gap.options).toHaveLength(16);
+    }
+  });
+
+  it('disables word-bank option in other gaps once selected', async () => {
+    render(
+      <SprachbausteineExam
+        mockId="B1_mock_01"
+        level="B1"
+        section={buildSection([teil2Part])}
+      />,
+    );
+    await startExam();
+
+    const gap11 = screen.getByTestId('gap-2-11') as HTMLSelectElement;
+    await userEvent.selectOptions(gap11, 'a');
+
+    // In gap 11, option 'a' is the selected value, so it remains enabled.
+    const optionAInGap11 = Array.from(gap11.options).find((o) => o.value === 'a');
+    expect(optionAInGap11?.disabled).toBe(false);
+
+    // In any other gap, option 'a' is now marked used and disabled.
+    const gap12 = screen.getByTestId('gap-2-12') as HTMLSelectElement;
+    const optionAInGap12 = Array.from(gap12.options).find((o) => o.value === 'a');
+    expect(optionAInGap12?.disabled).toBe(true);
+  });
+});
+
+describe('SprachbausteineExam — answering state', () => {
+  it('selecting an option marks the gap as answered (blue surface)', async () => {
+    render(
+      <SprachbausteineExam
+        mockId="B1_mock_01"
+        level="B1"
+        section={buildSection([teil1Part])}
+      />,
+    );
+    await startExam();
+
+    const gap = screen.getByTestId('gap-1-1') as HTMLSelectElement;
+    expect(gap.className).toContain('bg-surface-container');
+
+    await userEvent.selectOptions(gap, 'c');
+    expect(gap.value).toBe('c');
+    expect(gap.className).toContain('bg-brand-primary-surface');
+  });
+
+  it('submit button is disabled until all gaps are answered', async () => {
+    render(
+      <SprachbausteineExam
+        mockId="B1_mock_01"
+        level="B1"
+        section={buildSection([teil1Part])}
+      />,
+    );
+    await startExam();
+
+    expect(screen.getByTestId('submit-btn')).toBeDisabled();
+
+    // Fill 9 of 10 blanks.
+    for (let i = 1; i <= 9; i++) {
+      await userEvent.selectOptions(screen.getByTestId(`gap-1-${i}`), 'c');
+    }
+    expect(screen.getByTestId('submit-btn')).toBeDisabled();
+
+    // Fill the last one.
+    await userEvent.selectOptions(screen.getByTestId('gap-1-10'), 'c');
+    expect(screen.getByTestId('submit-btn')).not.toBeDisabled();
+  });
+
+  it('switching between part tabs preserves answers', async () => {
+    render(
+      <SprachbausteineExam
+        mockId="B1_mock_01"
+        level="B1"
+        section={buildSection([teil1Part, teil2Part])}
+      />,
+    );
+    await startExam();
+
+    await userEvent.selectOptions(screen.getByTestId('gap-1-1'), 'c');
+    await userEvent.click(screen.getByTestId('part-tab-2'));
+    expect(screen.getByTestId('gap-2-11')).toBeTruthy();
+
+    await userEvent.click(screen.getByTestId('part-tab-1'));
+    const gap = screen.getByTestId('gap-1-1') as HTMLSelectElement;
+    expect(gap.value).toBe('c');
+  });
+});
+
+describe('SprachbausteineExam — submit & review', () => {
+  async function fillPartCorrectly(partNumber: number, blanks: number[], correct: string) {
+    for (const b of blanks) {
+      await userEvent.selectOptions(screen.getByTestId(`gap-${partNumber}-${b}`), correct);
+    }
+  }
+
+  it('submitting with all-correct answers shows passed verdict and per-part scores', async () => {
+    render(
+      <SprachbausteineExam
+        mockId="B1_mock_01"
+        level="B1"
+        section={buildSection([teil1Part, teil2Part])}
+      />,
+    );
+    await startExam();
+
+    // Teil 1: all correct = 'c'
+    await fillPartCorrectly(
+      1,
+      Array.from({ length: 10 }, (_, i) => i + 1),
+      'c',
+    );
+
+    // Teil 2: fill each gap with its correct word-bank letter.
+    await userEvent.click(screen.getByTestId('part-tab-2'));
+    for (let b = 11; b <= 20; b++) {
+      await userEvent.selectOptions(
+        screen.getByTestId(`gap-2-${b}`),
+        teil2CorrectByBlank[b],
+      );
+    }
+
+    await userEvent.click(screen.getByTestId('submit-btn'));
+
+    // Overall verdict
+    expect(screen.getByText('20/20')).toBeTruthy();
+    expect(screen.getByText(/100% — Bestanden/)).toBeTruthy();
+
+    // Per-part scorecards
+    const part1Card = screen.getByTestId('part-score-1');
+    expect(within(part1Card).getByText('10/10')).toBeTruthy();
+    const part2Card = screen.getByTestId('part-score-2');
+    expect(within(part2Card).getByText('10/10')).toBeTruthy();
+
+    // Next-section link points to writing (Sprachbausteine → Schreiben).
+    expect(screen.getByTestId('next-section-link')).toHaveAttribute(
+      'href',
+      '/exam/B1_mock_01/writing',
+    );
+  });
+
+  it('review mode shows correct answers with explanations and marks wrong gaps', async () => {
+    render(
+      <SprachbausteineExam
+        mockId="B1_mock_01"
+        level="B1"
+        section={buildSection([teil1Part])}
+      />,
+    );
+    await startExam();
+
+    // Answer all gaps wrong ('a' instead of correct 'c').
+    for (let i = 1; i <= 10; i++) {
+      await userEvent.selectOptions(screen.getByTestId(`gap-1-${i}`), 'a');
+    }
+    await userEvent.click(screen.getByTestId('submit-btn'));
+
+    // Review rows show the user answer + the correct answer.
+    for (let i = 1; i <= 10; i++) {
+      const reviewGap = screen.getByTestId(`review-gap-1-${i}`);
+      // Wrong answer: displays "a → c ✗" inside an error-styled span.
+      expect(reviewGap.textContent).toContain('a → c');
+      expect(reviewGap.className).toContain('border-error');
+    }
+
+    // Explanation rows are present per question.
+    const explanation1 = screen.getByTestId('review-explanation-1-1');
+    expect(explanation1.textContent).toContain('Explanation for blank 1.');
+  });
+
+  it('review mode marks correctly-answered gaps as success', async () => {
+    render(
+      <SprachbausteineExam
+        mockId="B1_mock_01"
+        level="B1"
+        section={buildSection([teil1Part])}
+      />,
+    );
+    await startExam();
+
+    for (let i = 1; i <= 10; i++) {
+      await userEvent.selectOptions(screen.getByTestId(`gap-1-${i}`), 'c');
+    }
+    await userEvent.click(screen.getByTestId('submit-btn'));
+
+    for (let i = 1; i <= 10; i++) {
+      const reviewGap = screen.getByTestId(`review-gap-1-${i}`);
+      expect(reviewGap.className).toContain('border-success');
+      expect(reviewGap.textContent).toContain('c');
+    }
+  });
+
+  it('persists score into sessionStorage under the exam session key', async () => {
+    render(
+      <SprachbausteineExam
+        mockId="B1_mock_01"
+        level="B1"
+        section={buildSection([teil1Part])}
+      />,
+    );
+    await startExam();
+
+    for (let i = 1; i <= 10; i++) {
+      await userEvent.selectOptions(screen.getByTestId(`gap-1-${i}`), 'c');
+    }
+    await userEvent.click(screen.getByTestId('submit-btn'));
+
+    const raw = window.sessionStorage.getItem('exam_session_B1_mock_01');
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.sections.sprachbausteine).toBeDefined();
+    expect(parsed.sections.sprachbausteine.score.earned).toBe(10);
+    expect(parsed.sections.sprachbausteine.score.max).toBe(10);
+    expect(parsed.sections.sprachbausteine.score.passed).toBe(true);
+  });
+});

--- a/apps/web/src/app/exam/[mockId]/page.tsx
+++ b/apps/web/src/app/exam/[mockId]/page.tsx
@@ -24,9 +24,21 @@ export default async function MockExamDetailPage({
   const hasContent = exam !== null;
   const durations = SECTION_DURATIONS[level];
 
+  const hasSprachbausteine = Boolean(exam?.sections.sprachbausteine);
+
   const sections = [
     { name: "Hören", key: "listening" as const, icon: "🎧", route: "listening" },
     { name: "Lesen", key: "reading" as const, icon: "📖", route: "reading" },
+    ...(hasSprachbausteine
+      ? [
+          {
+            name: "Sprachbausteine",
+            key: "sprachbausteine" as const,
+            icon: "🧩",
+            route: "sprachbausteine",
+          },
+        ]
+      : []),
     { name: "Schreiben", key: "writing" as const, icon: "✍️", route: "writing" },
     { name: "Sprechen", key: "speaking" as const, icon: "🗣️", route: "speaking" },
   ];
@@ -87,7 +99,8 @@ export default async function MockExamDetailPage({
       <div className="space-y-3">
         <h2 className="text-lg font-semibold text-text-primary">Abschnitte</h2>
         {sections.map((section) => {
-          const duration = durations[section.key];
+          const duration =
+            (durations as Record<string, number | undefined>)[section.key] ?? 0;
           const href = `/exam/${mockId}/${section.route}`;
           return (
             <div

--- a/apps/web/src/app/exam/[mockId]/sprachbausteine/page.tsx
+++ b/apps/web/src/app/exam/[mockId]/sprachbausteine/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from 'next/navigation';
+import { getMockExamOrNotFound } from '@/lib/loadMockExam';
+import { SprachbausteineExam } from '@/components/exam/SprachbausteineExam';
+
+export default async function SprachbausteinePage({
+  params,
+}: {
+  params: Promise<{ mockId: string }>;
+}) {
+  const { mockId } = await params;
+  const { exam } = await getMockExamOrNotFound(mockId);
+
+  if (!exam.sections.sprachbausteine) notFound();
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <SprachbausteineExam
+        mockId={mockId}
+        level={exam.level}
+        section={exam.sections.sprachbausteine}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/exam/ExamResults.tsx
+++ b/apps/web/src/components/exam/ExamResults.tsx
@@ -15,6 +15,12 @@ interface ExamResultsProps {
 const SECTION_META = [
   { key: 'listening' as const, label: 'Hören', icon: '🎧', aggregate: 'written' as const },
   { key: 'reading' as const, label: 'Lesen', icon: '📖', aggregate: 'written' as const },
+  {
+    key: 'sprachbausteine' as const,
+    label: 'Sprachbausteine',
+    icon: '🧩',
+    aggregate: 'written' as const,
+  },
   { key: 'writing' as const, label: 'Schreiben', icon: '✍️', aggregate: 'written' as const },
   { key: 'speaking' as const, label: 'Sprechen', icon: '🗣️', aggregate: 'oral' as const },
 ] as const;
@@ -263,15 +269,21 @@ export function ExamResults({ mockId, level, mockNumber }: ExamResultsProps) {
       {/* Per-section scores */}
       <div className="space-y-3">
         <h2 className="text-lg font-semibold text-text-primary">Abschnitte</h2>
-        {SECTION_META.map((meta) => (
-          <SectionScoreCard
-            key={meta.key}
-            label={meta.label}
-            icon={meta.icon}
-            result={session.sections[meta.key]}
-            isHumanGraded={meta.key === 'writing' || meta.key === 'speaking'}
-          />
-        ))}
+        {SECTION_META
+          // Only show Sprachbausteine row if the exam actually has it (i.e. session
+          // already recorded a result). A1/A2/C1 don't have this section.
+          .filter(
+            (meta) => meta.key !== 'sprachbausteine' || !!session.sections.sprachbausteine,
+          )
+          .map((meta) => (
+            <SectionScoreCard
+              key={meta.key}
+              label={meta.label}
+              icon={meta.icon}
+              result={session.sections[meta.key]}
+              isHumanGraded={meta.key === 'writing' || meta.key === 'speaking'}
+            />
+          ))}
       </div>
 
       {/* Actions */}

--- a/apps/web/src/components/exam/ReadingExam.tsx
+++ b/apps/web/src/components/exam/ReadingExam.tsx
@@ -110,10 +110,14 @@ export function ReadingExam({ mockId, level, section }: ReadingExamProps) {
           </a>
           <a
             data-testid="next-section-link"
-            href={`/exam/${mockId}/writing`}
+            href={
+              level === 'B1' || level === 'B2'
+                ? `/exam/${mockId}/sprachbausteine`
+                : `/exam/${mockId}/writing`
+            }
             className="flex-1 rounded-xl bg-brand-primary py-3 text-center text-sm font-semibold text-white hover:opacity-90"
           >
-            Weiter: Schreiben
+            {level === 'B1' || level === 'B2' ? 'Weiter: Sprachbausteine' : 'Weiter: Schreiben'}
           </a>
         </div>
       </div>

--- a/apps/web/src/components/exam/SectionStatus.tsx
+++ b/apps/web/src/components/exam/SectionStatus.tsx
@@ -8,7 +8,7 @@ export function SectionStatusBadge({
   sectionKey,
 }: {
   mockId: string;
-  sectionKey: 'listening' | 'reading' | 'writing' | 'speaking';
+  sectionKey: 'listening' | 'reading' | 'sprachbausteine' | 'writing' | 'speaking';
 }) {
   const [done, setDone] = useState(false);
 
@@ -39,7 +39,7 @@ export function SectionActionButton({
   color,
 }: {
   mockId: string;
-  sectionKey: 'listening' | 'reading' | 'writing' | 'speaking';
+  sectionKey: 'listening' | 'reading' | 'sprachbausteine' | 'writing' | 'speaking';
   href: string;
   color: string;
 }) {

--- a/apps/web/src/components/exam/SprachbausteineExam.tsx
+++ b/apps/web/src/components/exam/SprachbausteineExam.tsx
@@ -1,0 +1,507 @@
+'use client';
+
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import { SECTION_DURATIONS, scoreSprachbausteine } from '@telc/core';
+import type {
+  SprachbausteineSection,
+  SprachbausteinePart,
+  SprachbausteineQuestion,
+  Level,
+} from '@telc/types';
+import type { ExamPhase } from '@/lib/examTypes';
+import { saveSection } from '@/lib/examSession';
+import { ExamTimer } from './ExamTimer';
+import { SectionIntro } from './SectionIntro';
+
+interface SprachbausteineExamProps {
+  mockId: string;
+  level: Level;
+  section: SprachbausteineSection;
+}
+
+// SECTION_DURATIONS is `as const` and only B1/B2 declare sprachbausteine.
+// Fall back to 15 min for any level that does not define it explicitly.
+function getTotalSeconds(level: Level): number {
+  const durations = SECTION_DURATIONS[level] as { sprachbausteine?: number };
+  return durations.sprachbausteine ?? 15 * 60;
+}
+
+export function answerKey(partNumber: number, blankNumber: number): string {
+  return `sprachbausteine_${partNumber}_${blankNumber}`;
+}
+
+/**
+ * Splits a text like "Liebe Sabine, __(1)__ Arbeit __(2)__." into ordered
+ * segments: text chunks alternating with blank markers. Blank markers retain
+ * their blankNumber so we can render the right dropdown inline.
+ */
+export type TextSegment =
+  | { kind: 'text'; content: string }
+  | { kind: 'blank'; blankNumber: number };
+
+export function parseTextSegments(text: string): TextSegment[] {
+  const segments: TextSegment[] = [];
+  const re = /__\((\d+)\)__/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ kind: 'text', content: text.slice(lastIndex, match.index) });
+    }
+    segments.push({ kind: 'blank', blankNumber: parseInt(match[1], 10) });
+    lastIndex = re.lastIndex;
+  }
+  if (lastIndex < text.length) {
+    segments.push({ kind: 'text', content: text.slice(lastIndex) });
+  }
+  return segments;
+}
+
+export function SprachbausteineExam({ mockId, level, section }: SprachbausteineExamProps) {
+  const [phase, setPhase] = useState<ExamPhase>('intro');
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [currentPart, setCurrentPart] = useState(0);
+  const totalSeconds = getTotalSeconds(level);
+
+  const handleAnswer = (key: string, value: string) => {
+    setAnswers((prev) => {
+      const next = { ...prev };
+      if (value === '') {
+        delete next[key];
+      } else {
+        next[key] = value;
+      }
+      return next;
+    });
+  };
+
+  const handleExpire = useCallback(() => setPhase('submitted'), []);
+
+  const score = useMemo(
+    () => (phase === 'submitted' ? scoreSprachbausteine(answers, section) : null),
+    [phase, answers, section],
+  );
+
+  // Per-part breakdown for the results screen.
+  const partScores = useMemo(() => {
+    return section.parts.map((p) => {
+      let earned = 0;
+      const total = p.questions.length;
+      for (const q of p.questions) {
+        const key = answerKey(p.partNumber, q.blankNumber);
+        const answer = answers[key];
+        if (
+          answer !== undefined &&
+          answer.trim().toLowerCase() === q.correctAnswer.trim().toLowerCase()
+        ) {
+          earned += 1;
+        }
+      }
+      return { partNumber: p.partNumber, earned, max: total };
+    });
+  }, [section.parts, answers]);
+
+  useEffect(() => {
+    if (phase === 'submitted' && score) {
+      saveSection(mockId, level, 'sprachbausteine', {
+        answers,
+        score,
+        submittedAt: new Date().toISOString(),
+      });
+    }
+  }, [phase, score, mockId, level, answers]);
+
+  const allAnswered = useMemo(
+    () =>
+      section.parts.every((p) =>
+        p.questions.every(
+          (q) => answers[answerKey(p.partNumber, q.blankNumber)] !== undefined,
+        ),
+      ),
+    [section.parts, answers],
+  );
+
+  const part = section.parts[currentPart];
+  const totalParts = section.parts.length;
+  const totalQuestions = section.parts.reduce((n, p) => n + p.questions.length, 0);
+
+  if (phase === 'intro') {
+    return (
+      <SectionIntro
+        title="Sprachbausteine"
+        icon="🧩"
+        totalSeconds={totalSeconds}
+        description={`${totalParts} Teile · ${totalQuestions} Lücken`}
+        extraInfo="Wählen Sie für jede Lücke die passende Antwort."
+        onStart={() => setPhase('active')}
+      />
+    );
+  }
+
+  if (phase === 'submitted' && score) {
+    return (
+      <ResultsView
+        mockId={mockId}
+        section={section}
+        answers={answers}
+        score={score}
+        partScores={partScores}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-text-primary">Sprachbausteine</h1>
+          <p className="text-sm text-text-secondary">
+            Teil {currentPart + 1} von {totalParts}
+          </p>
+        </div>
+        <ExamTimer
+          totalSeconds={totalSeconds}
+          isRunning={phase === 'active'}
+          onExpire={handleExpire}
+        />
+      </div>
+
+      <div className="flex gap-2">
+        {section.parts.map((p, i) => {
+          const done = p.questions.every(
+            (q) => answers[answerKey(p.partNumber, q.blankNumber)] !== undefined,
+          );
+          return (
+            <button
+              key={p.partNumber}
+              data-testid={`part-tab-${p.partNumber}`}
+              onClick={() => setCurrentPart(i)}
+              className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                i === currentPart
+                  ? 'bg-brand-primary text-white'
+                  : done
+                    ? 'bg-success-light text-success'
+                    : 'border border-border bg-white text-text-secondary hover:border-border-hover'
+              }`}
+            >
+              Teil {p.partNumber}
+            </button>
+          );
+        })}
+      </div>
+
+      <PartView part={part} answers={answers} onAnswer={handleAnswer} />
+
+      <div className="flex items-center justify-between pt-2">
+        <button
+          data-testid="section-nav-prev"
+          onClick={() => setCurrentPart((p) => Math.max(0, p - 1))}
+          disabled={currentPart === 0}
+          className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary disabled:opacity-40 hover:border-border-hover"
+        >
+          Zurück
+        </button>
+        {currentPart < totalParts - 1 ? (
+          <button
+            data-testid="section-nav-next"
+            onClick={() => setCurrentPart((p) => p + 1)}
+            className="rounded-lg bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+          >
+            Nächster Teil
+          </button>
+        ) : (
+          <button
+            data-testid="submit-btn"
+            onClick={() => setPhase('submitted')}
+            disabled={!allAnswered}
+            className="rounded-lg bg-brand-primary px-6 py-2 text-sm font-semibold text-white disabled:opacity-50 hover:opacity-90"
+          >
+            Abgeben
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PartView({
+  part,
+  answers,
+  onAnswer,
+}: {
+  part: SprachbausteinePart;
+  answers: Record<string, string>;
+  onAnswer: (key: string, value: string) => void;
+}) {
+  const questionByBlank = useMemo(() => {
+    const map = new Map<number, SprachbausteineQuestion>();
+    for (const q of part.questions) map.set(q.blankNumber, q);
+    return map;
+  }, [part.questions]);
+
+  const segments = useMemo(() => parseTextSegments(part.text), [part.text]);
+  const answeredCount = part.questions.filter(
+    (q) => answers[answerKey(part.partNumber, q.blankNumber)] !== undefined,
+  ).length;
+
+  // For word_bank Teil 2: track which options have been used across all gaps
+  // in this part so dropdowns can grey them out. The currently selected value
+  // in any gap is still shown as active in its own dropdown.
+  const usedValues = useMemo(() => {
+    const used = new Set<string>();
+    for (const q of part.questions) {
+      if (q.type !== 'word_bank') continue;
+      const v = answers[answerKey(part.partNumber, q.blankNumber)];
+      if (v !== undefined) used.add(v);
+    }
+    return used;
+  }, [part.questions, part.partNumber, answers]);
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-border bg-white p-4">
+        <p className="text-sm font-medium text-text-primary">{part.instructions}</p>
+        <p className="mt-2 text-xs text-text-secondary">
+          {answeredCount}/{part.questions.length} Lücken ausgefüllt
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-border bg-white p-5">
+        <div className="whitespace-pre-wrap font-sans text-[15px] leading-8 text-text-primary">
+          {segments.map((seg, idx) => {
+            if (seg.kind === 'text') {
+              return <span key={`t-${idx}`}>{seg.content}</span>;
+            }
+            const q = questionByBlank.get(seg.blankNumber);
+            if (!q) {
+              return (
+                <span key={`b-${idx}`} className="font-mono text-text-disabled">
+                  __({seg.blankNumber})__
+                </span>
+              );
+            }
+            const key = answerKey(part.partNumber, q.blankNumber);
+            const selected = answers[key] ?? '';
+            return (
+              <GapDropdown
+                key={`b-${idx}`}
+                partNumber={part.partNumber}
+                question={q}
+                selected={selected}
+                usedValues={q.type === 'word_bank' ? usedValues : undefined}
+                onChange={(value) => onAnswer(key, value)}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function optionValue(option: string): string {
+  // Options are formatted as "a) Dank" - value is "a". Falls back to trimmed option.
+  const sep = option.indexOf(')');
+  return sep > 0 ? option.slice(0, sep).trim() : option.trim();
+}
+
+function GapDropdown({
+  partNumber,
+  question,
+  selected,
+  usedValues,
+  onChange,
+}: {
+  partNumber: number;
+  question: SprachbausteineQuestion;
+  selected: string;
+  usedValues?: Set<string>;
+  onChange: (value: string) => void;
+}) {
+  const gapLabel = `Lücke ${question.blankNumber}`;
+  const testId = `gap-${partNumber}-${question.blankNumber}`;
+  const isAnswered = selected !== '';
+
+  return (
+    <span className="relative inline-block align-baseline">
+      <span className="sr-only">{gapLabel}: </span>
+      <select
+        data-testid={testId}
+        aria-label={gapLabel}
+        value={selected}
+        onChange={(e) => onChange(e.target.value)}
+        className={`mx-1 rounded-md border px-2 py-0.5 text-sm font-medium transition-colors focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary ${
+          isAnswered
+            ? 'border-brand-primary bg-brand-primary-surface text-text-primary'
+            : 'border-border bg-surface-container text-text-secondary hover:border-border-hover'
+        }`}
+      >
+        <option value="">{`(${question.blankNumber}) …`}</option>
+        {question.options.map((opt) => {
+          const value = optionValue(opt);
+          const isUsedElsewhere =
+            usedValues !== undefined && value !== selected && usedValues.has(value);
+          return (
+            <option key={opt} value={value} disabled={isUsedElsewhere}>
+              {opt}
+              {isUsedElsewhere ? ' (bereits verwendet)' : ''}
+            </option>
+          );
+        })}
+      </select>
+    </span>
+  );
+}
+
+function ResultsView({
+  mockId,
+  section,
+  answers,
+  score,
+  partScores,
+}: {
+  mockId: string;
+  section: SprachbausteineSection;
+  answers: Record<string, string>;
+  score: { earned: number; max: number; percentage: number; passed: boolean };
+  partScores: { partNumber: number; earned: number; max: number }[];
+}) {
+  const pct = Math.round(score.percentage * 100);
+
+  return (
+    <div className="space-y-6">
+      <div
+        className={`rounded-xl border-2 p-6 text-center ${
+          score.passed ? 'border-pass bg-pass-light' : 'border-fail bg-fail-light'
+        }`}
+      >
+        <div className={`text-4xl font-bold ${score.passed ? 'text-pass' : 'text-fail'}`}>
+          {score.earned}/{score.max}
+        </div>
+        <div className={`mt-1 text-lg font-medium ${score.passed ? 'text-pass' : 'text-fail'}`}>
+          {pct}% — {score.passed ? 'Bestanden' : 'Nicht bestanden'}
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {partScores.map((ps) => {
+          const partPct = ps.max > 0 ? Math.round((ps.earned / ps.max) * 100) : 0;
+          const partPassed = partPct >= 60;
+          return (
+            <div
+              key={ps.partNumber}
+              data-testid={`part-score-${ps.partNumber}`}
+              className={`rounded-xl border p-4 text-center ${
+                partPassed ? 'border-pass' : 'border-fail'
+              }`}
+            >
+              <div className="text-sm font-medium text-text-secondary">Teil {ps.partNumber}</div>
+              <div className={`text-2xl font-bold ${partPassed ? 'text-pass' : 'text-fail'}`}>
+                {ps.earned}/{ps.max}
+              </div>
+              <div className={`text-sm ${partPassed ? 'text-pass' : 'text-fail'}`}>{partPct}%</div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="space-y-4">
+        {section.parts.map((p) => (
+          <ReviewPart key={p.partNumber} part={p} answers={answers} />
+        ))}
+      </div>
+
+      <div className="flex gap-3">
+        <a
+          href={`/exam/${mockId}`}
+          className="rounded-xl border border-border px-5 py-3 text-sm font-medium text-text-secondary hover:border-border-hover"
+        >
+          Zur Prüfungsübersicht
+        </a>
+        <a
+          data-testid="next-section-link"
+          href={`/exam/${mockId}/writing`}
+          className="flex-1 rounded-xl bg-brand-primary py-3 text-center text-sm font-semibold text-white hover:opacity-90"
+        >
+          Weiter: Schreiben
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function ReviewPart({
+  part,
+  answers,
+}: {
+  part: SprachbausteinePart;
+  answers: Record<string, string>;
+}) {
+  const questionByBlank = useMemo(() => {
+    const map = new Map<number, SprachbausteineQuestion>();
+    for (const q of part.questions) map.set(q.blankNumber, q);
+    return map;
+  }, [part.questions]);
+
+  const segments = useMemo(() => parseTextSegments(part.text), [part.text]);
+
+  return (
+    <div className="rounded-xl border border-border bg-white p-5 space-y-4">
+      <h3 className="font-semibold text-text-primary">Teil {part.partNumber}</h3>
+      <div className="whitespace-pre-wrap font-sans text-[15px] leading-8 text-text-primary">
+        {segments.map((seg, idx) => {
+          if (seg.kind === 'text') {
+            return <span key={`rt-${idx}`}>{seg.content}</span>;
+          }
+          const q = questionByBlank.get(seg.blankNumber);
+          if (!q) return null;
+          const userAnswer = answers[answerKey(part.partNumber, q.blankNumber)] ?? '';
+          const isCorrect =
+            userAnswer.trim().toLowerCase() === q.correctAnswer.trim().toLowerCase();
+          const displayUser = userAnswer || '—';
+          return (
+            <span
+              key={`b-${idx}`}
+              data-testid={`review-gap-${part.partNumber}-${q.blankNumber}`}
+              className={`mx-1 inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-sm font-medium ${
+                isCorrect
+                  ? 'border-success bg-success-light text-success'
+                  : 'border-error bg-error-light text-error'
+              }`}
+            >
+              <span className="font-mono text-xs text-text-disabled">({q.blankNumber})</span>
+              <span>{isCorrect ? displayUser : `${displayUser} → ${q.correctAnswer}`}</span>
+              <span aria-hidden>{isCorrect ? '✓' : '✗'}</span>
+            </span>
+          );
+        })}
+      </div>
+
+      <div className="space-y-2 border-t border-border pt-3">
+        {part.questions.map((q) => {
+          const userAnswer = answers[answerKey(part.partNumber, q.blankNumber)] ?? '';
+          const isCorrect =
+            userAnswer.trim().toLowerCase() === q.correctAnswer.trim().toLowerCase();
+          return (
+            <details
+              key={q.blankNumber}
+              data-testid={`review-explanation-${part.partNumber}-${q.blankNumber}`}
+              className={`rounded-lg border p-3 ${
+                isCorrect ? 'border-success' : 'border-error'
+              }`}
+            >
+              <summary className="cursor-pointer text-sm font-medium text-text-primary">
+                Lücke {q.blankNumber}:{' '}
+                <span className={isCorrect ? 'text-success' : 'text-error'}>
+                  {userAnswer || '—'}
+                </span>
+                {!isCorrect && <span className="ml-1 text-success">→ {q.correctAnswer}</span>}
+              </summary>
+              <p className="mt-2 text-xs text-text-secondary">{q.explanation}</p>
+            </details>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/examSession.ts
+++ b/apps/web/src/lib/examSession.ts
@@ -16,6 +16,7 @@ export interface ExamSessionState {
   sections: {
     listening?: SectionResult;
     reading?: SectionResult;
+    sprachbausteine?: SectionResult;
     writing?: SectionResult;
     speaking?: SectionResult;
   };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export {
   calculateSectionScore,
   calculateExamScore,
+  scoreSprachbausteine,
   getReadinessLevel,
   formatScore,
 } from './scoring';

--- a/packages/core/src/scoring.ts
+++ b/packages/core/src/scoring.ts
@@ -71,7 +71,7 @@ export function calculateSectionScore(
   return makeSectionScore(earned, max);
 }
 
-function scoreSprachbausteine(
+export function scoreSprachbausteine(
   userAnswers: Record<string, string>,
   section: SprachbausteineSection
 ): SectionScore {

--- a/packages/core/src/timer.ts
+++ b/packages/core/src/timer.ts
@@ -21,13 +21,15 @@ export const SECTION_DURATIONS = {
   },
   B1: {
     listening: 30 * 60,
-    reading: 90 * 60,
+    reading: 75 * 60,
+    sprachbausteine: 15 * 60,
     writing: 30 * 60,
     speaking: 15 * 60,
   },
   B2: {
     listening: 20 * 60,
-    reading: 90 * 60,
+    reading: 70 * 60,
+    sprachbausteine: 20 * 60,
     writing: 30 * 60,
     speaking: 15 * 60,
   },


### PR DESCRIPTION
## Summary

Adds the missing Sprachbausteine renderer — the section telc B1 introduces (not present at A1/A2). Unblocks B1 mock_01 playability end-to-end.

## Components

- **`SprachbausteineExam.tsx`** — renders Teil 1 (10 MCQ grammar cloze) + Teil 2 (10 word-bank gaps from 15 options). Uses native `<select>` for keyboard a11y. Word-bank enforces "each word used once" via disabled options in other gaps (re-selectable in own gap for corrections).
- **Next.js route** `/exam/[mockId]/sprachbausteine`
- **Review mode** — green/red highlighting + per-gap explanation `<details>`

## Integration

- `examSession.ts` — optional sprachbausteine slot in section state
- Exam flow — Lesen → Sprachbausteine → Schreiben when present (B1/B2)
- `ExamResults` — per-part score row + aggregate inclusion
- `ReadingExam` — next-link routes to Sprachbausteine at B1/B2

## Scoring + timing

- `scoreSprachbausteine` exposed from `@telc/core`
- `SECTION_DURATIONS`:
  - B1: 90min Lesen split as 75 Lesen + 15 Sprachbausteine
  - B2: 70 Lesen + 20 Sprachbausteine
  - (telc bundles Lesen+SB in one block; UI splits for UX)

## Tests

- 14 new tests covering text parsing, answer-key format, Teil 1 MCQ rendering (3 options × 10 gaps), Teil 2 word-bank (15 options × 10 gaps), used-option disabling, selection UI state, submit gating, tab-switching persistence, per-part scores, review mode styling
- 143/143 web tests pass
- Typecheck clean

No changes to `@telc/types` — existing types fit.

## UX decisions (autonomous)

1. Gap input = native `<select>` (keyboard-navigable, screen-reader announces `aria-label="Lücke N"`, mobile-friendly, consistent with MCQ style)
2. Word-bank gating — used options `disabled` elsewhere but re-enabled in own gap for corrections
3. Review mode — green (correct), red (wrong, showing `user → correct`), explanation accordions

## Test plan

- [ ] Start B1 mock_01 exam → reach Sprachbausteine section after Lesen
- [ ] Teil 1: each gap is a 3-option select; submit scores correctly
- [ ] Teil 2: word bank of 15; each selected word disabled in other gaps
- [ ] Review mode shows correct/incorrect highlighting
- [ ] Results page includes Sprachbausteine row
- [ ] CI green