### PR TITLE
feat(web): speaking-practice recorder with mic, playback, retry

### DIFF
--- a/apps/web/src/__tests__/exam/SpeakingRecorder.test.tsx
+++ b/apps/web/src/__tests__/exam/SpeakingRecorder.test.tsx
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SpeakingRecorder } from '../../components/exam/SpeakingRecorder';
+
+// ---------- MediaRecorder / getUserMedia mocks ----------
+
+type RecorderEvent = 'dataavailable' | 'stop' | 'error';
+
+class MockMediaRecorder {
+  static isTypeSupported = vi.fn(() => true);
+  static instances: MockMediaRecorder[] = [];
+
+  state: 'inactive' | 'recording' | 'paused' = 'inactive';
+  mimeType: string;
+  ondataavailable: ((e: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+
+  constructor(_stream: MediaStream, opts?: { mimeType?: string }) {
+    this.mimeType = opts?.mimeType ?? 'audio/webm';
+    MockMediaRecorder.instances.push(this);
+  }
+
+  start() {
+    this.state = 'recording';
+  }
+
+  stop() {
+    this.state = 'inactive';
+    // Simulate chunk delivery + stop event like a real browser.
+    this.ondataavailable?.({ data: new Blob(['x'], { type: this.mimeType }) });
+    this.onstop?.();
+  }
+
+  // Convenience for tests to trigger errors.
+  emit(event: RecorderEvent, payload?: unknown) {
+    if (event === 'dataavailable') this.ondataavailable?.(payload as { data: Blob });
+    if (event === 'stop') this.onstop?.();
+    if (event === 'error') this.onerror?.(payload);
+  }
+}
+
+function buildStream(): MediaStream {
+  return {
+    getTracks: () => [{ stop: vi.fn() } as unknown as MediaStreamTrack],
+  } as unknown as MediaStream;
+}
+
+const getUserMedia = vi.fn();
+
+beforeEach(() => {
+  MockMediaRecorder.instances = [];
+  MockMediaRecorder.isTypeSupported = vi.fn(() => true);
+  getUserMedia.mockReset();
+  getUserMedia.mockResolvedValue(buildStream());
+
+  vi.stubGlobal('MediaRecorder', MockMediaRecorder as unknown as typeof MediaRecorder);
+
+  Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getUserMedia },
+  });
+
+  // jsdom lacks URL.createObjectURL/revokeObjectURL
+  vi.stubGlobal(
+    'URL',
+    Object.assign(URL, {
+      createObjectURL: vi.fn(() => 'blob:mock-url'),
+      revokeObjectURL: vi.fn(),
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function lastRecorder(): MockMediaRecorder {
+  const r = MockMediaRecorder.instances.at(-1);
+  if (!r) throw new Error('expected a MediaRecorder instance');
+  return r;
+}
+
+describe('SpeakingRecorder', () => {
+  it('renders idle state with record button', () => {
+    render(<SpeakingRecorder />);
+    const btn = screen.getByTestId('speaking-recorder-btn');
+    expect(btn).toBeTruthy();
+    expect(btn).toHaveAttribute('aria-label', 'Aufnahme starten');
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.queryByTestId('speaking-recorder-audio')).toBeNull();
+  });
+
+  it('requests mic permission on first click and enters recording state', async () => {
+    render(<SpeakingRecorder />);
+
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('speaking-recorder-btn'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+    expect(getUserMedia).toHaveBeenCalledWith({ audio: true });
+
+    const btn = screen.getByTestId('speaking-recorder-btn');
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+    expect(btn).toHaveAttribute('aria-label', 'Aufnahme stoppen');
+    expect(screen.getByTestId('speaking-recorder-timer')).toBeTruthy();
+  });
+
+  it('advances the timer while recording', async () => {
+    vi.useFakeTimers();
+    try {
+      render(<SpeakingRecorder />);
+
+      await act(async () => {
+        // userEvent doesn't play nicely with fake timers, so click directly.
+        screen.getByTestId('speaking-recorder-btn').click();
+        // flush the getUserMedia promise microtask
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Advance 2 seconds of real time; component polls every 250ms.
+      await act(async () => {
+        vi.advanceTimersByTime(2100);
+      });
+
+      expect(screen.getByTestId('speaking-recorder-timer').textContent).toMatch(
+        /00:0[12] \/ 03:00/,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('produces playback UI after stop', async () => {
+    render(<SpeakingRecorder />);
+
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('speaking-recorder-btn'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('speaking-recorder-btn'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const audio = screen.getByTestId('speaking-recorder-audio') as HTMLAudioElement;
+    expect(audio).toBeTruthy();
+    expect(audio.src).toBe('blob:mock-url');
+    expect(screen.getByTestId('speaking-recorder-retry')).toBeTruthy();
+  });
+
+  it('retry resets back to idle/ready state', async () => {
+    render(<SpeakingRecorder />);
+
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('speaking-recorder-btn'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('speaking-recorder-btn'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // On playback now — click retry
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('speaking-recorder-retry'));
+    });
+
+    expect(screen.queryByTestId('speaking-recorder-audio')).toBeNull();
+    const btn = screen.getByTestId('speaking-recorder-btn');
+    expect(btn).toHaveAttribute('aria-label', 'Aufnahme starten');
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('shows helpful error when permission is denied', async () => {
+    const denial = new Error('denied') as Error & { name: string };
+    denial.name = 'NotAllowedError';
+    getUserMedia.mockRejectedValueOnce(denial);
+
+    render(<SpeakingRecorder />);
+
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('speaking-recorder-btn'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const alert = screen.getByTestId('speaking-recorder-error');
+    expect(alert.textContent).toMatch(/Mikrofonzugriff/);
+    // back to non-recording button
+    const btn = screen.getByTestId('speaking-recorder-btn');
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('auto-stops when max duration is reached', async () => {
+    vi.useFakeTimers();
+    try {
+      render(<SpeakingRecorder maxDurationSeconds={2} />);
+
+      await act(async () => {
+        screen.getByTestId('speaking-recorder-btn').click();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(2500);
+      });
+
+      expect(lastRecorder().state).toBe('inactive');
+      expect(screen.getByTestId('speaking-recorder-audio')).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows unsupported message when MediaRecorder is missing', () => {
+    delete (globalThis as { MediaRecorder?: unknown }).MediaRecorder;
+
+    render(<SpeakingRecorder />);
+    expect(screen.getByRole('alert').textContent).toMatch(/keine Audioaufnahmen/);
+    expect(screen.queryByTestId('speaking-recorder-btn')).toBeNull();
+  });
+
+  it('renders idle state with a custom label for screen readers', () => {
+    render(<SpeakingRecorder label="Aufgabe 2" />);
+    expect(screen.getByTestId('speaking-recorder')).toHaveAttribute(
+      'aria-label',
+      'Aufnahme Aufgabe 2',
+    );
+  });
+});

--- a/apps/web/src/components/exam/PrepTimer.tsx
+++ b/apps/web/src/components/exam/PrepTimer.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { formatTime } from '@telc/core';
+
+interface PrepTimerProps {
+  totalSeconds: number;
+}
+
+/**
+ * Countdown for the B1/B2 speaking Vorbereitungszeit (20 min).
+ * Starts paused so the user can begin when ready.
+ */
+export function PrepTimer({ totalSeconds }: PrepTimerProps) {
+  const [remaining, setRemaining] = useState(totalSeconds);
+  const [isRunning, setIsRunning] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clear = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clear, [clear]);
+
+  useEffect(() => {
+    if (!isRunning) return;
+    intervalRef.current = setInterval(() => {
+      setRemaining((prev) => {
+        if (prev <= 1) {
+          clear();
+          setIsRunning(false);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return clear;
+  }, [isRunning, clear]);
+
+  const reset = () => {
+    clear();
+    setIsRunning(false);
+    setRemaining(totalSeconds);
+  };
+
+  const expired = remaining === 0;
+  const warning = !expired && remaining <= 60;
+
+  return (
+    <div
+      data-testid="prep-timer"
+      className="rounded-xl border border-border bg-white p-4 flex items-center justify-between gap-3"
+    >
+      <div>
+        <p className="text-sm font-semibold text-text-primary">Vorbereitungszeit</p>
+        <p className="text-xs text-text-secondary">
+          Zeit für Notizen vor dem Sprechen. Die Aufnahme läuft getrennt.
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <span
+          data-testid="prep-timer-clock"
+          aria-live="polite"
+          className={`rounded-lg px-3 py-1.5 text-sm font-mono font-semibold tabular-nums ${
+            expired
+              ? 'bg-fail-light text-fail'
+              : warning
+                ? 'bg-warning-light text-warning'
+                : 'bg-surface-container text-text-primary'
+          }`}
+        >
+          {expired ? 'Zeit vorbei' : formatTime(remaining)}
+        </span>
+        <button
+          data-testid="prep-timer-toggle"
+          type="button"
+          onClick={() => setIsRunning((v) => !v)}
+          disabled={expired}
+          className="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-secondary disabled:opacity-40 hover:border-border-hover"
+        >
+          {isRunning ? 'Pause' : remaining === totalSeconds ? 'Start' : 'Weiter'}
+        </button>
+        <button
+          data-testid="prep-timer-reset"
+          type="button"
+          onClick={reset}
+          className="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-secondary hover:border-border-hover"
+        >
+          Zurücksetzen
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/exam/SpeakingExam.tsx
+++ b/apps/web/src/components/exam/SpeakingExam.tsx
@@ -8,6 +8,8 @@ import type { ExamPhase } from '@/lib/examTypes';
 import { saveSection } from '@/lib/examSession';
 import { ExamTimer } from './ExamTimer';
 import { SectionIntro } from './SectionIntro';
+import { SpeakingRecorder } from './SpeakingRecorder';
+import { PrepTimer } from './PrepTimer';
 
 interface SpeakingExamProps {
   mockId: string;
@@ -165,6 +167,10 @@ export function SpeakingExam({ mockId, level, section }: SpeakingExamProps) {
         />
       </div>
 
+      {section.prepTimeMinutes > 0 && (
+        <PrepTimer totalSeconds={section.prepTimeMinutes * 60} />
+      )}
+
       <div className="flex gap-2">
         {section.parts.map((p, i) => (
           <button
@@ -232,6 +238,20 @@ export function SpeakingExam({ mockId, level, section }: SpeakingExamProps) {
             </ul>
           </div>
         )}
+
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-text-secondary mb-2">
+            Ihre Aufnahme:
+          </p>
+          <SpeakingRecorder
+            key={`recorder-part-${part.partNumber}`}
+            label={`Aufgabe ${part.partNumber}`}
+          />
+          <p className="mt-2 text-xs text-text-secondary">
+            Tipp: Nehmen Sie Ihre Antwort auf, hören Sie sie ab und vergleichen Sie sie mit
+            der Musterlösung. Aufnahmen werden nicht gespeichert.
+          </p>
+        </div>
 
         {part.sampleResponse && (
           <div>

--- a/apps/web/src/components/exam/SpeakingRecorder.tsx
+++ b/apps/web/src/components/exam/SpeakingRecorder.tsx
@@ -1,0 +1,362 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type RecorderState =
+  | 'idle'
+  | 'requesting-permission'
+  | 'ready'
+  | 'recording'
+  | 'playback'
+  | 'unsupported'
+  | 'denied'
+  | 'error';
+
+interface SpeakingRecorderProps {
+  /** Label used in accessible announcements, e.g. "Aufgabe 1". */
+  label?: string;
+  /** Maximum recording duration in seconds. Defaults to 180 (3 min). */
+  maxDurationSeconds?: number;
+}
+
+const DEFAULT_MAX_SECONDS = 180;
+
+function pickMimeType(): string | undefined {
+  if (typeof MediaRecorder === 'undefined') return undefined;
+  const candidates = [
+    'audio/webm;codecs=opus',
+    'audio/webm',
+    'audio/mp4',
+    'audio/ogg;codecs=opus',
+  ];
+  for (const type of candidates) {
+    try {
+      if (MediaRecorder.isTypeSupported?.(type)) return type;
+    } catch {
+      // some polyfills/browsers may throw — ignore
+    }
+  }
+  return undefined;
+}
+
+function formatClock(totalSeconds: number): string {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  const mm = Math.floor(s / 60)
+    .toString()
+    .padStart(2, '0');
+  const ss = (s % 60).toString().padStart(2, '0');
+  return `${mm}:${ss}`;
+}
+
+export function SpeakingRecorder({
+  label,
+  maxDurationSeconds = DEFAULT_MAX_SECONDS,
+}: SpeakingRecorderProps) {
+  const [state, setState] = useState<RecorderState>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<BlobPart[]>([]);
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startMsRef = useRef<number>(0);
+
+  // Detect unsupported environment once on mount.
+  useEffect(() => {
+    const hasMediaRecorder = typeof window !== 'undefined' && 'MediaRecorder' in window;
+    const hasGetUserMedia =
+      typeof navigator !== 'undefined' &&
+      !!navigator.mediaDevices &&
+      typeof navigator.mediaDevices.getUserMedia === 'function';
+    if (!hasMediaRecorder || !hasGetUserMedia) {
+      setState('unsupported');
+    }
+  }, []);
+
+  const stopTimer = useCallback(() => {
+    if (tickRef.current) {
+      clearInterval(tickRef.current);
+      tickRef.current = null;
+    }
+  }, []);
+
+  const releaseStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+  }, []);
+
+  // Cleanup on unmount: stop tracks, clear timers, revoke blob URL.
+  useEffect(() => {
+    return () => {
+      stopTimer();
+      releaseStream();
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleStop = useCallback(() => {
+    stopTimer();
+    releaseStream();
+    const mimeType = mediaRecorderRef.current?.mimeType || 'audio/webm';
+    const blob = new Blob(chunksRef.current, { type: mimeType });
+    chunksRef.current = [];
+    if (blob.size === 0) {
+      setState('ready');
+      return;
+    }
+    const url = URL.createObjectURL(blob);
+    setBlobUrl((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return url;
+    });
+    setState('playback');
+  }, [releaseStream, stopTimer]);
+
+  const startRecording = useCallback(async () => {
+    if (state === 'unsupported') return;
+    setErrorMessage(null);
+    setState('requesting-permission');
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+
+      const mimeType = pickMimeType();
+      const recorder = mimeType
+        ? new MediaRecorder(stream, { mimeType })
+        : new MediaRecorder(stream);
+      mediaRecorderRef.current = recorder;
+      chunksRef.current = [];
+
+      recorder.ondataavailable = (event: BlobEvent) => {
+        if (event.data && event.data.size > 0) {
+          chunksRef.current.push(event.data);
+        }
+      };
+      recorder.onstop = handleStop;
+      recorder.onerror = () => {
+        setErrorMessage('Aufnahme-Fehler. Bitte erneut versuchen.');
+        stopTimer();
+        releaseStream();
+        setState('error');
+      };
+
+      recorder.start();
+      startMsRef.current = Date.now();
+      setElapsed(0);
+      setState('recording');
+
+      tickRef.current = setInterval(() => {
+        const next = Math.floor((Date.now() - startMsRef.current) / 1000);
+        setElapsed(next);
+        if (next >= maxDurationSeconds) {
+          // Auto-stop when limit is reached.
+          try {
+            if (mediaRecorderRef.current?.state === 'recording') {
+              mediaRecorderRef.current.stop();
+            }
+          } catch {
+            // ignore — onstop will clean up
+          }
+        }
+      }, 250);
+    } catch (err: unknown) {
+      const name =
+        err instanceof Error && 'name' in err ? (err as DOMException).name : undefined;
+      if (name === 'NotAllowedError' || name === 'SecurityError') {
+        setErrorMessage(
+          'Mikrofonzugriff wurde verweigert. Bitte erlauben Sie den Zugriff in Ihren Browser-Einstellungen.',
+        );
+        setState('denied');
+      } else if (name === 'NotFoundError' || name === 'OverconstrainedError') {
+        setErrorMessage(
+          'Kein Mikrofon gefunden. Bitte schließen Sie ein Mikrofon an und versuchen Sie es erneut.',
+        );
+        setState('error');
+      } else {
+        setErrorMessage('Aufnahme konnte nicht gestartet werden.');
+        setState('error');
+      }
+      releaseStream();
+    }
+  }, [handleStop, maxDurationSeconds, releaseStream, state, stopTimer]);
+
+  const stopRecording = useCallback(() => {
+    const recorder = mediaRecorderRef.current;
+    if (recorder && recorder.state === 'recording') {
+      try {
+        recorder.stop();
+      } catch {
+        // fall back to manual cleanup
+        handleStop();
+      }
+    } else {
+      handleStop();
+    }
+  }, [handleStop]);
+
+  const retry = useCallback(() => {
+    if (blobUrl) {
+      URL.revokeObjectURL(blobUrl);
+    }
+    setBlobUrl(null);
+    setElapsed(0);
+    setErrorMessage(null);
+    setState('idle');
+  }, [blobUrl]);
+
+  if (state === 'unsupported') {
+    return (
+      <div
+        data-testid="speaking-recorder"
+        className="rounded-lg border border-border bg-surface-container p-4"
+      >
+        <p role="alert" className="text-sm text-text-secondary">
+          Ihr Browser unterstützt keine Audioaufnahmen. Bitte nutzen Sie einen aktuellen
+          Chrome, Firefox oder Safari Browser.
+        </p>
+      </div>
+    );
+  }
+
+  const isRecording = state === 'recording';
+  const isRequesting = state === 'requesting-permission';
+  const hasPlayback = state === 'playback' && blobUrl;
+  const remaining = Math.max(0, maxDurationSeconds - elapsed);
+  const maxClock = formatClock(maxDurationSeconds);
+
+  const buttonLabel = isRecording
+    ? 'Aufnahme stoppen'
+    : isRequesting
+      ? 'Mikrofon wird angefragt…'
+      : hasPlayback
+        ? 'Neue Aufnahme'
+        : 'Aufnahme starten';
+
+  const primaryAction = isRecording
+    ? stopRecording
+    : hasPlayback
+      ? retry
+      : startRecording;
+
+  const ariaLive =
+    state === 'recording'
+      ? `Aufnahme läuft. ${formatClock(elapsed)} von ${maxClock}.`
+      : state === 'playback'
+        ? 'Aufnahme beendet. Wiedergabe verfügbar.'
+        : state === 'denied'
+          ? (errorMessage ?? 'Mikrofonzugriff verweigert.')
+          : state === 'error'
+            ? (errorMessage ?? 'Aufnahme-Fehler.')
+            : state === 'requesting-permission'
+              ? 'Mikrofonzugriff wird angefragt.'
+              : '';
+
+  return (
+    <div
+      data-testid="speaking-recorder"
+      className="rounded-lg border border-border bg-surface-container p-4 space-y-3"
+      aria-label={label ? `Aufnahme ${label}` : 'Aufnahme'}
+    >
+      <span className="sr-only" role="status" aria-live="polite">
+        {ariaLive}
+      </span>
+
+      {errorMessage && (state === 'denied' || state === 'error') && (
+        <div
+          role="alert"
+          data-testid="speaking-recorder-error"
+          className="rounded-md bg-fail-light px-3 py-2 text-sm text-fail"
+        >
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <button
+          data-testid="speaking-recorder-btn"
+          type="button"
+          onClick={primaryAction}
+          disabled={isRequesting}
+          aria-pressed={isRecording}
+          aria-label={buttonLabel}
+          className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full transition-colors ${
+            isRecording
+              ? 'bg-fail text-white hover:opacity-90'
+              : isRequesting
+                ? 'bg-surface-disabled text-text-disabled cursor-not-allowed'
+                : 'bg-brand-primary text-white hover:opacity-90'
+          }`}
+        >
+          {isRecording ? (
+            <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="6" y="6" width="12" height="12" rx="1" />
+            </svg>
+          ) : (
+            <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 14a3 3 0 0 0 3-3V6a3 3 0 1 0-6 0v5a3 3 0 0 0 3 3Zm5-3a5 5 0 0 1-10 0H5a7 7 0 0 0 6 6.92V21h2v-3.08A7 7 0 0 0 19 11h-2Z" />
+            </svg>
+          )}
+        </button>
+
+        <div className="flex-1">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-text-primary">{buttonLabel}</span>
+            {(isRecording || hasPlayback) && (
+              <span
+                data-testid="speaking-recorder-timer"
+                className="text-xs font-mono tabular-nums text-text-secondary"
+              >
+                {formatClock(elapsed)} / {maxClock}
+              </span>
+            )}
+          </div>
+
+          {isRecording && (
+            <div className="mt-2 h-1 w-full overflow-hidden rounded-full bg-border">
+              <div
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={maxDurationSeconds}
+                aria-valuenow={elapsed}
+                className="h-full rounded-full bg-fail transition-[width] duration-200"
+                style={{
+                  width: `${Math.min(100, (elapsed / maxDurationSeconds) * 100)}%`,
+                }}
+              />
+            </div>
+          )}
+
+          {isRecording && remaining <= 10 && (
+            <p className="mt-1 text-xs text-fail">
+              Noch {remaining} Sekunden — Aufnahme stoppt automatisch.
+            </p>
+          )}
+        </div>
+      </div>
+
+      {hasPlayback && blobUrl && (
+        <div className="space-y-2">
+          <audio
+            data-testid="speaking-recorder-audio"
+            src={blobUrl}
+            controls
+            className="w-full"
+          />
+          <div className="flex gap-2">
+            <button
+              data-testid="speaking-recorder-retry"
+              type="button"
+              onClick={retry}
+              className="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-secondary hover:border-border-hover"
+            >
+              Neu aufnehmen
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

New speaking-practice recording component. Users record themselves answering Sprechen prompts, play back, retry.

## Components

- **`SpeakingRecorder.tsx`** — reusable MediaRecorder-based audio capture
  - States: `idle → requesting-permission → recording → playback → idle` + `unsupported/denied/error`
  - 3-min auto-stop, "Noch N Sekunden" warning in last 10s
  - MIME negotiation: Chrome/Firefox (webm/opus), Safari (mp4), ogg fallback
  - Ephemeral Blob URLs — no network uploads, no persistence
  - German-language error messaging (NotAllowedError, SecurityError, NotFoundError)

- **`PrepTimer.tsx`** — Vorbereitungszeit countdown for B1/B2 (pause/resume/reset)
  - Only rendered when `section.prepTimeMinutes > 0` (already 0 for A1/A2/C1 in data)

## Integration (SpeakingExam.tsx)

- `<PrepTimer>` above all parts when applicable (B1/B2)
- `<SpeakingRecorder>` under each part's prompt, keyed per part so switching parts remounts a fresh recorder

## Accessibility

- `aria-pressed` on toggle button
- `aria-label` reflects current state
- `role="status"` + `aria-live="polite"` state announcements in sr-only region
- `role="progressbar"` for timer bar

## Tests

- 9 new tests, all 138 web tests passing
- Mocks `MediaRecorder` + `getUserMedia` via Vitest
- Covers: idle render, permission flow, timer advance, stop→playback, retry, denial error, auto-stop, unsupported fallback, custom label prop

Typecheck clean on web + mobile.

## Test plan

- [ ] Speaking section of any mock shows record button
- [ ] Click → browser prompts for mic
- [ ] Recording shows timer, auto-stops at 3min
- [ ] Playback audio element appears after stop
- [ ] Retry resets to ready
- [ ] B1 mock shows 20-min prep countdown
- [ ] A1/A2/C1 mocks don't show prep countdown
- [ ] CI green