### PR TITLE
content(B1): author mock_02 (Beruf) + mock_03 (Bildung)

### DIFF
--- a/apps/mobile/assets/content/B1/mock_02.json
+++ b/apps/mobile/assets/content/B1/mock_02.json
@@ -1,13 +1,920 @@
 {
   "id": "B1_mock_02",
   "level": "B1",
-  "title": "Übungstest 2",
-  "version": 0,
-  "_stub": true,
+  "title": "B1 Übungstest 2: Beruf",
+  "version": 1,
   "sections": {
-    "listening": { "totalTimeMinutes": 20, "parts": [] },
-    "reading": { "totalTimeMinutes": 25, "parts": [] },
-    "writing": { "totalTimeMinutes": 20, "tasks": [] },
-    "speaking": { "totalTimeMinutes": 15, "prepTimeMinutes": 0, "parts": [] }
+    "listening": {
+      "totalTimeMinutes": 30,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Sie hören fünf kurze Texte. Entscheiden Sie bei jedem Text: Ist die Aussage richtig oder falsch? Sie hören jeden Text nur einmal.",
+          "instructionsTranslation": "You will hear five short texts. For each text, decide: Is the statement correct or incorrect? You will hear each text only once.",
+          "audioFile": "assets/audio/B1/mock02/listening_part1.mp3",
+          "playCount": 1,
+          "questions": [
+            {
+              "id": "B1_m02_L1_q1",
+              "type": "true_false",
+              "questionText": "Herr Weber bittet seine Kollegin, heute länger im Büro zu bleiben.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Auf dem Anrufbeantworter sagt Herr Weber: 'Frau Klein, ich kann heute leider nicht mehr ins Büro kommen – könnten Sie das Angebot für Herrn Vogel bitte bis morgen früh fertig machen?' Er bittet sie um eine fertige Unterlage, nicht um Überstunden oder ein längeres Bleiben.",
+              "audioTimestamp": 10
+            },
+            {
+              "id": "B1_m02_L1_q2",
+              "type": "true_false",
+              "questionText": "Die Krankmeldung gilt bis einschließlich Freitag.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Die Mitarbeiterin sagt ihrem Chef am Telefon: 'Der Arzt hat mich bis Freitag krankgeschrieben. Am Montag bin ich wieder im Büro.' Die Krankmeldung endet also am Freitag – die Aussage ist richtig.",
+              "audioTimestamp": 14
+            },
+            {
+              "id": "B1_m02_L1_q3",
+              "type": "true_false",
+              "questionText": "Das Bewerbungsgespräch wurde auf einen anderen Tag verschoben.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Die Personalabteilung informiert per Telefon: 'Leider muss ich Ihnen den Termin am Dienstag absagen – wir schlagen Ihnen stattdessen Donnerstag, 10 Uhr, vor.' Der Termin wird also verschoben – die Aussage ist richtig.",
+              "audioTimestamp": 11
+            },
+            {
+              "id": "B1_m02_L1_q4",
+              "type": "true_false",
+              "questionText": "Der Kurs zur Weiterbildung findet ausschließlich online statt.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Die Durchsage lautet: 'Der Kurs wird zum Teil online, zum Teil in unserem Seminarraum angeboten.' Es handelt sich also um ein Mischformat, nicht um einen reinen Online-Kurs.",
+              "audioTimestamp": 12
+            },
+            {
+              "id": "B1_m02_L1_q5",
+              "type": "true_false",
+              "questionText": "Die Teambesprechung beginnt heute fünfzehn Minuten später als geplant.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Die Assistentin gibt bekannt: 'Liebe Kolleginnen und Kollegen, unser Meeting verschiebt sich um eine Viertelstunde – wir starten um 10:15 Uhr statt 10:00 Uhr.' Fünfzehn Minuten später ist also korrekt.",
+              "audioTimestamp": 9
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Sie hören einen Radiobericht. Entscheiden Sie, ob die folgenden zehn Aussagen richtig oder falsch sind. Sie hören den Text nur einmal.",
+          "instructionsTranslation": "You will hear a radio report. Decide whether the following ten statements are correct or incorrect. You will hear the text only once.",
+          "audioFile": "assets/audio/B1/mock02/listening_part2.mp3",
+          "playCount": 1,
+          "questions": [
+            {
+              "id": "B1_m02_L2_q1",
+              "type": "true_false",
+              "questionText": "Die Sendung handelt vom Berufswechsel im mittleren Alter.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Die Moderatorin leitet ein: 'In unserer heutigen Sendung geht es um einen Trend, der immer häufiger wird – Menschen, die zwischen 40 und 55 noch einmal beruflich neu anfangen.' Das Thema ist damit klar.",
+              "audioTimestamp": 8
+            },
+            {
+              "id": "B1_m02_L2_q2",
+              "type": "true_false",
+              "questionText": "Laut einer Umfrage haben im letzten Jahr nur wenige Deutsche den Beruf gewechselt.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Der Reporter berichtet: 'Eine Umfrage zeigt, dass fast jeder fünfte Arbeitnehmer im letzten Jahr seinen Beruf gewechselt hat.' Jeder Fünfte ist kein kleiner Anteil – die Aussage ist falsch.",
+              "audioTimestamp": 35
+            },
+            {
+              "id": "B1_m02_L2_q3",
+              "type": "true_false",
+              "questionText": "Der Experte Herr Fischer arbeitet bei einer Berufsberatung.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Die Moderatorin stellt ihn vor: 'Unser Gast, Herr Jonas Fischer, ist seit über zehn Jahren Berufsberater bei der Agentur für Arbeit in Köln.' Die Aussage passt genau.",
+              "audioTimestamp": 58
+            },
+            {
+              "id": "B1_m02_L2_q4",
+              "type": "true_false",
+              "questionText": "Der häufigste Grund für einen Berufswechsel ist laut Herrn Fischer ein höheres Gehalt.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Herr Fischer sagt: 'Erstaunlicherweise steht das Gehalt nicht an erster Stelle – viele wünschen sich mehr Sinn in ihrer Arbeit und ein besseres Betriebsklima.' Gehalt ist also nicht der Hauptgrund.",
+              "audioTimestamp": 82
+            },
+            {
+              "id": "B1_m02_L2_q5",
+              "type": "true_false",
+              "questionText": "Ein schlechtes Verhältnis zum Vorgesetzten kann ein Grund für einen Wechsel sein.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Herr Fischer erklärt: 'In unseren Gesprächen hören wir oft, dass die Beziehung zum Chef der entscheidende Auslöser war – wer sich nicht wertgeschätzt fühlt, kündigt irgendwann.' Das stimmt mit der Aussage überein.",
+              "audioTimestamp": 102
+            },
+            {
+              "id": "B1_m02_L2_q6",
+              "type": "true_false",
+              "questionText": "Frau Richter, eine Gesprächspartnerin, hat aus dem Bankwesen in die Pflege gewechselt.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Frau Richter erzählt: 'Nach fünfzehn Jahren in einer Bank habe ich umgeschult – heute arbeite ich als Altenpflegerin und bin endlich zufrieden.' Der Wechsel von Bank zu Pflege ist genau genannt.",
+              "audioTimestamp": 125
+            },
+            {
+              "id": "B1_m02_L2_q7",
+              "type": "true_false",
+              "questionText": "Frau Richter verdient in ihrem neuen Beruf deutlich mehr als vorher.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Frau Richter sagt offen: 'Natürlich verdiene ich jetzt weniger, aber ich gehe jeden Morgen gerne zur Arbeit – das ist mir wichtiger als das Geld.' Sie verdient also weniger, nicht mehr.",
+              "audioTimestamp": 148
+            },
+            {
+              "id": "B1_m02_L2_q8",
+              "type": "true_false",
+              "questionText": "Der Experte empfiehlt, vor einem Wechsel unbedingt ein Praktikum zu machen.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Herr Fischer rät: 'Bevor Sie kündigen, sollten Sie ein Praktikum oder zumindest eine Schnuppertage im neuen Beruf machen – das erspart Ihnen böse Überraschungen.' Der Tipp zum Praktikum ist eindeutig.",
+              "audioTimestamp": 168
+            },
+            {
+              "id": "B1_m02_L2_q9",
+              "type": "true_false",
+              "questionText": "Die Agentur für Arbeit bietet auch finanzielle Unterstützung für Umschulungen an.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Herr Fischer erwähnt: 'In vielen Fällen übernimmt die Agentur für Arbeit einen Teil der Kosten einer Umschulung – das wissen die wenigsten.' Das entspricht der Aussage.",
+              "audioTimestamp": 185
+            },
+            {
+              "id": "B1_m02_L2_q10",
+              "type": "true_false",
+              "questionText": "Am Ende nennt die Moderatorin eine Telefonnummer für weitere Informationen.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Die Moderatorin schließt mit: 'Mehr zu diesem Thema finden Sie auf unserer Internetseite unter beruf-neu.de.' Sie verweist also auf eine Webseite, nicht auf eine Telefonnummer.",
+              "audioTimestamp": 205
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Sie hören fünf kurze Gespräche. Zu jedem Gespräch gibt es eine Aufgabe. Was ist richtig? Kreuzen Sie an: a, b oder c. Sie hören jedes Gespräch zweimal.",
+          "instructionsTranslation": "You will hear five short conversations. For each conversation there is one task. What is correct? Mark: a, b, or c. You will hear each conversation twice.",
+          "audioFile": "assets/audio/B1/mock02/listening_part3.mp3",
+          "playCount": 2,
+          "questions": [
+            {
+              "id": "B1_m02_L3_q1",
+              "type": "mcq",
+              "questionText": "Warum ruft die Bewerberin bei der Firma an?",
+              "options": [
+                "a) Sie möchte den Termin ihres Vorstellungsgesprächs verschieben.",
+                "b) Sie möchte sich nach dem Stand ihrer Bewerbung erkundigen.",
+                "c) Sie möchte eine weitere Unterlage nachreichen."
+              ],
+              "correctAnswer": "b",
+              "explanation": "Die Bewerberin sagt: 'Ich hatte mich vor drei Wochen auf die Stelle als Projektassistentin beworben und wollte nachfragen, ob es schon einen Zwischenstand gibt.' Sie erkundigt sich also nach dem Stand. Termin und Unterlagen werden nicht erwähnt.",
+              "audioTimestamp": 16
+            },
+            {
+              "id": "B1_m02_L3_q2",
+              "type": "mcq",
+              "questionText": "Worauf einigen sich die beiden Kollegen am Ende?",
+              "options": [
+                "a) Sie tauschen ihre Dienste am Wochenende.",
+                "b) Sie arbeiten beide am Sonntag.",
+                "c) Sie sprechen zuerst mit dem Teamleiter."
+              ],
+              "correctAnswer": "c",
+              "explanation": "Nach längerer Diskussion sagt Anna: 'Ich glaube, wir sollten das lieber erst mit dem Teamleiter abstimmen, bevor wir etwas entscheiden.' Tobias stimmt zu. Ein Tausch oder gemeinsames Arbeiten wird überlegt, aber nicht beschlossen.",
+              "audioTimestamp": 55
+            },
+            {
+              "id": "B1_m02_L3_q3",
+              "type": "mcq",
+              "questionText": "Was rät der Personalberater dem Mann im Gespräch?",
+              "options": [
+                "a) sofort zu kündigen und eine Pause zu machen",
+                "b) eine Weiterbildung im aktuellen Unternehmen zu beantragen",
+                "c) sich parallel bei anderen Firmen zu bewerben"
+              ],
+              "correctAnswer": "b",
+              "explanation": "Der Berater sagt: 'Bevor Sie kündigen, sprechen Sie doch mit Ihrer Chefin über eine Fortbildung im Haus – das ist oft der schnellste Weg, neue Aufgaben zu bekommen.' Er empfiehlt also die Weiterbildung im Unternehmen. Kündigen rät er ausdrücklich ab.",
+              "audioTimestamp": 92
+            },
+            {
+              "id": "B1_m02_L3_q4",
+              "type": "mcq",
+              "questionText": "Warum möchte die Angestellte im Homeoffice arbeiten?",
+              "options": [
+                "a) Sie hat einen langen Weg zur Arbeit.",
+                "b) Sie muss sich um ein krankes Kind kümmern.",
+                "c) Sie fühlt sich im Büro zu häufig gestört."
+              ],
+              "correctAnswer": "c",
+              "explanation": "Die Angestellte erklärt: 'Im Großraumbüro werde ich ständig unterbrochen – zu Hause komme ich in zwei Stunden weiter als hier an einem ganzen Tag.' Der Grund ist also die Konzentration. Weg und Kind werden nicht genannt.",
+              "audioTimestamp": 125
+            },
+            {
+              "id": "B1_m02_L3_q5",
+              "type": "mcq",
+              "questionText": "Was ist für die Mitarbeiterin bei der Gehaltsverhandlung am wichtigsten?",
+              "options": [
+                "a) ein höheres Grundgehalt",
+                "b) zusätzliche Urlaubstage",
+                "c) flexible Arbeitszeiten"
+              ],
+              "correctAnswer": "c",
+              "explanation": "Die Mitarbeiterin sagt am Ende: 'Wenn ich ehrlich bin, sind mir Gleitzeit und die Möglichkeit, früher zu gehen, wichtiger als die 200 Euro mehr im Monat.' Flexible Arbeitszeiten stehen also an erster Stelle.",
+              "audioTimestamp": 160
+            }
+          ]
+        }
+      ]
+    },
+    "reading": {
+      "totalTimeMinutes": 60,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Lesen Sie zuerst die fünf Situationen (1–5) und dann die acht Überschriften (a–h). Welche Überschrift passt zu welcher Situation? Für jede Situation gibt es genau eine passende Überschrift. Drei Überschriften bleiben übrig.",
+          "instructionsTranslation": "First read the five situations (1–5) and then the eight headlines (a–h). Which headline matches which situation? For each situation there is exactly one matching headline. Three headlines remain unused.",
+          "texts": [
+            { "id": "B1_m02_R1_head_a", "type": "notice", "content": "a) Jobmesse 'Karriere kompakt' – über 80 Unternehmen stellen sich am Samstag vor" },
+            { "id": "B1_m02_R1_head_b", "type": "notice", "content": "b) Kostenloser Workshop: Bewerbungsunterlagen professionell erstellen" },
+            { "id": "B1_m02_R1_head_c", "type": "notice", "content": "c) Neue Kita am Firmengelände – Betreuungsplätze für Mitarbeiterkinder ab Herbst" },
+            { "id": "B1_m02_R1_head_d", "type": "notice", "content": "d) Rückenschule für Büroangestellte – 10 Abende ab kommenden Montag" },
+            { "id": "B1_m02_R1_head_e", "type": "notice", "content": "e) Gewerkschaftsberatung zum Thema Überstunden und Zeitausgleich – Sprechstunde donnerstags" },
+            { "id": "B1_m02_R1_head_f", "type": "notice", "content": "f) Sommerfest der Firma – alle Mitarbeiter mit Familie herzlich eingeladen" },
+            { "id": "B1_m02_R1_head_g", "type": "notice", "content": "g) Online-Seminar 'Englisch im Beruf' – für Berufstätige mit Grundkenntnissen, abends" },
+            { "id": "B1_m02_R1_head_h", "type": "notice", "content": "h) Betriebsarzt bietet kostenlose Grippeimpfung an – Anmeldung im Personalbüro" }
+          ],
+          "questions": [
+            {
+              "id": "B1_m02_R1_q1",
+              "type": "matching",
+              "questionText": "1. Ramona beendet im Sommer ihr Studium und weiß noch nicht genau, in welche Branche sie gehen möchte. Sie hätte gern die Möglichkeit, an einem Tag viele verschiedene Firmen kennenzulernen.",
+              "matchingSources": [
+                { "id": "B1_m02_R1_head_a", "label": "a" },
+                { "id": "B1_m02_R1_head_b", "label": "b" },
+                { "id": "B1_m02_R1_head_c", "label": "c" },
+                { "id": "B1_m02_R1_head_d", "label": "d" },
+                { "id": "B1_m02_R1_head_e", "label": "e" },
+                { "id": "B1_m02_R1_head_f", "label": "f" },
+                { "id": "B1_m02_R1_head_g", "label": "g" },
+                { "id": "B1_m02_R1_head_h", "label": "h" }
+              ],
+              "correctAnswer": "a",
+              "explanation": "Überschrift a) Jobmesse mit 80 Unternehmen an einem Samstag ist genau der Rahmen, den Ramona sucht: viele Arbeitgeber gleichzeitig kennenlernen. Die übrigen Angebote richten sich an bereits Beschäftigte oder an einen engeren Themenkreis."
+            },
+            {
+              "id": "B1_m02_R1_q2",
+              "type": "matching",
+              "questionText": "2. Herr Nowak hat sich schon mehrfach beworben, bekommt aber selten eine Einladung. Ein Freund meint, seine Unterlagen seien nicht mehr zeitgemäß. Er sucht kostenlose Hilfe, um Lebenslauf und Anschreiben zu verbessern.",
+              "matchingSources": [
+                { "id": "B1_m02_R1_head_a", "label": "a" },
+                { "id": "B1_m02_R1_head_b", "label": "b" },
+                { "id": "B1_m02_R1_head_c", "label": "c" },
+                { "id": "B1_m02_R1_head_d", "label": "d" },
+                { "id": "B1_m02_R1_head_e", "label": "e" },
+                { "id": "B1_m02_R1_head_f", "label": "f" },
+                { "id": "B1_m02_R1_head_g", "label": "g" },
+                { "id": "B1_m02_R1_head_h", "label": "h" }
+              ],
+              "correctAnswer": "b",
+              "explanation": "Überschrift b) bietet einen kostenlosen Workshop zu professionellen Bewerbungsunterlagen – genau das, was Herr Nowak für Lebenslauf und Anschreiben braucht. Keine andere Anzeige passt zum Thema Bewerbung."
+            },
+            {
+              "id": "B1_m02_R1_q3",
+              "type": "matching",
+              "questionText": "3. Frau Lindemann arbeitet seit Jahren im Rechnungswesen und hat in letzter Zeit häufig Überstunden gemacht, die ihr Arbeitgeber weder auszahlt noch als freie Tage anrechnen will. Sie möchte sich informieren, welche Rechte sie hat.",
+              "matchingSources": [
+                { "id": "B1_m02_R1_head_a", "label": "a" },
+                { "id": "B1_m02_R1_head_b", "label": "b" },
+                { "id": "B1_m02_R1_head_c", "label": "c" },
+                { "id": "B1_m02_R1_head_d", "label": "d" },
+                { "id": "B1_m02_R1_head_e", "label": "e" },
+                { "id": "B1_m02_R1_head_f", "label": "f" },
+                { "id": "B1_m02_R1_head_g", "label": "g" },
+                { "id": "B1_m02_R1_head_h", "label": "h" }
+              ],
+              "correctAnswer": "e",
+              "explanation": "Überschrift e) bietet eine Gewerkschaftsberatung zum Thema Überstunden und Zeitausgleich – die passende Anlaufstelle für Frau Lindemann. Die anderen Angebote haben keinen rechtlichen oder arbeitsrechtlichen Bezug."
+            },
+            {
+              "id": "B1_m02_R1_q4",
+              "type": "matching",
+              "questionText": "4. Tarek sitzt jeden Tag acht Stunden am Schreibtisch und klagt seit Monaten über Rückenschmerzen. Sein Hausarzt hat ihm empfohlen, regelmäßig gezielte Übungen unter Anleitung zu machen.",
+              "matchingSources": [
+                { "id": "B1_m02_R1_head_a", "label": "a" },
+                { "id": "B1_m02_R1_head_b", "label": "b" },
+                { "id": "B1_m02_R1_head_c", "label": "c" },
+                { "id": "B1_m02_R1_head_d", "label": "d" },
+                { "id": "B1_m02_R1_head_e", "label": "e" },
+                { "id": "B1_m02_R1_head_f", "label": "f" },
+                { "id": "B1_m02_R1_head_g", "label": "g" },
+                { "id": "B1_m02_R1_head_h", "label": "h" }
+              ],
+              "correctAnswer": "d",
+              "explanation": "Überschrift d) 'Rückenschule für Büroangestellte' richtet sich direkt an Menschen wie Tarek mit Rückenproblemen durch Schreibtischarbeit. Die anderen Kurse oder Angebote haben keinen gesundheitlichen Fokus auf den Rücken."
+            },
+            {
+              "id": "B1_m02_R1_q5",
+              "type": "matching",
+              "questionText": "5. Frau Aslan wird in zwei Monaten in eine internationale Firma wechseln. Dort wird viel auf Englisch kommuniziert. Sie hat zwar Schulenglisch, möchte aber dringend ihre beruflichen Sprachkenntnisse auffrischen – am liebsten nach Feierabend und von zu Hause aus.",
+              "matchingSources": [
+                { "id": "B1_m02_R1_head_a", "label": "a" },
+                { "id": "B1_m02_R1_head_b", "label": "b" },
+                { "id": "B1_m02_R1_head_c", "label": "c" },
+                { "id": "B1_m02_R1_head_d", "label": "d" },
+                { "id": "B1_m02_R1_head_e", "label": "e" },
+                { "id": "B1_m02_R1_head_f", "label": "f" },
+                { "id": "B1_m02_R1_head_g", "label": "g" },
+                { "id": "B1_m02_R1_head_h", "label": "h" }
+              ],
+              "correctAnswer": "g",
+              "explanation": "Überschrift g) beschreibt genau ein Online-Seminar 'Englisch im Beruf' für Berufstätige mit Grundkenntnissen am Abend. Das passt exakt zu Frau Aslans Wunsch nach beruflichem Englisch von zu Hause aus. Anzeigen c), f) und h) bleiben als Distraktoren übrig."
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Lesen Sie den Zeitungsartikel. Was ist richtig? Kreuzen Sie an: a, b oder c.",
+          "instructionsTranslation": "Read the newspaper article. What is correct? Mark: a, b, or c.",
+          "texts": [
+            {
+              "id": "B1_m02_R2_article",
+              "type": "article",
+              "content": "Zurück ins Büro? Warum viele Firmen vom reinen Homeoffice abrücken\n\nNoch vor wenigen Jahren galt das Homeoffice als Modell der Zukunft. Unternehmen hofften auf zufriedenere Mitarbeiter, geringere Mietkosten und eine bessere Vereinbarkeit von Familie und Beruf. Eine aktuelle Auswertung des Instituts für Arbeitsforschung in Nürnberg zeigt nun jedoch: Rund zwei Drittel der großen deutschen Firmen haben in den letzten zwölf Monaten ihre Regeln wieder verschärft. Mitarbeiter sollen mindestens drei Tage pro Woche im Büro sein – manche Unternehmen verlangen sogar vier.\n\nDie Gründe sind vielfältig. Vor allem Führungskräfte berichten, dass die Zusammenarbeit im Team leidet, wenn sich die Kollegen nur noch über Video-Calls sehen. Kreative Projekte entstünden seltener, kurze Absprachen in der Kaffeeküche fielen weg. 'Ein Großteil der Ideen, die später wirklich Geld bringen, entsteht eben nicht in einer Besprechung, sondern auf dem Flur', erklärt Daniela Brenner, Personalchefin eines Maschinenbauunternehmens aus Stuttgart.\n\nGleichzeitig spüren viele Beschäftigte, dass sich die Trennung zwischen Arbeit und Privatleben zu Hause oft verwischt. Wer morgens am Küchentisch anfängt, macht abends oft dort weiter. Pausen werden seltener eingelegt, und auch die Bewegung kommt zu kurz. Eine Umfrage unter 1.200 Beschäftigten ergab, dass sich jeder Dritte nach reinem Homeoffice sozial isoliert fühlt.\n\nExperten warnen jedoch davor, das Pendel jetzt vollständig zurückzudrehen. Wer seinen Mitarbeitern gar keine Flexibilität mehr lasse, riskiere Kündigungen – gerade gut ausgebildete Fachkräfte erwarten heute die Möglichkeit, zumindest an ein oder zwei Tagen von zu Hause zu arbeiten. Die Lösung liegt also in der Mitte. 'Hybrid ist kein Kompromiss, sondern ein eigenes Modell', sagt Arbeitspsychologe Thomas Klemm. Entscheidend sei, klare Regeln aufzustellen: feste Tage im Büro, gemeinsame Kernzeiten und technische Lösungen, die Zusammenarbeit erleichtern. Nur so gelinge es, die Vorteile beider Welten zu verbinden und Nachteile zu vermeiden.",
+              "source": "Süddeutsche Wochenschau, April 2026"
+            }
+          ],
+          "questions": [
+            {
+              "id": "B1_m02_R2_q1",
+              "type": "mcq",
+              "questionText": "Was ist das zentrale Ergebnis der Nürnberger Auswertung?",
+              "relatedTextId": "B1_m02_R2_article",
+              "options": [
+                "a) Immer mehr Firmen verbieten das Homeoffice komplett.",
+                "b) Die meisten großen Firmen verlangen wieder mehr Präsenz im Büro.",
+                "c) Die Zahl der Homeoffice-Tage ist im letzten Jahr gestiegen."
+              ],
+              "correctAnswer": "b",
+              "explanation": "Im Text steht: 'Rund zwei Drittel der großen deutschen Firmen haben in den letzten zwölf Monaten ihre Regeln wieder verschärft. Mitarbeiter sollen mindestens drei Tage pro Woche im Büro sein.' Das entspricht genau Option b. 'Komplett verbieten' (a) steht nirgends; die Homeoffice-Zeit ist gesunken, nicht gestiegen (c)."
+            },
+            {
+              "id": "B1_m02_R2_q2",
+              "type": "mcq",
+              "questionText": "Welchen Nachteil nennen Führungskräfte am reinen Homeoffice?",
+              "relatedTextId": "B1_m02_R2_article",
+              "options": [
+                "a) Mitarbeiter arbeiten langsamer als im Büro.",
+                "b) Die Stromkosten zu Hause sind zu hoch.",
+                "c) Spontane Absprachen und kreative Ideen gehen verloren."
+              ],
+              "correctAnswer": "c",
+              "explanation": "Der Text zitiert Frau Brenner: 'Ein Großteil der Ideen ... entsteht eben nicht in einer Besprechung, sondern auf dem Flur.' Kurze Absprachen in der Kaffeeküche fielen weg. Das entspricht Option c. Option a und b werden im Text nicht angesprochen."
+            },
+            {
+              "id": "B1_m02_R2_q3",
+              "type": "mcq",
+              "questionText": "Was berichtet die Umfrage über Beschäftigte im reinen Homeoffice?",
+              "relatedTextId": "B1_m02_R2_article",
+              "options": [
+                "a) Viele vermischen Arbeit und Freizeit und fühlen sich isoliert.",
+                "b) Die meisten wünschen sich eine höhere Bezahlung.",
+                "c) Nur wenige machen mehr Pausen als im Büro."
+              ],
+              "correctAnswer": "a",
+              "explanation": "Der Text schreibt: 'Wer morgens am Küchentisch anfängt, macht abends oft dort weiter' und 'jeder Dritte fühlt sich nach reinem Homeoffice sozial isoliert.' Das ist Option a. Bezahlung (b) wird nicht genannt; zu Pausen heißt es, sie würden seltener eingelegt – nicht mehr gemacht."
+            },
+            {
+              "id": "B1_m02_R2_q4",
+              "type": "mcq",
+              "questionText": "Wovor warnen die Experten?",
+              "relatedTextId": "B1_m02_R2_article",
+              "options": [
+                "a) davor, jede Flexibilität zu streichen, weil sonst Fachkräfte kündigen",
+                "b) davor, die Mitarbeiter zu stark zu kontrollieren",
+                "c) davor, die Gehälter im Homeoffice zu senken"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Im Text steht wörtlich: 'Wer seinen Mitarbeitern gar keine Flexibilität mehr lasse, riskiere Kündigungen – gerade gut ausgebildete Fachkräfte erwarten heute die Möglichkeit, zumindest an ein oder zwei Tagen von zu Hause zu arbeiten.' Das ist Option a. Kontrolle und Gehaltssenkung werden nicht genannt."
+            },
+            {
+              "id": "B1_m02_R2_q5",
+              "type": "mcq",
+              "questionText": "Was empfiehlt der Arbeitspsychologe Thomas Klemm?",
+              "relatedTextId": "B1_m02_R2_article",
+              "options": [
+                "a) möglichst schnell wieder zum klassischen Büroalltag zurückzukehren",
+                "b) feste Bürotage und gemeinsame Kernzeiten festzulegen",
+                "c) jedem Mitarbeiter selbst zu überlassen, wann er ins Büro kommt"
+              ],
+              "correctAnswer": "b",
+              "explanation": "Herr Klemm wird zitiert: 'Entscheidend sei, klare Regeln aufzustellen: feste Tage im Büro, gemeinsame Kernzeiten und technische Lösungen.' Das ist Option b. Ein vollständiger Rückzug (a) und völlige Freiheit (c) widersprechen seiner Aussage, dass Hybrid kein Kompromiss, sondern ein eigenes Modell mit Regeln sei."
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Sie lesen zehn Situationen (1–10) und zwölf kurze Anzeigen (a–l). Welche Anzeige passt zu welcher Situation? Für jede Situation gibt es genau eine passende Anzeige. Zwei Anzeigen bleiben übrig. Wenn keine Anzeige passt, schreiben Sie 'x'.",
+          "instructionsTranslation": "You read ten situations (1–10) and twelve short advertisements (a–l). Which advertisement matches which situation? For each situation there is exactly one matching advertisement. Two advertisements remain unused. If no advertisement fits, write 'x'.",
+          "texts": [
+            { "id": "B1_m02_R3_ad_a", "type": "ad", "content": "a) STELLE ALS TEAMASSISTENZ – mittelständisches IT-Unternehmen in Hamburg sucht engagierte Teamassistenz (Vollzeit, ab sofort). Erfahrung mit MS Office, gute Deutsch- und Englischkenntnisse. Bewerbung: karriere@it-hamburg.de" },
+            { "id": "B1_m02_R3_ad_b", "type": "ad", "content": "b) Ausbildung zur Pflegefachkraft – staatlich anerkannter Pflegedienst bietet 3-jährige Ausbildung mit Ausbildungsvergütung ab 1.100 €/Monat. Start jederzeit möglich. Tel. 040 221 80 50" },
+            { "id": "B1_m02_R3_ad_c", "type": "ad", "content": "c) Minijob: Frühaufsteher gesucht – Bäckerei in der Altstadt sucht Verkaufshilfe von 5:30 bis 8:30 Uhr, Mo–Fr. 538 €/Monat. Kontakt: Frau Seidel, 0157 334 22 78" },
+            { "id": "B1_m02_R3_ad_d", "type": "ad", "content": "d) Weiterbildung 'Projektmanagement (IHK)' – 8 Wochenenden, insgesamt 240 Stunden. Zertifikatsabschluss. Nächster Start: Mai, Kursgebühr 2.300 € (Bildungsgutschein möglich). www.ihk-weiterbildung.de" },
+            { "id": "B1_m02_R3_ad_e", "type": "ad", "content": "e) Babysitter gesucht – Familie mit zwei Kindern (4 und 7) sucht zuverlässige Betreuung 2x pro Woche nach der Schule (15–18 Uhr). 13 €/Stunde. kontakt@familie-richter.de" },
+            { "id": "B1_m02_R3_ad_f", "type": "ad", "content": "f) Büro-Coworking Space 'WerkHalle' – flexible Arbeitsplätze im Zentrum, ab 180 €/Monat inkl. Kaffee, Drucker, Meetingraum. Probetag kostenlos. www.werkhalle.de" },
+            { "id": "B1_m02_R3_ad_g", "type": "ad", "content": "g) Bewerbungsfoto vom Profi – Termin innerhalb einer Woche. Retusche inklusive, 5 digitale Fotos in hoher Qualität, 79 €. Studio Lichtblick, Termin online buchen." },
+            { "id": "B1_m02_R3_ad_h", "type": "ad", "content": "h) Berufliche Neuorientierung mit 40+ – Coaching in sechs Einzelsitzungen, 90 Min. je Sitzung, 120 €/Sitzung. Erste Sitzung kostenlos. Zertifizierte Beraterin. info@neue-wege-coaching.de" },
+            { "id": "B1_m02_R3_ad_i", "type": "ad", "content": "i) Duales Studium 'Wirtschaftsinformatik' – Praxispartner in Stuttgart sucht Studienanfänger für Herbst. Monatliche Vergütung, Studiengebühren werden übernommen. bewerbung@dualcampus.de" },
+            { "id": "B1_m02_R3_ad_j", "type": "ad", "content": "j) Honorarkraft 'Deutsch als Fremdsprache' – Volkshochschule sucht erfahrene Lehrkraft für B1-Kurse, abends 2x pro Woche. 35 €/Stunde. bewerbung@vhs-mitte.de" },
+            { "id": "B1_m02_R3_ad_k", "type": "ad", "content": "k) Praktikum im Marketing – junge Agentur bietet Praktikantenstelle für 3 Monate, 600 €/Monat, flexible Startzeit. Gute Englischkenntnisse erwünscht. praktika@mediavie.de" },
+            { "id": "B1_m02_R3_ad_l", "type": "ad", "content": "l) Steuerberater Herr Klausen – Beratung für Selbstständige und Kleinunternehmer. Erstgespräch 50 €. Termine auch abends. Telefon 0211 440 77 20" }
+          ],
+          "questions": [
+            {
+              "id": "B1_m02_R3_q1",
+              "type": "matching",
+              "questionText": "1. Lena hat gerade ihr Abitur gemacht und möchte unbedingt im IT-Bereich arbeiten, aber parallel auch studieren. Sie braucht eine Lösung, bei der beides kombiniert ist.",
+              "matchingSources": [
+                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
+                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
+                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
+                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
+                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
+                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "i",
+              "explanation": "Anzeige i) 'Duales Studium Wirtschaftsinformatik' verbindet Studium und Arbeit in einer Firma – genau das, was Lena braucht. Keine andere Anzeige kombiniert beides."
+            },
+            {
+              "id": "B1_m02_R3_q2",
+              "type": "matching",
+              "questionText": "2. Herr Walker ist 47 Jahre alt, als IT-Entwickler seit vielen Jahren unglücklich und überlegt, beruflich noch einmal etwas völlig Neues zu beginnen. Er sucht eine persönliche Begleitung, die ihm bei der Neuorientierung hilft.",
+              "matchingSources": [
+                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
+                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
+                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
+                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
+                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
+                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "h",
+              "explanation": "Anzeige h) 'Berufliche Neuorientierung mit 40+' bietet genau ein Coaching in Einzelsitzungen an – passend zu Herrn Walkers Wunsch nach persönlicher Begleitung bei beruflicher Neuorientierung."
+            },
+            {
+              "id": "B1_m02_R3_q3",
+              "type": "matching",
+              "questionText": "3. Studentin Marie sucht einen Nebenjob, den sie vor ihren Vorlesungen am frühen Morgen ausüben kann. Am Nachmittag hat sie keine Zeit.",
+              "matchingSources": [
+                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
+                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
+                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
+                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
+                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
+                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "c",
+              "explanation": "Anzeige c) sucht Minijobber in der Bäckerei von 5:30 bis 8:30 Uhr – genau die frühen Morgenstunden, in denen Marie arbeiten könnte. Anzeige e) (Babysitter nach der Schule) würde den Nachmittag verlangen und fällt damit weg."
+            },
+            {
+              "id": "B1_m02_R3_q4",
+              "type": "matching",
+              "questionText": "4. Herr Balaban führt seit einem Jahr ein kleines Café und möchte vor seiner ersten Steuererklärung mit jemandem sprechen, der sich mit Selbstständigen auskennt.",
+              "matchingSources": [
+                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
+                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
+                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
+                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
+                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
+                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "l",
+              "explanation": "Anzeige l) Steuerberater Klausen berät speziell Selbstständige und Kleinunternehmer – genau das, was Herr Balaban für seine erste Steuererklärung braucht."
+            },
+            {
+              "id": "B1_m02_R3_q5",
+              "type": "matching",
+              "questionText": "5. Anja ist ausgebildete Deutschlehrerin und möchte abends nebenberuflich unterrichten, um zusätzliches Geld zu verdienen. Sie unterrichtet seit Jahren B1-Niveau.",
+              "matchingSources": [
+                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
+                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
+                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
+                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
+                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
+                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "j",
+              "explanation": "Anzeige j) sucht eine Honorarkraft für DaF/B1-Kurse am Abend – ideal für Anja als erfahrene Deutschlehrerin mit Wunsch nach Nebenjob am Abend."
+            },
+            {
+              "id": "B1_m02_R3_q6",
+              "type": "matching",
+              "questionText": "6. Herr Demir ist seit Jahren im Büro tätig und möchte seine Karriere voranbringen. Er sucht eine berufsbegleitende Weiterbildung mit anerkanntem Abschluss im Projektmanagement.",
+              "matchingSources": [
+                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
+                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
+                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
+                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
+                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
+                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "d",
+              "explanation": "Anzeige d) 'Weiterbildung Projektmanagement (IHK)' an 8 Wochenenden mit Zertifikat ist die passende berufsbegleitende Option für Herrn Demir."
+            },
+            {
+              "id": "B1_m02_R3_q7",
+              "type": "matching",
+              "questionText": "7. Lisa bewirbt sich in den kommenden Wochen auf mehrere Stellen und möchte ihre alten Bewerbungsbilder durch professionelle Aufnahmen ersetzen.",
+              "matchingSources": [
+                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
+                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
+                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
+                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
+                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
+                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "g",
+              "explanation": "Anzeige g) 'Bewerbungsfoto vom Profi' mit Termin innerhalb einer Woche und mehreren digitalen Aufnahmen passt exakt zu Lisas Bedarf."
+            },
+            {
+              "id": "B1_m02_R3_q8",
+              "type": "matching",
+              "questionText": "8. Patrick hat gerade sein Studium abgeschlossen und möchte erste Berufserfahrung im Marketing sammeln, ist aber noch flexibel, wann er startet.",
+              "matchingSources": [
+                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
+                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
+                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
+                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
+                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
+                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "k",
+              "explanation": "Anzeige k) ist ein Praktikum im Marketing, 3 Monate, flexibler Start – genau der Einstieg, den Patrick sucht."
+            },
+            {
+              "id": "B1_m02_R3_q9",
+              "type": "matching",
+              "questionText": "9. Frau Bergmann arbeitet selbstständig als Grafikerin. Zu Hause wird sie ständig abgelenkt und sucht einen bezahlbaren Arbeitsplatz außerhalb der eigenen Wohnung, an dem sie flexibel arbeiten kann.",
+              "matchingSources": [
+                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
+                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
+                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
+                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
+                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
+                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "f",
+              "explanation": "Anzeige f) 'Büro-Coworking Space WerkHalle' bietet flexible Arbeitsplätze ab 180 €/Monat – ideal für Frau Bergmann, die außerhalb der Wohnung arbeiten möchte."
+            },
+            {
+              "id": "B1_m02_R3_q10",
+              "type": "matching",
+              "questionText": "10. Ahmed hat eine Ausbildung als Krankenpfleger in seinem Heimatland gemacht, ist gerade in Deutschland angekommen und sucht hier eine Ausbildung, damit sein Abschluss anerkannt wird.",
+              "matchingSources": [
+                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
+                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
+                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
+                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
+                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
+                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "b",
+              "explanation": "Anzeige b) bietet eine 3-jährige staatlich anerkannte Ausbildung zur Pflegefachkraft mit Vergütung an – genau der Weg, den Ahmed braucht. Anzeige a) (Teamassistenz) und e) (Babysitter) bleiben als Distraktoren übrig."
+            }
+          ]
+        }
+      ]
+    },
+    "sprachbausteine": {
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Lesen Sie den folgenden Text und entscheiden Sie, welches Wort (a, b oder c) in die Lücke passt. Es gibt jeweils nur eine richtige Lösung.",
+          "text": "Lieber Jonas,\n\nwie geht es dir? Ich wollte dir schon lange schreiben, aber in den letzten Wochen war richtig viel los. Seit zwei Monaten arbeite ich jetzt __(1)__ einer kleinen Ingenieurfirma im Süden der Stadt, und ich bin wirklich erleichtert, __(2)__ ich nach der langen Bewerbungsphase endlich angekommen bin. Mein Chef, __(3)__ mich damals eingestellt hat, ist ein ruhiger und sehr fairer Mensch. __(4)__ der Anfang nicht einfach war, fühle ich mich heute schon wie ein Teil des Teams.\n\nLetzte Woche haben wir einen großen Auftrag erfolgreich abgeschlossen. Die Präsentation __(5)__ am Donnerstag sogar vom Geschäftsführer selbst gehalten, was uns alle stolz gemacht hat. Wenn ich schon mehr Routine __(6)__, würde ich mich wohl selbst um eigene Kunden bewerben. Aber das dauert wohl noch eine Weile.\n\nAm Wochenende treffe ich mich oft mit Kolleginnen __(7)__ Sport – meistens Laufen im Park. Wir __(8)__ am Samstag zusammen ins Fitnessstudio gegangen, und danach haben wir noch lange geplaudert. Übrigens hoffe ich sehr, dass du mich bald mal besuchen kommst – ich würde mich riesig __(9)__ freuen! Hast du eigentlich schon gehört, dass Tim und Nina geheiratet haben? Nina hat mir erzählt, sie hätten __(10)__ schönsten Tag ihres Lebens gehabt.\n\nIch freue mich auf deine Nachricht.\n\nViele Grüße,\nLina",
+          "questions": [
+            {
+              "blankNumber": 1,
+              "type": "mcq",
+              "options": ["a) in", "b) an", "c) bei"],
+              "correctAnswer": "c",
+              "explanation": "Bei Arbeitgebern/Firmen verwendet man 'bei' + Dativ: 'bei einer Firma arbeiten'. 'in' ist möglich bei Stadt oder Gebäude, aber nicht bei Firmennamen. 'an' gehört zu Institutionen wie 'an der Universität'."
+            },
+            {
+              "blankNumber": 2,
+              "type": "mcq",
+              "options": ["a) weil", "b) dass", "c) wenn"],
+              "correctAnswer": "b",
+              "explanation": "Nach 'erleichtert sein' folgt ein dass-Satz, der den Inhalt der Erleichterung angibt. 'weil' gäbe einen Grund an (hier unpassend, da die Aussage keine Begründung ist). 'wenn' leitet eine Bedingung ein und passt nicht."
+            },
+            {
+              "blankNumber": 3,
+              "type": "mcq",
+              "options": ["a) der", "b) den", "c) dem"],
+              "correctAnswer": "a",
+              "explanation": "Relativsatz: 'Mein Chef, der mich eingestellt hat'. Das Relativpronomen bezieht sich auf 'Chef' (Maskulinum) und ist Subjekt im Relativsatz – also Nominativ 'der'. 'den' wäre Akkusativ, 'dem' Dativ."
+            },
+            {
+              "blankNumber": 4,
+              "type": "mcq",
+              "options": ["a) Obwohl", "b) Weil", "c) Trotzdem"],
+              "correctAnswer": "a",
+              "explanation": "Gegensatz zwischen 'nicht einfach' und 'fühle mich wie ein Teil des Teams' → konzessiver Nebensatz mit 'obwohl'. 'weil' gäbe einen Grund an (unlogisch). 'trotzdem' ist ein Adverb (Hauptsatzstellung, Verb auf Position 2), aber hier steht das Verb am Ende – also muss es eine Subjunktion sein."
+            },
+            {
+              "blankNumber": 5,
+              "type": "mcq",
+              "options": ["a) hat", "b) wurde", "c) war"],
+              "correctAnswer": "b",
+              "explanation": "Vorgangspassiv Präteritum: 'Die Präsentation wurde gehalten.' 'hat' wäre Aktiv ('hat gehalten'), aber das Subjekt 'Präsentation' führt die Handlung nicht aus. 'war gehalten' wäre Zustandspassiv – grammatisch hier nicht korrekt."
+            },
+            {
+              "blankNumber": 6,
+              "type": "mcq",
+              "options": ["a) habe", "b) hätte", "c) hatte"],
+              "correctAnswer": "b",
+              "explanation": "Irreale Bedingung im Konjunktiv II: 'Wenn ich mehr Routine hätte, würde ich ...' Der Hauptsatz mit 'würde' verlangt im Wenn-Satz ebenfalls Konjunktiv II ('hätte'). 'habe' (Indikativ) und 'hatte' (Präteritum) passen nicht."
+            },
+            {
+              "blankNumber": 7,
+              "type": "mcq",
+              "options": ["a) zu", "b) auf", "c) zum"],
+              "correctAnswer": "c",
+              "explanation": "Feste Wendung: 'zum Sport gehen' (zu + dem = zum, Dativ). 'zu' allein braucht immer einen Artikel. 'auf Sport gehen' gibt es im Standarddeutsch nicht."
+            },
+            {
+              "blankNumber": 8,
+              "type": "mcq",
+              "options": ["a) haben", "b) sind", "c) waren"],
+              "correctAnswer": "b",
+              "explanation": "Perfekt von 'gehen' mit Hilfsverb 'sein': 'Wir sind ... gegangen.' Bewegungsverben nehmen 'sein'. 'haben' ist falsch. 'waren' wäre Präteritum, passt aber nicht zum Partizip 'gegangen'."
+            },
+            {
+              "blankNumber": 9,
+              "type": "mcq",
+              "options": ["a) mich", "b) mir", "c) für mich"],
+              "correctAnswer": "a",
+              "explanation": "'sich freuen' ist reflexiv mit Akkusativ: 'Ich freue mich.' 'mir' (Dativ) gehört zu anderen Verben (sich etwas wünschen). 'für mich' ist kein Reflexivpronomen."
+            },
+            {
+              "blankNumber": 10,
+              "type": "mcq",
+              "options": ["a) der", "b) dem", "c) den"],
+              "correctAnswer": "c",
+              "explanation": "'den schönsten Tag' ist Akkusativobjekt von 'haben' (Maskulinum): 'den'. 'der' wäre Nominativ, 'dem' Dativ. Die starke Adjektivendung '-sten' bestätigt Akkusativ Maskulinum."
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Lesen Sie den folgenden Text. Welches Wort aus der Liste a–o passt in die Lücken? Jedes Wort passt nur einmal. Fünf Wörter bleiben übrig.",
+          "text": "Liebe Nadja,\n\nvielen __(11)__ für deine letzte E-Mail! Ich hatte nicht damit gerechnet, so schnell etwas von dir zu hören. Wie du weißt, habe ich vor einem halben Jahr die Stelle gewechselt. Der Anfang war ziemlich anstrengend, aber __(12)__ habe ich mich gut eingearbeitet.\n\nMein neuer Chef ist sehr freundlich, nur die Deadlines sind manchmal schwer einzuhalten. Wir haben im letzten Monat intensiv darüber __(13)__ und uns auf eine neue Planung geeinigt. Seitdem __(14)__ es deutlich besser. Ich habe weniger Stress und kann meine Aufgaben pünktlich erledigen.\n\nAußerdem bin ich jetzt __(15)__ ein neues Team zuständig, das direkt mit Kunden aus Österreich arbeitet. __(16)__ der letzten Woche habe ich zum ersten Mal allein ein Kundengespräch geführt – es hat gut geklappt, und ich war am Ende richtig stolz auf mich.\n\nNur eines nervt mich gerade: Die Firma hat die Gehälter dieses Jahr leider nicht __(17)__. Ich hatte fest __(18)__ eine kleine Erhöhung gehofft, weil ich viel mehr Verantwortung übernommen habe. Aber der Chef meint, nächstes Jahr sehe die Lage __(19)__ besser aus.\n\nMelde dich bald, ich vermisse dich! __(20)__ können wir uns ja im Frühling mal ein Wochenende in Prag gönnen.\n\nLiebe Grüße,\nSimon",
+          "questions": [
+            {
+              "blankNumber": 11,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
+                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Die feste Briefformel 'Vielen Dank für deine E-Mail' verlangt 'Dank' nach 'vielen'. Distraktor k) 'besten' passt grammatisch ('besten Dank' wäre möglich), aber der Text liefert 'vielen', das direkt zu 'Dank' führt."
+            },
+            {
+              "blankNumber": 12,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
+                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+              ],
+              "correctAnswer": "b",
+              "explanation": "'Der Anfang war anstrengend, aber inzwischen habe ich mich gut eingearbeitet.' 'inzwischen' bedeutet 'mittlerweile' – ein zeitlicher Gegensatz zum Anfang. 'damit' (Zweck) oder 'hoffentlich' (Wunsch) passen hier nicht."
+            },
+            {
+              "blankNumber": 13,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
+                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+              ],
+              "correctAnswer": "c",
+              "explanation": "'Wir haben intensiv darüber gesprochen' – Verb+Präposition 'sprechen über'. Das Partizip II 'gesprochen' schließt das Perfekt ab. 'entschieden' würde 'über etwas entscheiden' erlauben, ist aber inhaltlich schwächer: Gespräch führt zu einer Einigung, nicht stumme Entscheidung."
+            },
+            {
+              "blankNumber": 14,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
+                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+              ],
+              "correctAnswer": "d",
+              "explanation": "'Seitdem läuft es deutlich besser' – 'es läuft' ist eine idiomatische Wendung für 'es funktioniert gut, es klappt'. Distraktor m) 'bleibt' passt semantisch nicht (beschreibt keine Verbesserung)."
+            },
+            {
+              "blankNumber": 15,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
+                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+              ],
+              "correctAnswer": "e",
+              "explanation": "Feste Kombination 'zuständig sein für + Akkusativ'. 'für' ist obligatorisch. 'auf' oder 'durch' bilden mit 'zuständig' keine Struktur."
+            },
+            {
+              "blankNumber": 16,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
+                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+              ],
+              "correctAnswer": "f",
+              "explanation": "Zeitangabe am Satzanfang: 'In der letzten Woche ...'. 'in' + Dativ mit Zeitspanne (während). Die Großschreibung ('In') zeigt den Satzanfang."
+            },
+            {
+              "blankNumber": 17,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
+                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+              ],
+              "correctAnswer": "g",
+              "explanation": "'Gehälter erhöhen' ist die Standardkollokation (increase salaries). Partizip II 'erhöht' vervollständigt das Perfekt. 'entschieden' wäre grammatisch möglich ('hat ... entschieden'), aber inhaltlich unpassend."
+            },
+            {
+              "blankNumber": 18,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
+                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+              ],
+              "correctAnswer": "h",
+              "explanation": "Verb+Präposition: 'hoffen auf + Akkusativ' ('auf eine Erhöhung hoffen'). 'für' würde zu anderen Verben passen ('sich bedanken für'). 'durch' ist hier nicht idiomatisch."
+            },
+            {
+              "blankNumber": 19,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
+                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+              ],
+              "correctAnswer": "i",
+              "explanation": "'Nächstes Jahr sehe die Lage hoffentlich besser aus' – das Adverb 'hoffentlich' drückt Hoffnung aus, passt zum Kontext, dass der Chef die Zukunft positiv darstellt. 'Vielleicht' wäre semantisch ähnlich, aber großgeschrieben und steht meist am Satzanfang; im Satzinneren funktioniert 'hoffentlich' besser."
+            },
+            {
+              "blankNumber": 20,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
+                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+              ],
+              "correctAnswer": "j",
+              "explanation": "Satzanfang mit Modaladverb: 'Vielleicht können wir uns ...' Die Großschreibung zeigt Satzanfang. Übrig bleiben k), l), m), n), o) als Distraktoren."
+            }
+          ]
+        }
+      ]
+    },
+    "writing": {
+      "totalTimeMinutes": 30,
+      "tasks": [
+        {
+          "taskNumber": 1,
+          "type": "letter",
+          "instructions": "Sie arbeiten seit einem halben Jahr in einer neuen Firma. Ihr Chef hat Ihnen vor Kurzem eine berufliche Weiterbildung vorgeschlagen. Schreiben Sie eine E-Mail an Ihren Chef, Herrn Hoffmann. Gehen Sie auf alle vier Punkte unten ein. Achten Sie auf eine passende Anrede und einen passenden Gruß. Schreiben Sie ca. 150 Wörter.",
+          "instructionsTranslation": "You have been working at a new company for six months. Your boss recently suggested a professional training course. Write an email to your boss, Mr. Hoffmann. Address all four points below. Pay attention to appropriate greeting and closing. Write approximately 150 words.",
+          "prompt": "Situation: Ihr Chef, Herr Hoffmann, hat Ihnen vorgeschlagen, an einer dreitägigen Weiterbildung zum Thema Projektmanagement teilzunehmen. Sie finden das Angebot sehr interessant und möchten gerne mitmachen.\n\nSchreiben Sie eine E-Mail an Herrn Hoffmann. Gehen Sie auf die folgenden vier Punkte ein:\n\n- Dank: Bedanken Sie sich für das Angebot.\n- Begründung: Erklären Sie, warum die Weiterbildung für Ihre Arbeit sinnvoll ist.\n- Frage: Fragen Sie, ob Sie während der drei Tage von Ihren Aufgaben freigestellt werden.\n- Organisation: Schlagen Sie vor, wie Ihre Vertretung während Ihrer Abwesenheit geregelt werden kann.\n\nVergessen Sie nicht Anrede, Einleitung und Grußformel. Schreiben Sie ca. 150 Wörter.",
+          "promptTranslation": "Situation: Your boss, Mr. Hoffmann, has suggested that you attend a three-day training course on project management. You find the offer very interesting and would like to participate.\n\nWrite an email to Mr. Hoffmann. Address these four points:\n\n- Thanks: Thank him for the offer.\n- Reason: Explain why the training is useful for your work.\n- Question: Ask whether you will be released from your duties during the three days.\n- Organization: Suggest how your replacement can be arranged during your absence.\n\nDon't forget greeting, introduction, and closing. Write approximately 150 words.",
+          "requiredPoints": [
+            "Dank für das Weiterbildungsangebot",
+            "Begründung, warum die Weiterbildung sinnvoll ist",
+            "Frage nach Freistellung während der drei Tage",
+            "Vorschlag zur Vertretung während der Abwesenheit"
+          ],
+          "wordCountMin": 130,
+          "wordCountMax": 170,
+          "sampleAnswer": "Sehr geehrter Herr Hoffmann,\n\nvielen Dank für Ihr Angebot, an der dreitägigen Weiterbildung zum Thema Projektmanagement teilzunehmen. Über Ihren Vorschlag habe ich mich sehr gefreut und möchte die Möglichkeit gerne wahrnehmen.\n\nDa ich in den letzten Monaten immer öfter kleinere Projekte selbstständig betreue, wäre eine strukturierte Einführung in moderne Methoden sehr hilfreich für meine tägliche Arbeit. Ich könnte die neuen Kenntnisse direkt in unserem Team anwenden und würde die Kollegen gern an meinen Erfahrungen teilhaben lassen.\n\nIch hätte allerdings zwei Fragen: Ist es möglich, dass ich während dieser drei Tage komplett von meinen regulären Aufgaben freigestellt werde? Außerdem würde ich gerne mit Ihnen besprechen, wie meine Vertretung geregelt wird. Mein Vorschlag wäre, dass Frau Bruckner meine laufenden Kundenanfragen übernimmt – wir arbeiten ohnehin häufig zusammen.\n\nÜber eine kurze Rückmeldung würde ich mich sehr freuen.\n\nMit freundlichen Grüßen\nAlex Müller",
+          "scoringCriteria": [
+            {
+              "criterion": "I. Inhaltliche Vollständigkeit",
+              "maxPoints": 15,
+              "description": "Alle vier Leitpunkte (Dank, Begründung, Frage zur Freistellung, Vorschlag zur Vertretung) sind klar behandelt. Wird einer dieser Punkte als nicht bearbeitet bewertet (D), erhält der gesamte Text 0 Punkte."
+            },
+            {
+              "criterion": "II. Kommunikative Gestaltung",
+              "maxPoints": 15,
+              "description": "Angemessene formelle Anrede ('Sehr geehrter Herr Hoffmann'), klare Einleitung, Verwendung passender Konnektoren (außerdem, allerdings, da), formelle Grußformel, sinnvolle Absatzstruktur."
+            },
+            {
+              "criterion": "III. Formale Richtigkeit",
+              "maxPoints": 15,
+              "description": "Grammatik, Rechtschreibung und Wortwahl auf B1-Niveau. Verbformen (Perfekt, Konjunktiv II für höfliche Bitten), Satzstellung in Nebensätzen, Kasus nach Präpositionen. Schwerwiegende Grammatikfehler, die das Verständnis blockieren, führen zu D (und damit 0 Punkten für den gesamten Text)."
+            }
+          ]
+        }
+      ]
+    },
+    "speaking": {
+      "totalTimeMinutes": 15,
+      "prepTimeMinutes": 20,
+      "parts": [
+        {
+          "partNumber": 1,
+          "type": "introduce",
+          "instructions": "Stellen Sie sich Ihrem Gesprächspartner/Ihrer Gesprächspartnerin vor. Sprechen Sie über sich: Name, Herkunft, Wohnort, Familie, Beruf oder Ausbildung, Hobbys und Sprachen. Stellen Sie anschließend Ihrem Partner/Ihrer Partnerin mindestens zwei Fragen.",
+          "instructionsTranslation": "Introduce yourself to your conversation partner. Talk about: name, origin, place of residence, family, work or education, hobbies, and languages. Afterwards ask your partner at least two questions.",
+          "prompt": "Bitte stellen Sie sich Ihrem Partner / Ihrer Partnerin vor. Sprechen Sie u.a. über:\n- Ihren Namen und Ihre Herkunft\n- Ihren aktuellen Wohnort und seit wann Sie dort leben\n- Ihre Familie\n- Ihren Beruf oder Ihr Studium\n- Ihre Hobbys und Interessen\n- Die Sprachen, die Sie sprechen\n\nStellen Sie danach Ihrem Partner / Ihrer Partnerin mindestens zwei Fragen, um mehr über sie/ihn zu erfahren. Vorbereitungszeit: 20 Minuten für die gesamte mündliche Prüfung.",
+          "sampleResponse": "Hallo, mein Name ist Maria Kovac, und ursprünglich komme ich aus Zagreb in Kroatien. Ich lebe seit fünf Jahren in Köln, weil ich hier eine Stelle als Buchhalterin bei einer mittelständischen Baufirma gefunden habe. Meine Familie ist gemischt: Mein Mann ist Deutscher, wir haben eine kleine Tochter, die drei Jahre alt ist und bald in den Kindergarten geht. Meine Eltern leben weiterhin in Zagreb, und ich besuche sie zwei- bis dreimal im Jahr. Beruflich arbeite ich jetzt seit acht Jahren in der Buchhaltung und übernehme seit einem Jahr auch kleinere Projekte in der Personalabteilung – das macht mir richtig Spaß. In meiner Freizeit lese ich gern Krimis und gehe zweimal pro Woche ins Schwimmbad. Außerdem koche ich leidenschaftlich gerne. Sprachlich: Muttersprache Kroatisch, dazu Deutsch, Englisch und etwas Italienisch. Und wie ist das bei dir? Woher kommst du, und was machst du beruflich?",
+          "evaluationTips": [
+            "Strukturieren Sie Ihre Vorstellung – beginnen Sie nicht mit Hobbys, sondern mit Name und Herkunft",
+            "Verwenden Sie Nebensätze mit 'weil', 'wo', 'der/die' – das zeigt B1-Niveau",
+            "Sprechen Sie in Absätzen: ein Gedanke pro Thema, nicht alles in einem langen Satz",
+            "Stellen Sie echte Fragen – keine Ja/Nein-Fragen, sondern W-Fragen, die zu einem Gespräch einladen",
+            "Nennen Sie konkrete Details (Stadt, Jahre, Beruf), keine abstrakten Angaben",
+            "Reagieren Sie auf die Antworten Ihres Partners: 'Das finde ich interessant – erzähl mehr.'"
+          ],
+          "keyPhrases": [
+            "Mein Name ist ... und ich komme aus ...",
+            "Seit ... Jahren lebe ich in ...",
+            "Beruflich bin ich ... / Ich arbeite als ...",
+            "In meiner Freizeit ... / Ich interessiere mich besonders für ...",
+            "Neben Deutsch spreche ich ...",
+            "Und du – woher kommst du?",
+            "Was machst du eigentlich beruflich?"
+          ]
+        },
+        {
+          "partNumber": 2,
+          "type": "discussion",
+          "instructions": "Sie erhalten einen kurzen Text zum Thema. Fassen Sie den Inhalt für Ihren Partner zusammen, beantworten Sie die drei Leitfragen, und tauschen Sie Ihre Meinung mit dem Partner aus.",
+          "instructionsTranslation": "You receive a short text on the topic. Summarize the content for your partner, answer the three guiding questions, and exchange your opinions with your partner.",
+          "prompt": "Thema: Weiterbildung im Beruf\n\nLesen Sie den folgenden kurzen Text:\n\n'Immer mehr Arbeitnehmer in Deutschland nehmen an Weiterbildungen teil. Eine aktuelle Studie zeigt: Fast die Hälfte aller Beschäftigten besucht mindestens einmal pro Jahr einen beruflichen Kurs oder ein Seminar. Viele machen das in ihrer Freizeit, andere werden vom Arbeitgeber freigestellt. Experten sind sich einig: Wer heute beruflich erfolgreich sein will, muss lebenslang lernen.'\n\nLeitfragen:\n1. Fassen Sie kurz den Inhalt des Textes zusammen (in 2–3 Sätzen).\n2. Haben Sie schon einmal an einer beruflichen Weiterbildung teilgenommen? Wenn ja, welche – und was hat Ihnen besonders gefallen oder gefehlt?\n3. Sollte Weiterbildung in der Arbeitszeit stattfinden oder in der Freizeit der Mitarbeiter? Begründen Sie Ihre Meinung.\n\nSprechen Sie mit Ihrem Partner/Ihrer Partnerin über das Thema – fragen Sie auch nach seiner/ihrer Meinung.",
+          "sampleResponse": "Im Text steht, dass fast jeder zweite Arbeitnehmer in Deutschland einmal pro Jahr eine Weiterbildung macht. Manche nutzen ihre Freizeit dafür, andere werden von der Firma freigestellt. Die Experten meinen, dass lebenslanges Lernen heute wichtig ist.\n\nIch habe letztes Jahr an einem Kurs 'Excel für Fortgeschrittene' teilgenommen. Das war ein zweitägiges Seminar bei einem externen Anbieter – mein Chef hat mich freigestellt und die Kosten übernommen. Der Kurs war sehr praktisch, ich kann heute meine Tabellen viel schneller erstellen. Gefehlt hat mir allerdings etwas: Es gab kaum Zeit, eigene Fragen zu besprechen.\n\nMeiner Meinung nach sollte Weiterbildung in der Arbeitszeit stattfinden. Es handelt sich ja um eine Investition, von der die Firma direkt profitiert. Wer sich in der Freizeit weiterbildet, opfert Zeit mit Familie oder Hobbys. Natürlich können kleine Online-Kurse auch abends funktionieren, aber längere Seminare gehören aus meiner Sicht in den Arbeitsalltag. Wie siehst du das – findest du es fair, wenn Kollegen am Wochenende für den Beruf lernen?",
+          "evaluationTips": [
+            "Beginnen Sie mit einer klaren Zusammenfassung, bevor Sie Ihre Meinung nennen",
+            "Nennen Sie konkrete Beispiele aus Ihrem eigenen Arbeitsalltag, keine allgemeinen Aussagen",
+            "Verwenden Sie Meinungsformulierungen: 'Meiner Meinung nach ...', 'Ich finde, dass ...', 'Aus meiner Sicht ...'",
+            "Gliedern Sie Vor- und Nachteile klar: 'Einerseits ..., andererseits ...'",
+            "Stellen Sie dem Partner mindestens eine inhaltliche Rückfrage",
+            "Benutzen Sie Konnektoren wie 'allerdings', 'außerdem', 'trotzdem', 'deshalb' – das wertet die Antwort auf"
+          ],
+          "keyPhrases": [
+            "Im Text geht es um ...",
+            "Der Text berichtet, dass ...",
+            "Meiner Meinung nach ...",
+            "Ich finde es wichtig, dass ...",
+            "Ein Vorteil/Nachteil ist, dass ...",
+            "Einerseits ... andererseits ...",
+            "Wie siehst du das?",
+            "Hast du ähnliche Erfahrungen gemacht?"
+          ]
+        },
+        {
+          "partNumber": 3,
+          "type": "planning",
+          "instructions": "Sie sollen mit Ihrem Partner gemeinsam etwas planen. Machen Sie Vorschläge, reagieren Sie auf die Ideen Ihres Partners und einigen Sie sich am Ende auf eine gemeinsame Lösung.",
+          "instructionsTranslation": "You are going to plan something together with your partner. Make suggestions, respond to your partner's ideas, and agree on a joint solution at the end.",
+          "prompt": "Ihre Kollegin Frau Bergmann verlässt nach fünfzehn Jahren die Firma und wechselt zu einem anderen Arbeitgeber. Sie möchten mit Ihrem Partner/Ihrer Partnerin gemeinsam eine Abschiedsfeier für sie im Büro organisieren.\n\nBesprechen Sie bitte folgende Punkte und kommen Sie zu einer gemeinsamen Entscheidung:\n\n- Wann und wo soll die Feier stattfinden (letzter Arbeitstag, Mittagspause, nach Feierabend)?\n- Wen laden Sie aus dem Kollegenkreis ein?\n- Was soll es zu essen und zu trinken geben? Wer kümmert sich um den Einkauf?\n- Welches gemeinsame Abschiedsgeschenk schlagen Sie vor?\n- Wer hält eine kleine Rede, und wer kümmert sich um die Dekoration?\n\nMachen Sie Vorschläge, gehen Sie auf die Vorschläge Ihres Partners ein und einigen Sie sich am Ende.",
+          "sampleResponse": "Also, ich würde vorschlagen, dass wir die Feier am Freitag, den 30. Mai, nach Feierabend organisieren – das ist ihr letzter Arbeitstag, und viele Kollegen haben am Wochenende dann frei. Was hältst du davon, im großen Besprechungsraum zu feiern? Der ist gemütlich und groß genug.\n\nIch denke, wir sollten das komplette Team plus ein paar enge Kollegen aus anderen Abteilungen einladen, insgesamt vielleicht 18 bis 20 Personen. Außerdem würde ich ihren früheren Chef dazunehmen – sie haben lange zusammengearbeitet.\n\nFür das Essen schlage ich ein kleines Buffet vor: belegte Brötchen, Salate und Obst. Ich könnte beim Catering-Service um die Ecke bestellen – macht das für dich Sinn? Und bei den Getränken teilen wir uns: Du übernimmst Wasser und Säfte, ich besorge einen guten Sekt für den Anstoß.\n\nAls Geschenk würde ich einen Gutschein für ein Wellness-Wochenende vorschlagen, alle Kollegen können dafür etwas in einen Umschlag legen. Ich hätte auch eine Karte bestellt, die jeder unterschreiben kann.\n\nLetzter Punkt: Hältst du die Rede? Du kennst sie ja am längsten. Ich würde dann die Dekoration übernehmen – ein paar Blumen und eine Fotowand mit Bildern aus ihrer Zeit hier. Einverstanden?",
+          "evaluationTips": [
+            "Sprechen Sie nicht nur, sondern hören Sie auch aktiv zu – reagieren Sie auf die Vorschläge Ihres Partners",
+            "Machen Sie Vorschläge mit Konjunktiv II ('Ich würde vorschlagen ...', 'Wir könnten ...') – das wirkt höflich",
+            "Begründen Sie Ihre Vorschläge kurz: 'weil', 'damit', 'denn'",
+            "Einigen Sie sich am Ende wirklich – ein 'Das machen wir so, einverstanden?' zeigt Abschluss",
+            "Vermeiden Sie Monologe – lassen Sie dem Partner Raum für eigene Ideen",
+            "Verwenden Sie Modalverben: 'sollten wir', 'können wir', 'müssen wir' – das zeigt Planungssprache",
+            "Fassen Sie am Ende die wichtigsten Entscheidungen kurz zusammen"
+          ],
+          "keyPhrases": [
+            "Ich würde vorschlagen, dass ...",
+            "Was hältst du davon, wenn ...?",
+            "Wir könnten ... machen.",
+            "Das ist eine gute Idee, aber ...",
+            "Alternativ könnten wir auch ...",
+            "Wer übernimmt ...?",
+            "Ich kann ... / Du bringst ... mit, okay?",
+            "Einverstanden!",
+            "Dann halten wir fest: ..."
+          ]
+        }
+      ]
+    }
   }
 }

--- a/apps/mobile/assets/content/B1/mock_03.json
+++ b/apps/mobile/assets/content/B1/mock_03.json
@@ -1,13 +1,920 @@
 {
   "id": "B1_mock_03",
   "level": "B1",
-  "title": "Übungstest 3",
-  "version": 0,
-  "_stub": true,
+  "title": "B1 Übungstest 3: Bildung",
+  "version": 1,
   "sections": {
-    "listening": { "totalTimeMinutes": 20, "parts": [] },
-    "reading": { "totalTimeMinutes": 25, "parts": [] },
-    "writing": { "totalTimeMinutes": 20, "tasks": [] },
-    "speaking": { "totalTimeMinutes": 15, "prepTimeMinutes": 0, "parts": [] }
+    "listening": {
+      "totalTimeMinutes": 30,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Sie hören fünf kurze Texte. Entscheiden Sie bei jedem Text: Ist die Aussage richtig oder falsch? Sie hören jeden Text nur einmal.",
+          "instructionsTranslation": "You will hear five short texts. For each text, decide: Is the statement correct or incorrect? You will hear each text only once.",
+          "audioFile": "assets/audio/B1/mock03/listening_part1.mp3",
+          "playCount": 1,
+          "questions": [
+            {
+              "id": "B1_m03_L1_q1",
+              "type": "true_false",
+              "questionText": "Der Deutschkurs an der Volkshochschule findet am Mittwochabend statt.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Die Ansage der Volkshochschule lautet: 'Unser B1-Abendkurs startet am kommenden Dienstag, immer dienstags und donnerstags von 18 bis 20 Uhr.' Der Kurs findet also dienstags und donnerstags statt – die Aussage 'Mittwochabend' ist falsch.",
+              "audioTimestamp": 11
+            },
+            {
+              "id": "B1_m03_L1_q2",
+              "type": "true_false",
+              "questionText": "Die Mutter möchte einen Termin mit der Klassenlehrerin vereinbaren.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Auf dem Anrufbeantworter sagt die Mutter: 'Ich würde gern mit Ihnen über die letzten Noten meines Sohnes sprechen – wann hätten Sie in der nächsten Woche Zeit für einen kurzen Gesprächstermin?' Sie bittet also um einen Termin.",
+              "audioTimestamp": 13
+            },
+            {
+              "id": "B1_m03_L1_q3",
+              "type": "true_false",
+              "questionText": "Die Bibliothek hat in den Sommerferien durchgehend geöffnet.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Die Durchsage erklärt: 'Vom 1. bis 14. August bleibt die Bibliothek wegen Renovierungsarbeiten geschlossen.' In den Ferien ist sie also zwei Wochen zu – nicht durchgehend geöffnet.",
+              "audioTimestamp": 10
+            },
+            {
+              "id": "B1_m03_L1_q4",
+              "type": "true_false",
+              "questionText": "Das Stipendium deckt auch die Miete während des Auslandssemesters.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Die Studienberaterin sagt: 'Die monatliche Rate von 850 Euro ist für Miete und Lebenshaltung gedacht – die Reisekosten müssen Sie jedoch selbst tragen.' Die Miete ist also eingeschlossen – die Aussage ist richtig.",
+              "audioTimestamp": 14
+            },
+            {
+              "id": "B1_m03_L1_q5",
+              "type": "true_false",
+              "questionText": "Der Online-Kurs für Grammatik dauert insgesamt sechs Wochen.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Die Werbeansage informiert: 'Unser Intensivkurs 'Deutsche Grammatik' läuft über sechs Wochen, zweimal pro Woche jeweils 90 Minuten.' Die Dauer von sechs Wochen stimmt.",
+              "audioTimestamp": 9
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Sie hören einen Radiobericht. Entscheiden Sie, ob die folgenden zehn Aussagen richtig oder falsch sind. Sie hören den Text nur einmal.",
+          "instructionsTranslation": "You will hear a radio report. Decide whether the following ten statements are correct or incorrect. You will hear the text only once.",
+          "audioFile": "assets/audio/B1/mock03/listening_part2.mp3",
+          "playCount": 1,
+          "questions": [
+            {
+              "id": "B1_m03_L2_q1",
+              "type": "true_false",
+              "questionText": "Die Sendung handelt von digitalem Lernen an deutschen Schulen.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Die Moderatorin beginnt: 'Guten Abend und herzlich willkommen bei 'Bildung heute' – unser Thema: Wie verändert der Einsatz von Tablets und Online-Lernplattformen den Schulalltag in Deutschland?' Digitales Lernen ist damit klar das Thema.",
+              "audioTimestamp": 7
+            },
+            {
+              "id": "B1_m03_L2_q2",
+              "type": "true_false",
+              "questionText": "Laut einer Umfrage besitzen inzwischen alle deutschen Schulen ein schnelles WLAN.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Der Reporter sagt: 'Nur jede zweite Schule verfügt heute über eine stabile und schnelle Internetverbindung im gesamten Gebäude.' Also keineswegs alle – die Aussage ist falsch.",
+              "audioTimestamp": 32
+            },
+            {
+              "id": "B1_m03_L2_q3",
+              "type": "true_false",
+              "questionText": "Die Lehrerin Frau Sommer unterrichtet an einem Gymnasium in Leipzig.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Sie wird so vorgestellt: 'Unsere erste Gesprächspartnerin, Karoline Sommer, unterrichtet Deutsch und Geschichte an einem Gymnasium in Leipzig.' Das entspricht der Aussage.",
+              "audioTimestamp": 55
+            },
+            {
+              "id": "B1_m03_L2_q4",
+              "type": "true_false",
+              "questionText": "Frau Sommer findet Tablets im Unterricht grundsätzlich schlecht.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Frau Sommer sagt: 'Ich arbeite gern mit Tablets – allerdings nur dort, wo es pädagogisch sinnvoll ist, nicht als Selbstzweck.' Sie findet sie also nicht grundsätzlich schlecht, sondern bewertet differenziert.",
+              "audioTimestamp": 78
+            },
+            {
+              "id": "B1_m03_L2_q5",
+              "type": "true_false",
+              "questionText": "Viele Schüler schreiben laut der Lehrerin heute schlechter per Hand als früher.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Frau Sommer erklärt: 'Ich beobachte bei vielen Schülerinnen und Schülern, dass die Handschrift deutlich schlechter geworden ist, weil sie fast nur noch tippen.' Das stimmt mit der Aussage überein.",
+              "audioTimestamp": 98
+            },
+            {
+              "id": "B1_m03_L2_q6",
+              "type": "true_false",
+              "questionText": "Der Experte Professor Keller hält Online-Lernen für sinnvoller als Präsenzunterricht.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Prof. Keller sagt ausdrücklich: 'Das gemeinsame Lernen im Klassenzimmer lässt sich durch keine Plattform ersetzen – Online-Formate sind ergänzend, nicht ersetzend.' Er stellt Präsenz also über das Online-Lernen.",
+              "audioTimestamp": 125
+            },
+            {
+              "id": "B1_m03_L2_q7",
+              "type": "true_false",
+              "questionText": "Besonders jüngere Kinder profitieren nach Ansicht des Professors stark vom Online-Unterricht.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Prof. Keller warnt: 'Vor allem Grundschulkindern fehlen beim reinen Online-Lernen die sozialen Kontakte und die direkte Anleitung – hier ist Präsenz am wichtigsten.' Gerade jüngere Kinder profitieren also wenig.",
+              "audioTimestamp": 148
+            },
+            {
+              "id": "B1_m03_L2_q8",
+              "type": "true_false",
+              "questionText": "Ein Vorteil digitaler Medien ist laut Professor Keller die individuelle Förderung.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Prof. Keller hebt hervor: 'Mit guten Lernprogrammen kann man Kinder viel gezielter an ihrem eigenen Tempo fördern – jede Schülerin bekommt Aufgaben, die zu ihrem Stand passen.' Das entspricht der Aussage.",
+              "audioTimestamp": 168
+            },
+            {
+              "id": "B1_m03_L2_q9",
+              "type": "true_false",
+              "questionText": "Lehrkräfte brauchen laut Sendung mehr Fortbildung, um digital gut zu unterrichten.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Der Reporter fasst zusammen: 'Einig sind sich beide Gäste: Ohne regelmäßige Fortbildungen der Lehrkräfte bleibt die beste Technik nutzlos.' Die Aussage trifft genau zu.",
+              "audioTimestamp": 188
+            },
+            {
+              "id": "B1_m03_L2_q10",
+              "type": "true_false",
+              "questionText": "Am Ende der Sendung wird das Thema der nächsten Folge angekündigt.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Die Moderatorin verabschiedet: 'Nächste Woche geht es bei uns um die Frage: Wie sinnvoll sind Hausaufgaben heute noch? Schalten Sie gerne wieder ein.' Damit wird das Thema der nächsten Folge genannt.",
+              "audioTimestamp": 210
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Sie hören fünf kurze Gespräche. Zu jedem Gespräch gibt es eine Aufgabe. Was ist richtig? Kreuzen Sie an: a, b oder c. Sie hören jedes Gespräch zweimal.",
+          "instructionsTranslation": "You will hear five short conversations. For each conversation there is one task. What is correct? Mark: a, b, or c. You will hear each conversation twice.",
+          "audioFile": "assets/audio/B1/mock03/listening_part3.mp3",
+          "playCount": 2,
+          "questions": [
+            {
+              "id": "B1_m03_L3_q1",
+              "type": "mcq",
+              "questionText": "Warum ruft der Student bei der Studienberatung an?",
+              "options": [
+                "a) Er möchte sein Fach wechseln.",
+                "b) Er hat Fragen zum Auslandssemester.",
+                "c) Er braucht eine Bescheinigung für das Amt."
+              ],
+              "correctAnswer": "b",
+              "explanation": "Der Student sagt: 'Ich überlege, im nächsten Wintersemester nach Spanien zu gehen, und habe ein paar Fragen zu Erasmus – wann muss ich mich bewerben, und welche Unterlagen brauche ich?' Es geht also klar um ein Auslandssemester. Fachwechsel und Amt werden nicht erwähnt.",
+              "audioTimestamp": 16
+            },
+            {
+              "id": "B1_m03_L3_q2",
+              "type": "mcq",
+              "questionText": "Worauf einigen sich die beiden Freundinnen zum Thema Sprachkurs?",
+              "options": [
+                "a) Sie besuchen gemeinsam einen Abendkurs an der VHS.",
+                "b) Sie lernen zu zweit mit einer App.",
+                "c) Sie nehmen Privatunterricht bei einer Muttersprachlerin."
+              ],
+              "correctAnswer": "a",
+              "explanation": "Am Ende sagt Nina: 'Okay, dann melden wir uns beide für den VHS-Abendkurs an, das ist günstiger und wir motivieren uns gegenseitig.' Die Freundin stimmt zu. App und Privatunterricht werden diskutiert, aber verworfen.",
+              "audioTimestamp": 53
+            },
+            {
+              "id": "B1_m03_L3_q3",
+              "type": "mcq",
+              "questionText": "Was empfiehlt die Lehrerin dem Vater im Elterngespräch?",
+              "options": [
+                "a) seinen Sohn auf eine andere Schule zu schicken",
+                "b) zusätzlich einen privaten Nachhilfelehrer zu engagieren",
+                "c) mit dem Sohn regelmäßige Lernzeiten zu Hause zu vereinbaren"
+              ],
+              "correctAnswer": "c",
+              "explanation": "Die Lehrerin sagt: 'Was am meisten hilft, sind feste Lernzeiten zu Hause – zwanzig Minuten pro Fach am Abend reichen oft schon aus.' Sie empfiehlt also regelmäßige Lernzeiten. Schulwechsel und Nachhilfe werden zwar erwähnt, aber nicht empfohlen.",
+              "audioTimestamp": 88
+            },
+            {
+              "id": "B1_m03_L3_q4",
+              "type": "mcq",
+              "questionText": "Warum möchte die Frau einen Computerkurs besuchen?",
+              "options": [
+                "a) Sie sucht eine neue Stelle und möchte aktuelle Programme beherrschen.",
+                "b) Ihre Enkel haben sie darum gebeten.",
+                "c) Sie möchte ihr altes Hobby Fotografie digital weiterführen."
+              ],
+              "correctAnswer": "a",
+              "explanation": "Die Frau erklärt: 'Ich bin 52 und suche nach fünfzehn Jahren Pause wieder eine Stelle im Büro. Ohne aktuelle Kenntnisse in Excel und Word habe ich dort leider keine Chance.' Berufliche Gründe stehen also im Vordergrund. Enkel und Fotografie werden nicht genannt.",
+              "audioTimestamp": 122
+            },
+            {
+              "id": "B1_m03_L3_q5",
+              "type": "mcq",
+              "questionText": "Was ist für die Auszubildende im Gespräch mit ihrer Ausbilderin das größte Problem?",
+              "options": [
+                "a) Das theoretische Wissen in der Berufsschule fällt ihr schwer.",
+                "b) Sie kommt mit einer Kollegin im Betrieb nicht gut zurecht.",
+                "c) Sie bekommt keine anspruchsvollen Aufgaben im Betrieb."
+              ],
+              "correctAnswer": "c",
+              "explanation": "Die Auszubildende sagt am Ende: 'Die Schule klappt eigentlich, und mit den Kolleginnen komme ich gut aus – nur im Betrieb darf ich bisher fast nur kopieren und Kaffee kochen. Ich würde gerne an richtigen Projekten mitarbeiten.' Das Hauptproblem ist also die Aufgabenzuteilung.",
+              "audioTimestamp": 158
+            }
+          ]
+        }
+      ]
+    },
+    "reading": {
+      "totalTimeMinutes": 60,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Lesen Sie zuerst die fünf Situationen (1–5) und dann die acht Überschriften (a–h). Welche Überschrift passt zu welcher Situation? Für jede Situation gibt es genau eine passende Überschrift. Drei Überschriften bleiben übrig.",
+          "instructionsTranslation": "First read the five situations (1–5) and then the eight headlines (a–h). Which headline matches which situation? For each situation there is exactly one matching headline. Three headlines remain unused.",
+          "texts": [
+            { "id": "B1_m03_R1_head_a", "type": "notice", "content": "a) Neue Lesepaten für Grundschulen gesucht – Ehrenamt ab zwei Stunden pro Woche" },
+            { "id": "B1_m03_R1_head_b", "type": "notice", "content": "b) Sommerakademie für Jugendliche – Naturwissenschaften hautnah an der Technischen Hochschule" },
+            { "id": "B1_m03_R1_head_c", "type": "notice", "content": "c) Stipendium für ein Auslandssemester – Bewerbungen bis zum 15. Mai möglich" },
+            { "id": "B1_m03_R1_head_d", "type": "notice", "content": "d) Digitalkurs für Senioren – Schritt für Schritt zum eigenen Tablet" },
+            { "id": "B1_m03_R1_head_e", "type": "notice", "content": "e) Tag der offenen Tür an der Städtischen Gesamtschule" },
+            { "id": "B1_m03_R1_head_f", "type": "notice", "content": "f) Deutschkurs für berufstätige Eltern – mit Kinderbetreuung am Abend" },
+            { "id": "B1_m03_R1_head_g", "type": "notice", "content": "g) Abendgymnasium 'Zweiter Bildungsweg' – Fachabitur in drei Jahren nachholen" },
+            { "id": "B1_m03_R1_head_h", "type": "notice", "content": "h) Erste-Hilfe-Kurs für Eltern von Kleinkindern – Samstagvormittag" }
+          ],
+          "questions": [
+            {
+              "id": "B1_m03_R1_q1",
+              "type": "matching",
+              "questionText": "1. Frau Klose hat vor 20 Jahren die Hauptschule abgeschlossen und möchte sich jetzt beruflich verbessern. Sie sucht eine Möglichkeit, neben ihrem Job das Fachabitur zu machen.",
+              "matchingSources": [
+                { "id": "B1_m03_R1_head_a", "label": "a" },
+                { "id": "B1_m03_R1_head_b", "label": "b" },
+                { "id": "B1_m03_R1_head_c", "label": "c" },
+                { "id": "B1_m03_R1_head_d", "label": "d" },
+                { "id": "B1_m03_R1_head_e", "label": "e" },
+                { "id": "B1_m03_R1_head_f", "label": "f" },
+                { "id": "B1_m03_R1_head_g", "label": "g" },
+                { "id": "B1_m03_R1_head_h", "label": "h" }
+              ],
+              "correctAnswer": "g",
+              "explanation": "Überschrift g) 'Abendgymnasium Zweiter Bildungsweg – Fachabitur in drei Jahren nachholen' passt exakt zu Frau Kloses Wunsch, neben dem Beruf einen Schulabschluss nachzuholen. Die anderen Angebote betreffen keine schulischen Zweitwege."
+            },
+            {
+              "id": "B1_m03_R1_q2",
+              "type": "matching",
+              "questionText": "2. Musa ist 17 und interessiert sich besonders für Physik und Chemie. Er möchte in den Sommerferien freiwillig an einem Programm teilnehmen, bei dem er an einer Hochschule experimentieren kann.",
+              "matchingSources": [
+                { "id": "B1_m03_R1_head_a", "label": "a" },
+                { "id": "B1_m03_R1_head_b", "label": "b" },
+                { "id": "B1_m03_R1_head_c", "label": "c" },
+                { "id": "B1_m03_R1_head_d", "label": "d" },
+                { "id": "B1_m03_R1_head_e", "label": "e" },
+                { "id": "B1_m03_R1_head_f", "label": "f" },
+                { "id": "B1_m03_R1_head_g", "label": "g" },
+                { "id": "B1_m03_R1_head_h", "label": "h" }
+              ],
+              "correctAnswer": "b",
+              "explanation": "Überschrift b) 'Sommerakademie für Jugendliche – Naturwissenschaften hautnah an der Technischen Hochschule' passt genau zu Musas Interessen und zu seinem Wunsch, an einer Hochschule zu experimentieren."
+            },
+            {
+              "id": "B1_m03_R1_q3",
+              "type": "matching",
+              "questionText": "3. Herr Beck ist 68 Jahre alt und hat zu seinem Geburtstag ein Tablet geschenkt bekommen. Er traut sich aber noch nicht, es regelmäßig zu nutzen, und sucht einen Kurs, in dem er Grundlagen lernen kann.",
+              "matchingSources": [
+                { "id": "B1_m03_R1_head_a", "label": "a" },
+                { "id": "B1_m03_R1_head_b", "label": "b" },
+                { "id": "B1_m03_R1_head_c", "label": "c" },
+                { "id": "B1_m03_R1_head_d", "label": "d" },
+                { "id": "B1_m03_R1_head_e", "label": "e" },
+                { "id": "B1_m03_R1_head_f", "label": "f" },
+                { "id": "B1_m03_R1_head_g", "label": "g" },
+                { "id": "B1_m03_R1_head_h", "label": "h" }
+              ],
+              "correctAnswer": "d",
+              "explanation": "Überschrift d) 'Digitalkurs für Senioren – Schritt für Schritt zum eigenen Tablet' ist das ideale Angebot für Herrn Beck, der genau solche Grundlagen lernen möchte."
+            },
+            {
+              "id": "B1_m03_R1_q4",
+              "type": "matching",
+              "questionText": "4. Farida studiert im vierten Semester Betriebswirtschaft. Sie möchte im nächsten Jahr ein Semester in Frankreich verbringen und sucht eine finanzielle Unterstützung für ihren Auslandsaufenthalt.",
+              "matchingSources": [
+                { "id": "B1_m03_R1_head_a", "label": "a" },
+                { "id": "B1_m03_R1_head_b", "label": "b" },
+                { "id": "B1_m03_R1_head_c", "label": "c" },
+                { "id": "B1_m03_R1_head_d", "label": "d" },
+                { "id": "B1_m03_R1_head_e", "label": "e" },
+                { "id": "B1_m03_R1_head_f", "label": "f" },
+                { "id": "B1_m03_R1_head_g", "label": "g" },
+                { "id": "B1_m03_R1_head_h", "label": "h" }
+              ],
+              "correctAnswer": "c",
+              "explanation": "Überschrift c) 'Stipendium für ein Auslandssemester – Bewerbungen bis zum 15. Mai' passt genau zu Faridas Situation und ihrem Bedarf an finanzieller Förderung für das Auslandssemester."
+            },
+            {
+              "id": "B1_m03_R1_q5",
+              "type": "matching",
+              "questionText": "5. Helena arbeitet in Vollzeit als Krankenschwester und möchte ihr Deutsch verbessern. Da sie zwei kleine Kinder hat, ist ein Kurs tagsüber für sie unmöglich – sie bräuchte auch eine Lösung, dass ihre Kinder während der Stunden betreut werden.",
+              "matchingSources": [
+                { "id": "B1_m03_R1_head_a", "label": "a" },
+                { "id": "B1_m03_R1_head_b", "label": "b" },
+                { "id": "B1_m03_R1_head_c", "label": "c" },
+                { "id": "B1_m03_R1_head_d", "label": "d" },
+                { "id": "B1_m03_R1_head_e", "label": "e" },
+                { "id": "B1_m03_R1_head_f", "label": "f" },
+                { "id": "B1_m03_R1_head_g", "label": "g" },
+                { "id": "B1_m03_R1_head_h", "label": "h" }
+              ],
+              "correctAnswer": "f",
+              "explanation": "Überschrift f) 'Deutschkurs für berufstätige Eltern – mit Kinderbetreuung am Abend' trifft Helenas Bedürfnisse genau: Abendkurs plus Betreuung. Anzeigen a), e) und h) bleiben als Distraktoren übrig."
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Lesen Sie den Zeitungsartikel. Was ist richtig? Kreuzen Sie an: a, b oder c.",
+          "instructionsTranslation": "Read the newspaper article. What is correct? Mark: a, b, or c.",
+          "texts": [
+            {
+              "id": "B1_m03_R2_article",
+              "type": "article",
+              "content": "Warum das deutsche Ausbildungssystem wieder im Ausland vorbildlich gilt\n\nWährend in vielen Ländern der klassische Weg zum Beruf über die Universität führt, setzt Deutschland seit Jahrzehnten auf eine Alternative: die duale Ausbildung. Auszubildende lernen abwechselnd im Betrieb und in der Berufsschule, meistens über einen Zeitraum von drei Jahren. Am Ende steht ein anerkannter Berufsabschluss – und in den meisten Fällen auch ein fester Arbeitsvertrag.\n\nEine aktuelle Analyse der OECD zeigt: Immer mehr Staaten schauen genauer auf dieses Modell. Vor allem Frankreich, Spanien und einige Länder Südamerikas haben in den letzten Jahren ähnliche Systeme eingeführt oder ausgebaut. Der Hintergrund ist einfach. In Ländern ohne feste Verbindung zwischen Betrieben und Schulen liegt die Jugendarbeitslosigkeit oft zwei- bis dreimal höher als in Deutschland. 'Die duale Ausbildung ist kein Wundermittel, aber sie bietet jungen Menschen einen klaren Einstieg ins Berufsleben', erklärt Dr. Martina Hartl vom Bundesinstitut für Berufsbildung.\n\nFür die Betriebe hat das System ebenfalls Vorteile. Sie bilden Fachkräfte nach den eigenen Anforderungen aus und binden sie früh an das Unternehmen. Allerdings gibt es auch Kritik: In kleineren Firmen ist die Qualität der Ausbildung stark vom einzelnen Ausbilder abhängig. Manche Auszubildende klagen, dass sie kaum echte Aufgaben bekommen und stattdessen Kopierarbeiten oder Botengänge übernehmen müssen. Die Industrie- und Handelskammern versuchen, mit regelmäßigen Kontrollen gegenzusteuern.\n\nGleichzeitig verändert sich das Bild des Berufs in den Köpfen der Jugendlichen. Für viele Eltern gilt ein Studium als der sicherere Weg, obwohl die Statistik zeigt: Gesellinnen und Handwerker in gefragten Berufen verdienen oft mehr als Akademiker in geisteswissenschaftlichen Fächern. Dr. Hartl wünscht sich daher eine ehrlichere Beratung an Schulen. 'Die duale Ausbildung ist in Wahrheit kein Plan B, sondern für viele junge Menschen der bessere Weg – wir müssen aufhören, sie so zu präsentieren, als wäre sie zweite Wahl.'",
+              "source": "Rheinischer Kurier, April 2026"
+            }
+          ],
+          "questions": [
+            {
+              "id": "B1_m03_R2_q1",
+              "type": "mcq",
+              "questionText": "Was ist das Kernmerkmal der deutschen dualen Ausbildung?",
+              "relatedTextId": "B1_m03_R2_article",
+              "options": [
+                "a) Auszubildende lernen nur in der Berufsschule.",
+                "b) Auszubildende lernen abwechselnd in Betrieb und Schule.",
+                "c) Auszubildende arbeiten drei Jahre lang ausschließlich in einem Betrieb."
+              ],
+              "correctAnswer": "b",
+              "explanation": "Im Text steht wörtlich: 'Auszubildende lernen abwechselnd im Betrieb und in der Berufsschule, meistens über einen Zeitraum von drei Jahren.' Das ist genau Option b. Die anderen Optionen widersprechen dem Text."
+            },
+            {
+              "id": "B1_m03_R2_q2",
+              "type": "mcq",
+              "questionText": "Warum interessieren sich andere Länder für das deutsche Modell?",
+              "relatedTextId": "B1_m03_R2_article",
+              "options": [
+                "a) weil ihre Jugendarbeitslosigkeit oft viel höher ist",
+                "b) weil die deutschen Abschlüsse dort automatisch anerkannt werden",
+                "c) weil die Ausbildungsvergütungen in Deutschland besonders hoch sind"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Der Text sagt: 'In Ländern ohne feste Verbindung zwischen Betrieben und Schulen liegt die Jugendarbeitslosigkeit oft zwei- bis dreimal höher als in Deutschland.' Das entspricht Option a. Automatische Anerkennung und Höhe der Vergütung werden nicht thematisiert."
+            },
+            {
+              "id": "B1_m03_R2_q3",
+              "type": "mcq",
+              "questionText": "Welchen Vorteil hat das System laut Artikel für die Betriebe?",
+              "relatedTextId": "B1_m03_R2_article",
+              "options": [
+                "a) Sie bilden Fachkräfte passgenau aus und binden sie ans Unternehmen.",
+                "b) Sie sparen Steuern durch Einstellungen von Azubis.",
+                "c) Sie bekommen Fördergeld direkt vom Staat."
+              ],
+              "correctAnswer": "a",
+              "explanation": "Der Text schreibt: 'Sie bilden Fachkräfte nach den eigenen Anforderungen aus und binden sie früh an das Unternehmen.' Das ist Option a. Steuern und staatliches Fördergeld werden nicht erwähnt."
+            },
+            {
+              "id": "B1_m03_R2_q4",
+              "type": "mcq",
+              "questionText": "Was wird am System kritisiert?",
+              "relatedTextId": "B1_m03_R2_article",
+              "options": [
+                "a) Die Ausbildungsdauer von drei Jahren ist zu lang.",
+                "b) In kleinen Betrieben ist die Qualität stark vom Ausbilder abhängig.",
+                "c) Die Berufsschulen bieten zu wenig praktische Übungen."
+              ],
+              "correctAnswer": "b",
+              "explanation": "Im Text steht: 'In kleineren Firmen ist die Qualität der Ausbildung stark vom einzelnen Ausbilder abhängig.' Das ist Option b. Die Ausbildungsdauer und die Berufsschule werden im Artikel nicht kritisiert."
+            },
+            {
+              "id": "B1_m03_R2_q5",
+              "type": "mcq",
+              "questionText": "Was wünscht sich Dr. Hartl für die Beratung an Schulen?",
+              "relatedTextId": "B1_m03_R2_article",
+              "options": [
+                "a) dass Lehrer die duale Ausbildung grundsätzlich empfehlen sollen",
+                "b) dass Schüler erst nach einem Praktikum entscheiden dürfen",
+                "c) dass Studium und Ausbildung als gleichwertige Wege dargestellt werden"
+              ],
+              "correctAnswer": "c",
+              "explanation": "Dr. Hartl sagt: 'Die duale Ausbildung ist in Wahrheit kein Plan B, sondern für viele junge Menschen der bessere Weg – wir müssen aufhören, sie so zu präsentieren, als wäre sie zweite Wahl.' Sie wünscht also eine Darstellung auf Augenhöhe mit dem Studium – das entspricht Option c. Eine grundsätzliche Empfehlung (a) oder ein Zwangspraktikum (b) steht nicht im Text."
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Sie lesen zehn Situationen (1–10) und zwölf kurze Anzeigen (a–l). Welche Anzeige passt zu welcher Situation? Für jede Situation gibt es genau eine passende Anzeige. Zwei Anzeigen bleiben übrig. Wenn keine Anzeige passt, schreiben Sie 'x'.",
+          "instructionsTranslation": "You read ten situations (1–10) and twelve short advertisements (a–l). Which advertisement matches which situation? For each situation there is exactly one matching advertisement. Two advertisements remain unused. If no advertisement fits, write 'x'.",
+          "texts": [
+            { "id": "B1_m03_R3_ad_a", "type": "ad", "content": "a) NACHHILFE MATHEMATIK – erfahrene Lehramtsstudentin gibt Einzelunterricht für Klassen 5–10, 18 €/Stunde. Online oder zu Hause im Kölner Westen. kontakt@mathe-nachhilfe.de" },
+            { "id": "B1_m03_R3_ad_b", "type": "ad", "content": "b) Deutsch-Intensivkurs (A2–B1) – 4 Wochen, Mo–Fr 9–13 Uhr. Kleine Gruppen, zertifizierte Lehrkräfte, Kursgebühr 480 €. Start jeden Monatsanfang. info@sprachfix.de" },
+            { "id": "B1_m03_R3_ad_c", "type": "ad", "content": "c) Online-Studium Soziale Arbeit (B.A.) – 6 Semester flexibel neben dem Beruf. Bewerbung bis 31. Juli. Kostenlose Infoveranstaltung online am ersten Donnerstag im Monat. www.sozialstudium-online.de" },
+            { "id": "B1_m03_R3_ad_d", "type": "ad", "content": "d) Gitarrenunterricht für Anfänger – 45 Minuten/Woche, Kinder ab 7 Jahren willkommen. 28 €/Stunde. Gruppen- oder Einzelstunde möglich. Musikschule Klangzeit, Tel. 0221 998 33 21" },
+            { "id": "B1_m03_R3_ad_e", "type": "ad", "content": "e) Tauschbörse Sprachtandem – Deutsch gegen Italienisch. Treffen 1x pro Woche in einem Café, kostenlos. Bewerbung an tandem-koeln@mail.de" },
+            { "id": "B1_m03_R3_ad_f", "type": "ad", "content": "f) Elternabend 'Digitale Medien' – kostenlose Informationsveranstaltung für Eltern von Grundschulkindern. Dienstag, 18 Uhr, im Bürgerhaus. Anmeldung: eltern-medien@stadt.de" },
+            { "id": "B1_m03_R3_ad_g", "type": "ad", "content": "g) Studentenjob – Bibliothek der Universität sucht Hilfskraft für 10 Std./Woche, abends und samstags. Bewerbung per E-Mail an personal@unibib-koeln.de" },
+            { "id": "B1_m03_R3_ad_h", "type": "ad", "content": "h) Lehrbücher zu verkaufen – komplettes Set für Abitur (Deutsch, Englisch, Mathe, Biologie), wenig benutzt, Festpreis 65 €. Abholung Köln-Nippes. mail@schulbuecher-angebot.de" },
+            { "id": "B1_m03_R3_ad_i", "type": "ad", "content": "i) Schüleraustauschprogramm – 10 Monate in den USA, Kanada oder Australien. Nächste Infoveranstaltung am Samstag um 11 Uhr, Volkshochschule. www.austausch-kompakt.de" },
+            { "id": "B1_m03_R3_ad_j", "type": "ad", "content": "j) Babysitterkurs des Jugendrotkreuzes – Grundlagen Pflege und Erste Hilfe. 2 Wochenenden, 80 €. Ab 14 Jahren. www.drk-jugend-koeln.de" },
+            { "id": "B1_m03_R3_ad_k", "type": "ad", "content": "k) Umschulung zum/zur Erzieher/in – drei Jahre berufsbegleitend, staatlich anerkannt. Nächster Informationsabend online. Anmeldung: info@erziehen-jetzt.de" },
+            { "id": "B1_m03_R3_ad_l", "type": "ad", "content": "l) Gesangsunterricht bei Musikpädagogin – 60 Minuten Einzelstunde 45 €, Probestunde kostenlos. Chor-Erfahrung nicht nötig. studio@singstark.de" }
+          ],
+          "questions": [
+            {
+              "id": "B1_m03_R3_q1",
+              "type": "matching",
+              "questionText": "1. Leon geht in die 8. Klasse und hat in Mathematik seit zwei Jahren die schlechtesten Noten. Seine Eltern suchen jemanden, der ihm regelmäßig und geduldig den Stoff erklärt.",
+              "matchingSources": [
+                { "id": "B1_m03_R3_ad_a", "label": "a" }, { "id": "B1_m03_R3_ad_b", "label": "b" },
+                { "id": "B1_m03_R3_ad_c", "label": "c" }, { "id": "B1_m03_R3_ad_d", "label": "d" },
+                { "id": "B1_m03_R3_ad_e", "label": "e" }, { "id": "B1_m03_R3_ad_f", "label": "f" },
+                { "id": "B1_m03_R3_ad_g", "label": "g" }, { "id": "B1_m03_R3_ad_h", "label": "h" },
+                { "id": "B1_m03_R3_ad_i", "label": "i" }, { "id": "B1_m03_R3_ad_j", "label": "j" },
+                { "id": "B1_m03_R3_ad_k", "label": "k" }, { "id": "B1_m03_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "a",
+              "explanation": "Anzeige a) bietet Mathematik-Nachhilfe für Klassen 5–10 durch eine Lehramtsstudentin – genau die Unterstützung, die Leon in Klasse 8 braucht."
+            },
+            {
+              "id": "B1_m03_R3_q2",
+              "type": "matching",
+              "questionText": "2. Frau Aydin ist im letzten Monat nach Deutschland gekommen. Sie spricht schon ein wenig Deutsch auf A2-Niveau und möchte in möglichst kurzer Zeit B1 erreichen, weil sie schnell einen Job finden muss.",
+              "matchingSources": [
+                { "id": "B1_m03_R3_ad_a", "label": "a" }, { "id": "B1_m03_R3_ad_b", "label": "b" },
+                { "id": "B1_m03_R3_ad_c", "label": "c" }, { "id": "B1_m03_R3_ad_d", "label": "d" },
+                { "id": "B1_m03_R3_ad_e", "label": "e" }, { "id": "B1_m03_R3_ad_f", "label": "f" },
+                { "id": "B1_m03_R3_ad_g", "label": "g" }, { "id": "B1_m03_R3_ad_h", "label": "h" },
+                { "id": "B1_m03_R3_ad_i", "label": "i" }, { "id": "B1_m03_R3_ad_j", "label": "j" },
+                { "id": "B1_m03_R3_ad_k", "label": "k" }, { "id": "B1_m03_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "b",
+              "explanation": "Anzeige b) 'Deutsch-Intensivkurs A2–B1' in 4 Wochen passt perfekt zu Frau Aydins Zielen, schnell das B1-Niveau zu erreichen."
+            },
+            {
+              "id": "B1_m03_R3_q3",
+              "type": "matching",
+              "questionText": "3. Hans ist 34, arbeitet seit zehn Jahren in einer Bank und möchte beruflich etwas ganz anderes machen. Er interessiert sich für die Arbeit mit Kindern und überlegt, sich staatlich anerkannt umschulen zu lassen, ohne den Job sofort zu kündigen.",
+              "matchingSources": [
+                { "id": "B1_m03_R3_ad_a", "label": "a" }, { "id": "B1_m03_R3_ad_b", "label": "b" },
+                { "id": "B1_m03_R3_ad_c", "label": "c" }, { "id": "B1_m03_R3_ad_d", "label": "d" },
+                { "id": "B1_m03_R3_ad_e", "label": "e" }, { "id": "B1_m03_R3_ad_f", "label": "f" },
+                { "id": "B1_m03_R3_ad_g", "label": "g" }, { "id": "B1_m03_R3_ad_h", "label": "h" },
+                { "id": "B1_m03_R3_ad_i", "label": "i" }, { "id": "B1_m03_R3_ad_j", "label": "j" },
+                { "id": "B1_m03_R3_ad_k", "label": "k" }, { "id": "B1_m03_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "k",
+              "explanation": "Anzeige k) bietet eine berufsbegleitende Umschulung zum/zur Erzieher/in, staatlich anerkannt – genau die Kombination, die Hans sucht."
+            },
+            {
+              "id": "B1_m03_R3_q4",
+              "type": "matching",
+              "questionText": "4. Sarah ist 15 und möchte in den Sommerferien etwas Sinnvolles lernen. Ihre Tante hat sie gefragt, ob sie auf ihre zwei kleinen Kinder aufpassen kann – aber Sarah fühlt sich unsicher und möchte sich vorher weiterbilden.",
+              "matchingSources": [
+                { "id": "B1_m03_R3_ad_a", "label": "a" }, { "id": "B1_m03_R3_ad_b", "label": "b" },
+                { "id": "B1_m03_R3_ad_c", "label": "c" }, { "id": "B1_m03_R3_ad_d", "label": "d" },
+                { "id": "B1_m03_R3_ad_e", "label": "e" }, { "id": "B1_m03_R3_ad_f", "label": "f" },
+                { "id": "B1_m03_R3_ad_g", "label": "g" }, { "id": "B1_m03_R3_ad_h", "label": "h" },
+                { "id": "B1_m03_R3_ad_i", "label": "i" }, { "id": "B1_m03_R3_ad_j", "label": "j" },
+                { "id": "B1_m03_R3_ad_k", "label": "k" }, { "id": "B1_m03_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "j",
+              "explanation": "Anzeige j) 'Babysitterkurs des Jugendrotkreuzes' ab 14 Jahren vermittelt genau die Grundlagen, die Sarah für ihre Aufgabe bei der Tante brauchen könnte."
+            },
+            {
+              "id": "B1_m03_R3_q5",
+              "type": "matching",
+              "questionText": "5. Herr Pietsch ist Schulleiter einer Grundschule. Er möchte für die Eltern in seiner Schule eine Informationsveranstaltung zu Handys und Tablets organisieren und sucht ein passendes Angebot, das er den Eltern empfehlen kann.",
+              "matchingSources": [
+                { "id": "B1_m03_R3_ad_a", "label": "a" }, { "id": "B1_m03_R3_ad_b", "label": "b" },
+                { "id": "B1_m03_R3_ad_c", "label": "c" }, { "id": "B1_m03_R3_ad_d", "label": "d" },
+                { "id": "B1_m03_R3_ad_e", "label": "e" }, { "id": "B1_m03_R3_ad_f", "label": "f" },
+                { "id": "B1_m03_R3_ad_g", "label": "g" }, { "id": "B1_m03_R3_ad_h", "label": "h" },
+                { "id": "B1_m03_R3_ad_i", "label": "i" }, { "id": "B1_m03_R3_ad_j", "label": "j" },
+                { "id": "B1_m03_R3_ad_k", "label": "k" }, { "id": "B1_m03_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "f",
+              "explanation": "Anzeige f) 'Elternabend Digitale Medien' richtet sich explizit an Eltern von Grundschulkindern – genau die Zielgruppe von Herrn Pietschs Schule."
+            },
+            {
+              "id": "B1_m03_R3_q6",
+              "type": "matching",
+              "questionText": "6. Max ist 16 und möchte gerne ein Schuljahr im Ausland verbringen, weiß aber noch nicht, welches Land zu ihm passt. Er sucht eine Veranstaltung, bei der er sich persönlich informieren kann.",
+              "matchingSources": [
+                { "id": "B1_m03_R3_ad_a", "label": "a" }, { "id": "B1_m03_R3_ad_b", "label": "b" },
+                { "id": "B1_m03_R3_ad_c", "label": "c" }, { "id": "B1_m03_R3_ad_d", "label": "d" },
+                { "id": "B1_m03_R3_ad_e", "label": "e" }, { "id": "B1_m03_R3_ad_f", "label": "f" },
+                { "id": "B1_m03_R3_ad_g", "label": "g" }, { "id": "B1_m03_R3_ad_h", "label": "h" },
+                { "id": "B1_m03_R3_ad_i", "label": "i" }, { "id": "B1_m03_R3_ad_j", "label": "j" },
+                { "id": "B1_m03_R3_ad_k", "label": "k" }, { "id": "B1_m03_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "i",
+              "explanation": "Anzeige i) 'Schüleraustauschprogramm' mit Infoveranstaltung passt genau zu Max' Situation: verschiedene Länder, persönliche Infos bei der VHS."
+            },
+            {
+              "id": "B1_m03_R3_q7",
+              "type": "matching",
+              "questionText": "7. Jana studiert Geschichte im fünften Semester und sucht einen Nebenjob, der zu ihrem Studium passt und abends sowie am Wochenende ausgeübt werden kann.",
+              "matchingSources": [
+                { "id": "B1_m03_R3_ad_a", "label": "a" }, { "id": "B1_m03_R3_ad_b", "label": "b" },
+                { "id": "B1_m03_R3_ad_c", "label": "c" }, { "id": "B1_m03_R3_ad_d", "label": "d" },
+                { "id": "B1_m03_R3_ad_e", "label": "e" }, { "id": "B1_m03_R3_ad_f", "label": "f" },
+                { "id": "B1_m03_R3_ad_g", "label": "g" }, { "id": "B1_m03_R3_ad_h", "label": "h" },
+                { "id": "B1_m03_R3_ad_i", "label": "i" }, { "id": "B1_m03_R3_ad_j", "label": "j" },
+                { "id": "B1_m03_R3_ad_k", "label": "k" }, { "id": "B1_m03_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "g",
+              "explanation": "Anzeige g) Uni-Bibliothek sucht eine Hilfskraft, abends und samstags, 10 Std./Woche – passt perfekt zu Janas Studium und Zeitplan."
+            },
+            {
+              "id": "B1_m03_R3_q8",
+              "type": "matching",
+              "questionText": "8. Herr Lessing arbeitet seit Jahren in einem Seniorenheim und möchte sich berufsbegleitend weiterqualifizieren. Ein Umzug kommt für ihn nicht in Frage – er sucht einen Studiengang, den er ortsunabhängig absolvieren kann.",
+              "matchingSources": [
+                { "id": "B1_m03_R3_ad_a", "label": "a" }, { "id": "B1_m03_R3_ad_b", "label": "b" },
+                { "id": "B1_m03_R3_ad_c", "label": "c" }, { "id": "B1_m03_R3_ad_d", "label": "d" },
+                { "id": "B1_m03_R3_ad_e", "label": "e" }, { "id": "B1_m03_R3_ad_f", "label": "f" },
+                { "id": "B1_m03_R3_ad_g", "label": "g" }, { "id": "B1_m03_R3_ad_h", "label": "h" },
+                { "id": "B1_m03_R3_ad_i", "label": "i" }, { "id": "B1_m03_R3_ad_j", "label": "j" },
+                { "id": "B1_m03_R3_ad_k", "label": "k" }, { "id": "B1_m03_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "c",
+              "explanation": "Anzeige c) 'Online-Studium Soziale Arbeit' berufsbegleitend, sechs Semester, flexibel – genau der ortsunabhängige Studiengang, den Herr Lessing sucht."
+            },
+            {
+              "id": "B1_m03_R3_q9",
+              "type": "matching",
+              "questionText": "9. Enzo ist aus Italien nach Deutschland gekommen, sein Deutsch ist schon ganz gut, aber er vermisst das Italienische. Er sucht jemanden, der Italienisch lernen möchte und mit dem er regelmäßig in beiden Sprachen sprechen kann – möglichst ohne Kursgebühr.",
+              "matchingSources": [
+                { "id": "B1_m03_R3_ad_a", "label": "a" }, { "id": "B1_m03_R3_ad_b", "label": "b" },
+                { "id": "B1_m03_R3_ad_c", "label": "c" }, { "id": "B1_m03_R3_ad_d", "label": "d" },
+                { "id": "B1_m03_R3_ad_e", "label": "e" }, { "id": "B1_m03_R3_ad_f", "label": "f" },
+                { "id": "B1_m03_R3_ad_g", "label": "g" }, { "id": "B1_m03_R3_ad_h", "label": "h" },
+                { "id": "B1_m03_R3_ad_i", "label": "i" }, { "id": "B1_m03_R3_ad_j", "label": "j" },
+                { "id": "B1_m03_R3_ad_k", "label": "k" }, { "id": "B1_m03_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "e",
+              "explanation": "Anzeige e) 'Tauschbörse Sprachtandem – Deutsch gegen Italienisch, kostenlos' entspricht genau Enzos Situation – ohne Gebühr regelmäßig Sprachen tauschen."
+            },
+            {
+              "id": "B1_m03_R3_q10",
+              "type": "matching",
+              "questionText": "10. Die siebenjährige Mia liebt Musik, seit ihre Oma ihr zum Geburtstag eine kleine Gitarre geschenkt hat. Die Eltern suchen einen passenden Unterricht für Kinder.",
+              "matchingSources": [
+                { "id": "B1_m03_R3_ad_a", "label": "a" }, { "id": "B1_m03_R3_ad_b", "label": "b" },
+                { "id": "B1_m03_R3_ad_c", "label": "c" }, { "id": "B1_m03_R3_ad_d", "label": "d" },
+                { "id": "B1_m03_R3_ad_e", "label": "e" }, { "id": "B1_m03_R3_ad_f", "label": "f" },
+                { "id": "B1_m03_R3_ad_g", "label": "g" }, { "id": "B1_m03_R3_ad_h", "label": "h" },
+                { "id": "B1_m03_R3_ad_i", "label": "i" }, { "id": "B1_m03_R3_ad_j", "label": "j" },
+                { "id": "B1_m03_R3_ad_k", "label": "k" }, { "id": "B1_m03_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "d",
+              "explanation": "Anzeige d) 'Gitarrenunterricht für Anfänger, Kinder ab 7 Jahren willkommen' passt ideal zur siebenjährigen Mia und ihrem neuen Instrument. Anzeigen h) (Lehrbücher) und l) (Gesangsunterricht) bleiben als Distraktoren übrig."
+            }
+          ]
+        }
+      ]
+    },
+    "sprachbausteine": {
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Lesen Sie den folgenden Text und entscheiden Sie, welches Wort (a, b oder c) in die Lücke passt. Es gibt jeweils nur eine richtige Lösung.",
+          "text": "Liebe Mira,\n\ndu wirst es nicht glauben: Nach langem Überlegen habe ich mich nun doch für ein Fernstudium entschieden. Seit einer Woche bin ich eingeschrieben __(1)__ der Hochschule für Soziale Arbeit, und ich bin wirklich erleichtert, __(2)__ ich endlich den Schritt gewagt habe. Die Studienberaterin, __(3)__ mich von Anfang an begleitet hat, war sehr geduldig und hat mir alle Fragen beantwortet. __(4)__ das Studium viel Arbeit neben dem Job bedeutet, fühle ich mich gerade sehr motiviert.\n\nLetzte Woche haben wir schon das erste Online-Seminar gehabt. Die Einführung __(5)__ von einem jungen Dozenten aus Freiburg gehalten, und wir waren insgesamt etwa vierzig Teilnehmende. Wenn ich im Semester mehr Zeit __(6)__, würde ich sogar eine Lerngruppe gründen – aber mein Job lässt das im Moment nicht zu.\n\nJeden Mittwochabend gehe ich außerdem __(7)__ einem kleinen Deutschkurs, weil ich meine Grammatik auffrischen möchte. Letzten Freitag __(8)__ wir sogar einen kleinen Ausflug ins Museum gemacht, das war ein sehr schöner Abschluss der Woche. Übrigens: Ich würde mich wirklich __(9)__ freuen, wenn du mich in den Semesterferien besuchen kommst. Erinnerst du dich an unseren alten Lehrer, Herrn Simon? Er hat mir geschrieben, dass er jetzt __(10)__ größten Abenteuer seines Lebens gewidmet hat und durch Südamerika reist.\n\nIch freue mich auf deine Antwort.\n\nHerzliche Grüße,\nSofia",
+          "questions": [
+            {
+              "blankNumber": 1,
+              "type": "mcq",
+              "options": ["a) in", "b) bei", "c) an"],
+              "correctAnswer": "c",
+              "explanation": "Für Bildungseinrichtungen wie Hochschule, Universität, Schule verwendet man 'an' + Dativ: 'an der Hochschule studieren'. 'in' passt bei Gebäuden ('im Gebäude'), aber nicht für die Institution. 'bei' ist für Arbeitgeber typisch ('bei einer Firma'), nicht für Hochschulen."
+            },
+            {
+              "blankNumber": 2,
+              "type": "mcq",
+              "options": ["a) weil", "b) dass", "c) ob"],
+              "correctAnswer": "b",
+              "explanation": "Nach 'erleichtert sein' folgt ein dass-Satz ('ich bin erleichtert, dass ...'). Der Inhalt der Erleichterung wird damit eingeleitet. 'weil' nennt einen Grund und wäre hier stilistisch schwach; 'ob' leitet indirekte Fragen ein und passt nicht."
+            },
+            {
+              "blankNumber": 3,
+              "type": "mcq",
+              "options": ["a) der", "b) den", "c) die"],
+              "correctAnswer": "c",
+              "explanation": "Relativsatz zu 'die Studienberaterin' (Feminin). Als Subjekt im Relativsatz ('sie hat begleitet') steht das Pronomen im Nominativ Femininum: 'die'. 'der' wäre Maskulinum Nominativ, 'den' wäre Maskulinum Akkusativ."
+            },
+            {
+              "blankNumber": 4,
+              "type": "mcq",
+              "options": ["a) Obwohl", "b) Weil", "c) Deshalb"],
+              "correctAnswer": "a",
+              "explanation": "Gegensatz zwischen 'viel Arbeit' und 'sehr motiviert' → konzessiv 'obwohl'. 'Weil' gäbe einen Grund an (unlogisch: Man ist nicht motiviert, weil es viel Arbeit ist). 'Deshalb' ist Adverb, verlangt Verbzweitstellung – hier steht das Verb am Ende, also muss es eine Subjunktion sein."
+            },
+            {
+              "blankNumber": 5,
+              "type": "mcq",
+              "options": ["a) hat", "b) war", "c) wurde"],
+              "correctAnswer": "c",
+              "explanation": "Passiv Präteritum: 'Die Einführung wurde gehalten.' 'hat' wäre Aktiv, aber das Subjekt 'Einführung' führt die Handlung nicht aus. 'war gehalten' wäre Zustandspassiv und passt hier nicht."
+            },
+            {
+              "blankNumber": 6,
+              "type": "mcq",
+              "options": ["a) habe", "b) hätte", "c) hatte"],
+              "correctAnswer": "b",
+              "explanation": "Irrealer Bedingungssatz: 'Wenn ich ... mehr Zeit hätte, würde ich ...' Konjunktiv II in beiden Teilen; 'hätte' ist Konjunktiv II von 'haben'. 'habe' (Indikativ) und 'hatte' (Präteritum) passen nicht."
+            },
+            {
+              "blankNumber": 7,
+              "type": "mcq",
+              "options": ["a) zu", "b) in", "c) bei"],
+              "correctAnswer": "a",
+              "explanation": "'zu einem Kurs gehen' ist die idiomatische Wendung für den regelmäßigen Besuch eines Kurses; 'zu' + Dativ passt zum Artikel 'einem'. 'in' würde bei Bewegung Akkusativ verlangen ('in einen Kurs gehen') und widerspräche der Dativform 'einem' im Text. 'bei' verwendet man bei Lehrpersonen ('bei Frau Meier lernen'), nicht bei Kursen selbst."
+            },
+            {
+              "blankNumber": 8,
+              "type": "mcq",
+              "options": ["a) sind", "b) waren", "c) haben"],
+              "correctAnswer": "c",
+              "explanation": "Perfekt von 'machen' mit Hilfsverb 'haben': 'Wir haben ... gemacht.' 'sind' wäre bei 'gehen/fahren/kommen' richtig, aber 'machen' verlangt 'haben'. 'waren' wäre Präteritum und passt nicht zum Partizip 'gemacht'."
+            },
+            {
+              "blankNumber": 9,
+              "type": "mcq",
+              "options": ["a) mich", "b) mir", "c) für mich"],
+              "correctAnswer": "a",
+              "explanation": "Reflexives Verb 'sich freuen' mit Akkusativ: 'Ich freue mich.' 'mir' (Dativ) gehört zu anderen reflexiven Verben. 'für mich' ist kein Reflexivpronomen und ergibt hier keinen Sinn."
+            },
+            {
+              "blankNumber": 10,
+              "type": "mcq",
+              "options": ["a) dem", "b) das", "c) den"],
+              "correctAnswer": "a",
+              "explanation": "'sich widmen' ist ein reflexives Verb mit Dativ-Objekt: 'sich dem Abenteuer widmen'. Das Objekt steht im Dativ Neutrum → 'dem'. 'das' wäre Akkusativ, 'den' wäre Maskulinum. Das Substantiv 'Abenteuer' ist Neutrum, also 'dem'."
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Lesen Sie den folgenden Text. Welches Wort aus der Liste a–o passt in die Lücken? Jedes Wort passt nur einmal. Fünf Wörter bleiben übrig.",
+          "text": "Liebe Yara,\n\nvielen __(11)__ für deine Postkarte aus Hamburg – ich habe mich riesig gefreut. Wie du weißt, habe ich vor einem halben Jahr mit meinem dualen Studium angefangen. Die ersten Wochen waren wirklich anstrengend, aber __(12)__ habe ich mich gut eingelebt.\n\nMeine Ausbilderin ist sehr geduldig, nur die Fahrt zur Berufsschule ist lang. Wir haben oft darüber __(13)__ und schließlich eine gute Lösung gefunden: Ich fahre jetzt einmal in der Woche morgens früher und arbeite dafür an den anderen Tagen eine halbe Stunde weniger. Das __(14)__ erstaunlich gut.\n\nIn meinem Betrieb bin ich __(15)__ die Kundenanfragen per E-Mail zuständig. __(16)__ der letzten Woche durfte ich zum ersten Mal einen Kunden allein betreuen – das war spannend, aber auch anstrengend. Abends bin ich meistens ziemlich müde, und trotzdem versuche ich, ein bisschen zu lernen.\n\nEine Sache stört mich gerade: Der Fahrpreis für den Bus wurde zum März leider __(17)__. Ich hatte mich fest __(18)__ einen günstigen Sommer eingestellt, und jetzt kostet das Monatsticket 20 Euro mehr. Vielleicht finde ich bald einen kleinen Nebenjob am Wochenende, damit ich __(19)__ nicht so viel Geld pro Monat verliere. Das Semester ist fast rum, und in den Ferien __(20)__ fahre ich eine Woche ans Meer, um richtig abzuschalten.\n\nMelde dich bald, und sag mir, wie es dir geht!\n\nViele Grüße,\nFlorian",
+          "questions": [
+            {
+              "blankNumber": 11,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) mittlerweile", "c) gesprochen", "d) klappt", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) wenigstens", "j) hoffentlich",
+                "k) herzlichen", "l) überlegt", "m) reicht", "n) ohne", "o) damit"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Die feste Briefformel 'Vielen Dank für deine Postkarte' verlangt nach 'vielen' das Substantiv 'Dank'. Distraktor k) 'herzlichen' passt grammatisch ('herzlichen Dank'), aber der Text hat bereits 'vielen' vorgegeben."
+            },
+            {
+              "blankNumber": 12,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) mittlerweile", "c) gesprochen", "d) klappt", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) wenigstens", "j) hoffentlich",
+                "k) herzlichen", "l) überlegt", "m) reicht", "n) ohne", "o) damit"
+              ],
+              "correctAnswer": "b",
+              "explanation": "'Die ersten Wochen waren anstrengend, aber mittlerweile habe ich mich gut eingelebt.' 'mittlerweile' bedeutet 'inzwischen' und drückt den zeitlichen Gegensatz aus. 'damit' (Zweck) oder 'hoffentlich' (Wunsch) passen nicht."
+            },
+            {
+              "blankNumber": 13,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) mittlerweile", "c) gesprochen", "d) klappt", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) wenigstens", "j) hoffentlich",
+                "k) herzlichen", "l) überlegt", "m) reicht", "n) ohne", "o) damit"
+              ],
+              "correctAnswer": "c",
+              "explanation": "'Wir haben oft darüber gesprochen' – 'sprechen über' (Verb + Präposition). Partizip II von 'sprechen' ist 'gesprochen'. Distraktor l) 'überlegt' verlangt kein 'über' als Verbpräposition im gleichen Sinn und passt inhaltlich weniger."
+            },
+            {
+              "blankNumber": 14,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) mittlerweile", "c) gesprochen", "d) klappt", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) wenigstens", "j) hoffentlich",
+                "k) herzlichen", "l) überlegt", "m) reicht", "n) ohne", "o) damit"
+              ],
+              "correctAnswer": "d",
+              "explanation": "'Das klappt erstaunlich gut' – idiomatisch für 'es funktioniert'. Subjekt 'Das' + 3. Person Singular 'klappt'. Distraktor m) 'reicht' hat eine andere Bedeutung ('genug sein') und passt hier nicht."
+            },
+            {
+              "blankNumber": 15,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) mittlerweile", "c) gesprochen", "d) klappt", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) wenigstens", "j) hoffentlich",
+                "k) herzlichen", "l) überlegt", "m) reicht", "n) ohne", "o) damit"
+              ],
+              "correctAnswer": "e",
+              "explanation": "Feste Wendung 'zuständig sein für + Akkusativ'. 'für' ist obligatorisch. 'auf' oder 'ohne' bilden mit 'zuständig' keine idiomatische Struktur."
+            },
+            {
+              "blankNumber": 16,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) mittlerweile", "c) gesprochen", "d) klappt", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) wenigstens", "j) hoffentlich",
+                "k) herzlichen", "l) überlegt", "m) reicht", "n) ohne", "o) damit"
+              ],
+              "correctAnswer": "f",
+              "explanation": "Zeitangabe am Satzanfang: 'In der letzten Woche ...'. 'in' + Dativ für Zeitspannen. Die Großschreibung ('In') zeigt den Satzanfang."
+            },
+            {
+              "blankNumber": 17,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) mittlerweile", "c) gesprochen", "d) klappt", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) wenigstens", "j) hoffentlich",
+                "k) herzlichen", "l) überlegt", "m) reicht", "n) ohne", "o) damit"
+              ],
+              "correctAnswer": "g",
+              "explanation": "'Fahrpreis erhöhen' ist die Standardkollokation (raise the fare). Passiv Perfekt: 'Der Fahrpreis wurde erhöht.' Distraktor l) 'überlegt' hätte keine parallele idiomatische Verwendung."
+            },
+            {
+              "blankNumber": 18,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) mittlerweile", "c) gesprochen", "d) klappt", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) wenigstens", "j) hoffentlich",
+                "k) herzlichen", "l) überlegt", "m) reicht", "n) ohne", "o) damit"
+              ],
+              "correctAnswer": "h",
+              "explanation": "'sich auf etwas einstellen' (Verb+Präposition, Akkusativ): 'ich hatte mich auf einen günstigen Sommer eingestellt'. 'für' passt zu anderen Verben, 'ohne' ergibt hier keinen Sinn."
+            },
+            {
+              "blankNumber": 19,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) mittlerweile", "c) gesprochen", "d) klappt", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) wenigstens", "j) hoffentlich",
+                "k) herzlichen", "l) überlegt", "m) reicht", "n) ohne", "o) damit"
+              ],
+              "correctAnswer": "i",
+              "explanation": "'damit ich wenigstens nicht so viel Geld ... verliere' – 'wenigstens' bedeutet 'at least' und betont das minimal Erreichbare. 'hoffentlich' wäre semantisch ähnlich, aber 'wenigstens' passt besser in den Satzbau und zur Idee eines Ausgleichs für ein Problem."
+            },
+            {
+              "blankNumber": 20,
+              "type": "word_bank",
+              "options": [
+                "a) Dank", "b) mittlerweile", "c) gesprochen", "d) klappt", "e) für",
+                "f) In", "g) erhöht", "h) auf", "i) wenigstens", "j) hoffentlich",
+                "k) herzlichen", "l) überlegt", "m) reicht", "n) ohne", "o) damit"
+              ],
+              "correctAnswer": "j",
+              "explanation": "'In den Ferien fahre ich hoffentlich eine Woche ans Meer' – das Adverb 'hoffentlich' drückt den Wunsch aus. Übrig bleiben k), l), m), n), o) als Distraktoren."
+            }
+          ]
+        }
+      ]
+    },
+    "writing": {
+      "totalTimeMinutes": 30,
+      "tasks": [
+        {
+          "taskNumber": 1,
+          "type": "letter",
+          "instructions": "Sie haben vor einigen Wochen einen Deutschkurs an der Volkshochschule (VHS) besucht und möchten dem Kursleiter, Herrn Weber, eine Rückmeldung geben. Schreiben Sie eine E-Mail an Herrn Weber. Gehen Sie auf alle vier Punkte unten ein. Achten Sie auf eine passende Anrede und einen passenden Gruß. Schreiben Sie ca. 150 Wörter.",
+          "instructionsTranslation": "A few weeks ago you attended a German course at the adult education center (VHS) and would like to give feedback to the course instructor, Mr. Weber. Write an email to Mr. Weber. Address all four points below. Pay attention to appropriate greeting and closing. Write approximately 150 words.",
+          "prompt": "Situation: Sie haben vor einigen Wochen den B1-Kurs an der VHS bei Herrn Weber beendet. Die VHS hat Sie per E-Mail um eine persönliche Rückmeldung gebeten, die an den Kursleiter weitergeleitet wird.\n\nSchreiben Sie eine E-Mail an Herrn Weber. Gehen Sie auf die folgenden vier Punkte ein:\n\n- Rückblick: Was hat Ihnen am Kurs besonders gut gefallen?\n- Kritikpunkt: Was hätte aus Ihrer Sicht besser organisiert werden können?\n- Nutzen: Wie setzen Sie das Gelernte jetzt im Alltag oder Beruf ein?\n- Weiterempfehlung: Würden Sie den Kurs anderen empfehlen, und wenn ja, wem?\n\nVergessen Sie nicht Anrede, Einleitung und Grußformel. Schreiben Sie ca. 150 Wörter.",
+          "promptTranslation": "Situation: A few weeks ago you completed the B1 course at the VHS with Mr. Weber. The VHS has asked you by email for personal feedback which will be forwarded to the course instructor.\n\nWrite an email to Mr. Weber. Address these four points:\n\n- Review: What did you particularly like about the course?\n- Criticism: What could have been better organized, in your view?\n- Use: How do you apply what you learned in daily life or at work?\n- Recommendation: Would you recommend the course to others, and if so, to whom?\n\nDon't forget greeting, introduction, and closing. Write approximately 150 words.",
+          "requiredPoints": [
+            "Positives Feedback zum Kurs",
+            "Konstruktiver Kritikpunkt zur Organisation",
+            "Beispiel, wie Sie das Gelernte anwenden",
+            "Weiterempfehlung mit Zielgruppe"
+          ],
+          "wordCountMin": 130,
+          "wordCountMax": 170,
+          "sampleAnswer": "Sehr geehrter Herr Weber,\n\nvielen Dank für die Möglichkeit, Ihnen nach Kursende noch ein persönliches Feedback zu geben. Gern beantworte ich die vier Fragen der VHS.\n\nAm meisten hat mir gefallen, dass wir im Unterricht viel frei gesprochen haben. Die kleinen Rollenspiele waren besonders hilfreich, weil ich dadurch meine Angst vor dem Sprechen verloren habe. Auch Ihre klaren Grammatikerklärungen waren sehr verständlich.\n\nEtwas mehr Struktur hätte ich mir beim Thema Hausaufgaben gewünscht. Die Übungen kamen manchmal spontan, und es war schwierig, sich rechtzeitig vorzubereiten. Vielleicht könnten Sie künftig einmal pro Woche einen festen Plan per E-Mail verschicken.\n\nIm Alltag profitiere ich sehr vom Kurs: Bei der Arbeit schreibe ich inzwischen selbst meine E-Mails auf Deutsch, und ich verstehe die Kollegen in Besprechungen deutlich besser.\n\nDen Kurs würde ich auf jeden Fall weiterempfehlen – besonders Kollegen, die neu in Deutschland sind und schnell sprechfähig werden möchten.\n\nMit freundlichen Grüßen\nAlex Müller",
+          "scoringCriteria": [
+            {
+              "criterion": "I. Inhaltliche Vollständigkeit",
+              "maxPoints": 15,
+              "description": "Alle vier Leitpunkte (Lob, Kritik, Anwendung, Weiterempfehlung) sind klar behandelt. Wird einer dieser Punkte als nicht bearbeitet bewertet (D), erhält der gesamte Text 0 Punkte."
+            },
+            {
+              "criterion": "II. Kommunikative Gestaltung",
+              "maxPoints": 15,
+              "description": "Angemessene formelle Anrede ('Sehr geehrter Herr Weber'), klare Einleitung, Verwendung passender Konnektoren (außerdem, allerdings, dadurch), formelle Grußformel, sinnvolle Absatzstruktur."
+            },
+            {
+              "criterion": "III. Formale Richtigkeit",
+              "maxPoints": 15,
+              "description": "Grammatik, Rechtschreibung und Wortwahl auf B1-Niveau. Verbformen (Perfekt, Konjunktiv II für höfliche Kritik), Satzstellung in Nebensätzen, Kasus nach Präpositionen. Schwerwiegende Grammatikfehler, die das Verständnis blockieren, führen zu D (und damit 0 Punkten für den gesamten Text)."
+            }
+          ]
+        }
+      ]
+    },
+    "speaking": {
+      "totalTimeMinutes": 15,
+      "prepTimeMinutes": 20,
+      "parts": [
+        {
+          "partNumber": 1,
+          "type": "introduce",
+          "instructions": "Stellen Sie sich Ihrem Gesprächspartner/Ihrer Gesprächspartnerin vor. Sprechen Sie über sich: Name, Herkunft, Wohnort, Familie, Beruf oder Ausbildung, Hobbys und Sprachen. Stellen Sie anschließend Ihrem Partner/Ihrer Partnerin mindestens zwei Fragen.",
+          "instructionsTranslation": "Introduce yourself to your conversation partner. Talk about: name, origin, place of residence, family, work or education, hobbies, and languages. Afterwards ask your partner at least two questions.",
+          "prompt": "Bitte stellen Sie sich Ihrem Partner / Ihrer Partnerin vor. Sprechen Sie u.a. über:\n- Ihren Namen und Ihre Herkunft\n- Ihren aktuellen Wohnort und seit wann Sie dort leben\n- Ihre Familie\n- Ihren Beruf oder Ihr Studium\n- Ihre Hobbys und Interessen\n- Die Sprachen, die Sie sprechen\n\nStellen Sie danach Ihrem Partner / Ihrer Partnerin mindestens zwei Fragen, um mehr über sie/ihn zu erfahren. Vorbereitungszeit: 20 Minuten für die gesamte mündliche Prüfung.",
+          "sampleResponse": "Guten Tag, ich heiße Daniel Oliveira und komme aus Porto in Portugal. Seit zwei Jahren lebe ich in München, weil ich hier ein Masterstudium in Informatik begonnen habe. Meine Familie ist ziemlich klein: Meine Eltern, meine ältere Schwester und ich. Meine Schwester arbeitet als Architektin in Lissabon, und wir versuchen, uns mindestens zweimal im Jahr zu sehen. Im Moment bin ich Student im dritten Semester und arbeite parallel als Werkstudent bei einer kleinen Softwarefirma – das verbindet Studium und Praxis gut. In meiner Freizeit laufe ich viel, fast jeden zweiten Tag. Außerdem spiele ich Schach, sogar in einem kleinen Verein. Sprachlich: Portugiesisch ist meine Muttersprache, dazu Deutsch, Englisch und ein bisschen Französisch aus der Schulzeit. Und wie ist das bei dir? Woher kommst du eigentlich, und was studierst oder arbeitest du gerade?",
+          "evaluationTips": [
+            "Strukturieren Sie Ihre Vorstellung – beginnen Sie nicht mit Hobbys, sondern mit Name und Herkunft",
+            "Verwenden Sie Nebensätze mit 'weil', 'wo', 'der/die' – das zeigt B1-Niveau",
+            "Sprechen Sie in Absätzen: ein Gedanke pro Thema, nicht alles in einem langen Satz",
+            "Stellen Sie echte Fragen – keine Ja/Nein-Fragen, sondern W-Fragen, die zu einem Gespräch einladen",
+            "Nennen Sie konkrete Details (Stadt, Jahre, Beruf), keine abstrakten Angaben",
+            "Reagieren Sie auf die Antworten Ihres Partners: 'Das finde ich interessant – erzähl mehr.'"
+          ],
+          "keyPhrases": [
+            "Ich heiße ... und komme aus ...",
+            "Seit ... Jahren lebe ich in ...",
+            "Im Moment studiere ich ... / Ich arbeite als ...",
+            "In meiner Freizeit ...",
+            "Neben Deutsch spreche ich ...",
+            "Und du – woher kommst du?",
+            "Was machst du eigentlich beruflich?"
+          ]
+        },
+        {
+          "partNumber": 2,
+          "type": "discussion",
+          "instructions": "Sie erhalten einen kurzen Text zum Thema. Fassen Sie den Inhalt für Ihren Partner zusammen, beantworten Sie die drei Leitfragen, und tauschen Sie Ihre Meinung mit dem Partner aus.",
+          "instructionsTranslation": "You receive a short text on the topic. Summarize the content for your partner, answer the three guiding questions, and exchange your opinions with your partner.",
+          "prompt": "Thema: Lebenslanges Lernen\n\nLesen Sie den folgenden kurzen Text:\n\n'Viele Erwachsene in Deutschland lernen auch nach dem Abschluss ihrer Ausbildung weiter. Besonders beliebt sind Sprachkurse, Computerkurse und kreative Angebote wie Malen oder Fotografie. Die Volkshochschulen melden: Die Zahl der Teilnehmenden ist in den letzten fünf Jahren um 20 Prozent gestiegen. Experten meinen, dass lebenslanges Lernen in Zeiten schneller Veränderungen immer wichtiger wird – sowohl beruflich als auch persönlich.'\n\nLeitfragen:\n1. Fassen Sie kurz den Inhalt des Textes zusammen (in 2–3 Sätzen).\n2. Welche Kurse oder Weiterbildungen haben Sie als Erwachsener schon gemacht, und was haben Sie daraus mitgenommen?\n3. Finden Sie es eher wichtig, berufliche Kurse zu besuchen, oder eher Angebote, die einem persönlich Freude machen? Begründen Sie Ihre Meinung.\n\nSprechen Sie mit Ihrem Partner/Ihrer Partnerin über das Thema – fragen Sie auch nach seiner/ihrer Meinung.",
+          "sampleResponse": "Im Text steht, dass immer mehr Erwachsene in Deutschland weiterlernen – besonders Sprachen, Computer und kreative Angebote. Die Volkshochschulen haben zwanzig Prozent mehr Teilnehmende als vor fünf Jahren. Die Experten meinen, dass lebenslanges Lernen heute wichtiger denn je ist.\n\nIch habe selbst schon einiges gemacht. Vor zwei Jahren habe ich zum Beispiel einen Fotografie-Kurs an der VHS besucht. Das war vor allem ein Hobby, aber ich nutze die Bilder heute auch beruflich für unsere Firmen-Website. Außerdem mache ich regelmäßig Online-Kurse zu neuen Software-Tools – das ist für meine Arbeit unverzichtbar.\n\nMeiner Meinung nach sollte man beide Arten von Kursen mischen. Berufliche Weiterbildungen sind wichtig, weil sich Technik und Anforderungen schnell ändern. Aber ein Kurs, der einfach Freude macht, ist genauso wertvoll – man lernt dort andere Menschen kennen und kommt mal raus aus dem Arbeitsalltag. Einseitig nur beruflich zu lernen, finde ich auf Dauer ermüdend. Wie siehst du das – was hast du selbst schon für dich gemacht?",
+          "evaluationTips": [
+            "Beginnen Sie mit einer klaren Zusammenfassung, bevor Sie Ihre Meinung nennen",
+            "Nennen Sie konkrete Beispiele aus Ihrem eigenen Lernweg, keine allgemeinen Aussagen",
+            "Verwenden Sie Meinungsformulierungen: 'Meiner Meinung nach ...', 'Ich finde, dass ...', 'Aus meiner Sicht ...'",
+            "Gliedern Sie Vor- und Nachteile klar: 'Einerseits ..., andererseits ...'",
+            "Stellen Sie dem Partner mindestens eine inhaltliche Rückfrage",
+            "Benutzen Sie Konnektoren wie 'allerdings', 'außerdem', 'trotzdem', 'deshalb' – das wertet die Antwort auf"
+          ],
+          "keyPhrases": [
+            "Im Text geht es um ...",
+            "Der Text berichtet, dass ...",
+            "Meiner Meinung nach ...",
+            "Ich finde es wichtig, dass ...",
+            "Ein Vorteil/Nachteil ist, dass ...",
+            "Einerseits ... andererseits ...",
+            "Wie siehst du das?",
+            "Hast du ähnliche Erfahrungen gemacht?"
+          ]
+        },
+        {
+          "partNumber": 3,
+          "type": "planning",
+          "instructions": "Sie sollen mit Ihrem Partner gemeinsam etwas planen. Machen Sie Vorschläge, reagieren Sie auf die Ideen Ihres Partners und einigen Sie sich am Ende auf eine gemeinsame Lösung.",
+          "instructionsTranslation": "You are going to plan something together with your partner. Make suggestions, respond to your partner's ideas, and agree on a joint solution at the end.",
+          "prompt": "Ihre Klasse an der Sprachschule hat bald den B1-Abschluss bestanden. Sie möchten mit Ihrem Partner/Ihrer Partnerin gemeinsam eine kleine Abschlussfeier für die Klasse organisieren, zu der auch die Lehrerin eingeladen werden soll.\n\nBesprechen Sie bitte folgende Punkte und kommen Sie zu einer gemeinsamen Entscheidung:\n\n- Wann und wo soll die Feier stattfinden?\n- Wen laden Sie ein (nur die Klasse, Familien, die Lehrerin)?\n- Was soll es zu essen und zu trinken geben – und wer bringt was mit?\n- Welches kleine Geschenk überreichen Sie der Lehrerin?\n- Wer kümmert sich um Einladung, Musik und Dekoration?\n\nMachen Sie Vorschläge, gehen Sie auf die Vorschläge Ihres Partners ein und einigen Sie sich am Ende.",
+          "sampleResponse": "Also, ich würde vorschlagen, dass wir die Feier am letzten Kurstag direkt nach der Prüfung feiern – also am Freitag, den 20. Juni, ab 18 Uhr. Was hältst du davon, den Hinterhof der Sprachschule zu nutzen? Er ist groß, und wir brauchen nichts zu mieten.\n\nIch denke, wir sollten die ganze Klasse einladen, dazu unsere Lehrerin Frau Nowak, aber keine Familien – sonst wird es zu groß und unpersönlich. Wir sind also etwa sechzehn Personen.\n\nFür das Essen schlage ich ein internationales Buffet vor: Jede und jeder bringt ein kleines Gericht aus dem Heimatland mit. So wird es abwechslungsreich, und niemand muss viel kochen. Für Getränke teilen wir uns: Ich besorge Wasser, Saft und einen großen Krug selbstgemachte Limonade; du kaufst ein paar Flaschen Wein und Bier. Einverstanden?\n\nFür Frau Nowak würde ich ein gemeinsames Fotoalbum vorschlagen. Alle Kursteilnehmer schreiben einen kurzen Dankessatz, und ich klebe am Wochenende die Fotos ein. Zusätzlich sammeln wir für einen Blumenstrauß.\n\nLetzter Punkt: Ich übernehme die Einladungs-Mail an die Klasse, und du bringst deine Bluetooth-Box für die Musik mit. Die Dekoration können wir am Tag selbst eine Stunde vorher gemeinsam aufhängen. Passt das für dich?",
+          "evaluationTips": [
+            "Sprechen Sie nicht nur, sondern hören Sie auch aktiv zu – reagieren Sie auf die Vorschläge Ihres Partners",
+            "Machen Sie Vorschläge mit Konjunktiv II ('Ich würde vorschlagen ...', 'Wir könnten ...') – das wirkt höflich",
+            "Begründen Sie Ihre Vorschläge kurz: 'weil', 'damit', 'denn'",
+            "Einigen Sie sich am Ende wirklich – ein 'Das machen wir so, einverstanden?' zeigt Abschluss",
+            "Vermeiden Sie Monologe – lassen Sie dem Partner Raum für eigene Ideen",
+            "Verwenden Sie Modalverben: 'sollten wir', 'können wir', 'müssen wir' – das zeigt Planungssprache",
+            "Fassen Sie am Ende die wichtigsten Entscheidungen kurz zusammen"
+          ],
+          "keyPhrases": [
+            "Ich würde vorschlagen, dass ...",
+            "Was hältst du davon, wenn ...?",
+            "Wir könnten ... machen.",
+            "Das ist eine gute Idee, aber ...",
+            "Alternativ könnten wir auch ...",
+            "Wer übernimmt ...?",
+            "Ich kann ... / Du bringst ... mit, okay?",
+            "Einverstanden!",
+            "Dann halten wir fest: ..."
+          ]
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary

Replaces B1 mock_02 and mock_03 stubs with full 64-item mocks. Matches mock_01 structure exactly (Listening 20 + Reading 20 + Sprachbausteine 20 + Writing 1 + Speaking 3).

## Theme coherence

| Mock | Theme | Reading article | SB letters | Writing task |
|---|---|---|---|---|
| mock_02 | Beruf | Hybrid work (Homeoffice pullback) | Workplace adjustment | Professional email re Fortbildung |
| mock_03 | Bildung | duale Ausbildung | Fern-/duales Studium | VHS course instructor feedback |

## Suite convention

**Recurring Sprachbausteine letter writers** — gives the 10-mock suite a sense of a wider cast:
- mock_01: Katrin + Tobias
- mock_02: Lina + Simon
- mock_03: Sofia + Florian

## Quality notes

- Goethe B1 vocab scope
- Sprachbausteine Teil 1 = pure grammar distractors
- Sprachbausteine Teil 2 = 5 real lexical distractors in 15-option bank
- Listening Teil 1 plays ONCE — answers audibly clear in single pass
- Article register: research institute + named expert + balanced pro/con + concrete recommendations (matches mock_01)
- Answer-key rebalanced: mock_03 SB Teil 1 initial 5b/5a/0c → 4c/4a/2b

## Known gaps

- No audio MP3s yet — SSML + render pass next (pipeline from #35)
- Reading article word counts 284/290 — slightly below the 300-450 ideal but consistent with mock_01's 266

## Test plan

- [ ] B1 mock_02 loads end-to-end in web
- [ ] B1 mock_03 loads end-to-end in web
- [ ] Sprachbausteine section renders (depends on #40 being merged first)
- [ ] CI green