### PR TITLE
rebrand: telc-fasttrack → Fastrack Deutsch (#48)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,4 @@ jobs:
         run: pnpm typecheck
 
       - name: Run tests
-        run: pnpm turbo run test --filter='!@telc/mobile'
+        run: pnpm turbo run test --filter='!@fastrack/mobile'

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,11 +1,11 @@
 {
   "expo": {
-    "name": "Telc-FastTrack",
-    "slug": "telc-fasttrack",
+    "name": "Fastrack Deutsch",
+    "slug": "fastrack-deutsch",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "telc-fasttrack",
+    "scheme": "fastrack-deutsch",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "splash": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@telc/mobile",
+  "name": "@fastrack/mobile",
   "main": "expo-router/entry",
   "version": "1.0.0",
   "private": true,
@@ -19,10 +19,10 @@
     "@jamsch/expo-speech-recognition": "^0.2.15",
     "@react-navigation/bottom-tabs": "^7.0.0",
     "@react-navigation/native": "^7.0.0",
-    "@telc/config": "workspace:*",
-    "@telc/content": "workspace:*",
-    "@telc/core": "workspace:*",
-    "@telc/types": "workspace:*",
+    "@fastrack/config": "workspace:*",
+    "@fastrack/content": "workspace:*",
+    "@fastrack/core": "workspace:*",
+    "@fastrack/types": "workspace:*",
     "date-fns": "^3.0.0",
     "expo": "^54.0.0",
     "expo-audio": "~1.1.1",
@@ -53,7 +53,7 @@
   "jest": {
     "preset": "jest-expo",
     "transformIgnorePatterns": [
-      "node_modules/(?!(?:\\.pnpm/.+/node_modules/)?(?:react-native|@react-native|expo|@expo|react-navigation|@react-navigation|@unimodules|unimodules|native-base|react-native-svg|@telc)/)"
+      "node_modules/(?!(?:\\.pnpm/.+/node_modules/)?(?:react-native|@react-native|expo|@expo|react-navigation|@react-navigation|@unimodules|unimodules|native-base|react-native-svg|@fastrack)/)"
     ],
     "moduleNameMapper": {
       "^react-native-reanimated$": "<rootDir>/src/__mocks__/reanimated.ts"

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -119,8 +119,8 @@ export default function HomeScreen() {
       {/* Header */}
       <View style={styles.header}>
         <View>
-          <Text style={styles.appTitle}>Telc FastTrack</Text>
-          <Text style={styles.appSubtitle}>German exam prep</Text>
+          <Text style={styles.appTitle}>Fastrack Deutsch</Text>
+          <Text style={styles.appSubtitle}>telc exam prep</Text>
         </View>
         <View style={[styles.levelBadge, { backgroundColor: levelColor }]}>
           <Text style={styles.levelBadgeText}>{level}</Text>

--- a/apps/mobile/src/services/contentLoader.ts
+++ b/apps/mobile/src/services/contentLoader.ts
@@ -1,5 +1,5 @@
-import type { MockExam } from '@telc/types';
-import { getMockId, validateMockExam } from '@telc/content';
+import type { MockExam } from '@fastrack/types';
+import { getMockId, validateMockExam } from '@fastrack/content';
 
 // Static asset map — dynamic require() is not supported by Metro bundler.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/mobile/src/services/database.ts
+++ b/apps/mobile/src/services/database.ts
@@ -1,5 +1,5 @@
 // SQLite database initialization and migrations
-// Source: telc-fasttrack-implementation-plan.md section 6
+// Source: fastrack-deutsch-implementation-plan.md section 6
 //
 // All database operations are async. Use execAsync, getAllAsync, getFirstAsync.
 // WAL mode is enabled for better concurrent read performance.
@@ -10,7 +10,7 @@ let db: SQLite.SQLiteDatabase | null = null;
 
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
   if (db) return db;
-  db = await SQLite.openDatabaseAsync('telcfasttrack.db');
+  db = await SQLite.openDatabaseAsync('fastrackdeutsch.db');
   await enableWAL(db);
   await runMigrations(db);
   return db;

--- a/apps/mobile/src/services/scoringEngine.ts
+++ b/apps/mobile/src/services/scoringEngine.ts
@@ -1,13 +1,13 @@
-// Re-export scoring logic from the shared @telc/core package.
+// Re-export scoring logic from the shared @fastrack/core package.
 export {
   calculateSectionScore,
   calculateExamScore,
   getReadinessLevel,
   formatScore,
-} from '@telc/core';
+} from '@fastrack/core';
 export type {
   SectionScore,
   ExamScore,
   QuestionResponse,
   ReadinessLevel,
-} from '@telc/core';
+} from '@fastrack/core';

--- a/apps/mobile/src/services/spacedRepetition.ts
+++ b/apps/mobile/src/services/spacedRepetition.ts
@@ -1,8 +1,8 @@
-// Re-export spaced repetition logic from the shared @telc/core package.
+// Re-export spaced repetition logic from the shared @fastrack/core package.
 export {
   calculateNextReview,
   isDueToday,
   getDaysUntilReview,
   getQualityLabel,
-} from '@telc/core';
-export type { SM2Result } from '@telc/core';
+} from '@fastrack/core';
+export type { SM2Result } from '@fastrack/core';

--- a/apps/mobile/src/services/timerService.ts
+++ b/apps/mobile/src/services/timerService.ts
@@ -1,7 +1,7 @@
-// Re-export pure timer logic from @telc/core.
+// Re-export pure timer logic from @fastrack/core.
 // The React hook (useExamTimer) stays here since it depends on React state.
-import { SECTION_DURATIONS, createTimerState, tickTimer, formatTime } from '@telc/core';
-import type { TimerState } from '@telc/core';
+import { SECTION_DURATIONS, createTimerState, tickTimer, formatTime } from '@fastrack/core';
+import type { TimerState } from '@fastrack/core';
 import { colors } from '../utils/theme';
 
 export { SECTION_DURATIONS, createTimerState, tickTimer, formatTime };

--- a/apps/mobile/src/services/vocabularyService.ts
+++ b/apps/mobile/src/services/vocabularyService.ts
@@ -1,6 +1,6 @@
 import { getDatabase } from './database';
-import type { VocabularyItem } from '@telc/types';
-import type { SM2Result } from '@telc/core';
+import type { VocabularyItem } from '@fastrack/types';
+import type { SM2Result } from '@fastrack/core';
 
 export async function seedVocabularyIfEmpty(
   level: string,

--- a/apps/mobile/src/types/exam.ts
+++ b/apps/mobile/src/types/exam.ts
@@ -1,4 +1,4 @@
-// Re-export all types from the shared @telc/types package.
+// Re-export all types from the shared @fastrack/types package.
 // Existing relative imports throughout the mobile app resolve here.
 export type {
   Level,
@@ -25,4 +25,4 @@ export type {
   GrammarExercise,
   ExamAttempt,
   UserProgress,
-} from '@telc/types';
+} from '@fastrack/types';

--- a/apps/mobile/src/utils/theme.ts
+++ b/apps/mobile/src/utils/theme.ts
@@ -1,4 +1,4 @@
-// Re-export all design tokens from the shared @telc/config package.
+// Re-export all design tokens from the shared @fastrack/config package.
 export {
   colors,
   typography,
@@ -7,4 +7,4 @@ export {
   shadows,
   MIN_TOUCH_TARGET,
   LEVEL_CONFIG,
-} from '@telc/config';
+} from '@fastrack/config';

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -5,14 +5,14 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
-      "@telc/types": ["../../packages/types/src/index.ts"],
-      "@telc/types/*": ["../../packages/types/src/*"],
-      "@telc/core": ["../../packages/core/src/index.ts"],
-      "@telc/core/*": ["../../packages/core/src/*"],
-      "@telc/config": ["../../packages/config/src/index.ts"],
-      "@telc/config/*": ["../../packages/config/src/*"],
-      "@telc/content": ["../../packages/content/src/index.ts"],
-      "@telc/content/*": ["../../packages/content/src/*"]
+      "@fastrack/types": ["../../packages/types/src/index.ts"],
+      "@fastrack/types/*": ["../../packages/types/src/*"],
+      "@fastrack/core": ["../../packages/core/src/index.ts"],
+      "@fastrack/core/*": ["../../packages/core/src/*"],
+      "@fastrack/config": ["../../packages/config/src/index.ts"],
+      "@fastrack/config/*": ["../../packages/config/src/*"],
+      "@fastrack/content": ["../../packages/content/src/index.ts"],
+      "@fastrack/content/*": ["../../packages/content/src/*"]
     }
   },
   "include": [

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,10 +6,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const nextConfig: NextConfig = {
   transpilePackages: [
-    "@telc/config",
-    "@telc/content",
-    "@telc/core",
-    "@telc/types",
+    "@fastrack/config",
+    "@fastrack/content",
+    "@fastrack/core",
+    "@fastrack/types",
   ],
   turbopack: {
     root: path.resolve(__dirname, "../../"),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@telc/web",
+  "name": "@fastrack/web",
   "version": "0.0.1",
   "private": true,
   "scripts": {
@@ -13,10 +13,10 @@
     "clean": "rm -rf .next .turbo node_modules"
   },
   "dependencies": {
-    "@telc/config": "workspace:*",
-    "@telc/content": "workspace:*",
-    "@telc/core": "workspace:*",
-    "@telc/types": "workspace:*",
+    "@fastrack/config": "workspace:*",
+    "@fastrack/content": "workspace:*",
+    "@fastrack/core": "workspace:*",
+    "@fastrack/types": "workspace:*",
     "next": "^15.3.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/apps/web/src/__tests__/exam/ListeningExam.test.tsx
+++ b/apps/web/src/__tests__/exam/ListeningExam.test.tsx
@@ -2,9 +2,9 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ListeningExam } from '../../components/exam/ListeningExam';
-import type { ListeningSection, ListeningPart } from '@telc/types';
+import type { ListeningSection, ListeningPart } from '@fastrack/types';
 
-vi.mock('@telc/core', () => ({
+vi.mock('@fastrack/core', () => ({
   SECTION_DURATIONS: { A1: { listening: 1200 } },
   calculateSectionScore: vi.fn(() => ({
     earned: 8,

--- a/apps/web/src/__tests__/exam/SprachbausteineExam.test.tsx
+++ b/apps/web/src/__tests__/exam/SprachbausteineExam.test.tsx
@@ -10,9 +10,9 @@ import type {
   SprachbausteineSection,
   SprachbausteinePart,
   SprachbausteineQuestion,
-} from '@telc/types';
+} from '@fastrack/types';
 
-vi.mock('@telc/core', () => ({
+vi.mock('@fastrack/core', () => ({
   SECTION_DURATIONS: {
     B1: { sprachbausteine: 15 * 60, reading: 75 * 60 },
     A1: { reading: 25 * 60 },

--- a/apps/web/src/__tests__/exam/calculateSectionScore.test.ts
+++ b/apps/web/src/__tests__/exam/calculateSectionScore.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { calculateSectionScore } from '@telc/core';
-import type { ListeningSection } from '@telc/types';
+import { calculateSectionScore } from '@fastrack/core';
+import type { ListeningSection } from '@fastrack/types';
 
 function makeSection(questions: { id: string; correctAnswer: string }[]): ListeningSection {
   return {

--- a/apps/web/src/__tests__/grammar/ExercisePlayer.test.tsx
+++ b/apps/web/src/__tests__/grammar/ExercisePlayer.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ExercisePlayer } from '../../components/grammar/ExercisePlayer';
-import type { GrammarExercise } from '@telc/types';
+import type { GrammarExercise } from '@fastrack/types';
 
 const fillBlank: GrammarExercise = {
   type: 'fill_blank',

--- a/apps/web/src/__tests__/grammar/TopicCard.test.tsx
+++ b/apps/web/src/__tests__/grammar/TopicCard.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { TopicCard } from '../../components/grammar/TopicCard';
-import type { GrammarTopic } from '@telc/types';
+import type { GrammarTopic } from '@fastrack/types';
 
 const mockTopic: GrammarTopic = {
   id: 1,

--- a/apps/web/src/__tests__/vocab/FlashcardSession.test.tsx
+++ b/apps/web/src/__tests__/vocab/FlashcardSession.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { FlashcardSession } from '../../components/vocab/FlashcardSession';
 import type { VocabularyWord } from '../../lib/loadVocabulary';
 
-vi.mock('@telc/core', () => ({
+vi.mock('@fastrack/core', () => ({
   calculateNextReview: vi.fn((quality: number) => ({
     easeFactor: quality >= 3 ? 2.6 : 2.1,
     intervalDays: quality >= 3 ? 1 : 0,
@@ -98,7 +98,7 @@ describe('FlashcardSession', () => {
   });
 
   it('calls calculateNextReview with correct args on grade', async () => {
-    const { calculateNextReview } = await import('@telc/core');
+    const { calculateNextReview } = await import('@fastrack/core');
     render(<FlashcardSession allWords={makeWords(25)} {...defaultProps} />);
     fireEvent.click(screen.getByTestId('start-review'));
     fireEvent.click(screen.getByTestId('flip-button'));

--- a/apps/web/src/app/exam/[mockId]/page.tsx
+++ b/apps/web/src/app/exam/[mockId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
-import { LEVEL_CONFIG } from "@telc/config";
-import { SECTION_DURATIONS, formatTime } from "@telc/core";
-import type { Level } from "@telc/types";
+import { LEVEL_CONFIG } from "@fastrack/config";
+import { SECTION_DURATIONS, formatTime } from "@fastrack/core";
+import type { Level } from "@fastrack/types";
 import { loadMockExam, parseMockId } from "@/lib/loadMockExam";
 import { SectionStatusBadge, SectionActionButton, ViewResultsLink } from "@/components/exam/SectionStatus";
 

--- a/apps/web/src/app/exam/[mockId]/results/page.tsx
+++ b/apps/web/src/app/exam/[mockId]/results/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 import { parseMockId } from '@/lib/loadMockExam';
-import type { Level } from '@telc/types';
+import type { Level } from '@fastrack/types';
 import { ExamResults } from '@/components/exam/ExamResults';
 
 export default async function ResultsPage({

--- a/apps/web/src/app/exam/page.tsx
+++ b/apps/web/src/app/exam/page.tsx
@@ -1,6 +1,6 @@
-import { LEVEL_CONFIG } from "@telc/config";
-import { getMocksForLevel, getAvailableLevels } from "@telc/content";
-import type { Level } from "@telc/types";
+import { LEVEL_CONFIG } from "@fastrack/config";
+import { getMocksForLevel, getAvailableLevels } from "@fastrack/content";
+import type { Level } from "@fastrack/types";
 
 export default function ExamListPage({
   searchParams,

--- a/apps/web/src/app/grammar/GrammarPageClient.tsx
+++ b/apps/web/src/app/grammar/GrammarPageClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import type { Level, GrammarTopic } from '@telc/types';
+import type { Level, GrammarTopic } from '@fastrack/types';
 import { TopicCard } from '@/components/grammar/TopicCard';
 
 interface LevelConfig {

--- a/apps/web/src/app/grammar/[topicId]/TopicDetailPage.tsx
+++ b/apps/web/src/app/grammar/[topicId]/TopicDetailPage.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import type { GrammarTopic } from '@telc/types';
+import type { GrammarTopic } from '@fastrack/types';
 import { TopicDetail } from '@/components/grammar/TopicDetail';
 import { ExercisePlayer } from '@/components/grammar/ExercisePlayer';
 

--- a/apps/web/src/app/grammar/page.tsx
+++ b/apps/web/src/app/grammar/page.tsx
@@ -1,5 +1,5 @@
-import { LEVEL_CONFIG } from '@telc/config';
-import type { Level } from '@telc/types';
+import { LEVEL_CONFIG } from '@fastrack/config';
+import type { Level } from '@fastrack/types';
 import { loadGrammar } from '@/lib/loadGrammar';
 import { GrammarPageClient } from './GrammarPageClient';
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,9 +2,15 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "telc FastTrack — German Exam Prep",
+  title: "Fastrack Deutsch — German Exam Prep",
   description:
-    "Spend X hours. Pass telc. Practice mock exams, vocabulary, and grammar for telc A1 through C1.",
+    "Spend X hours. Pass the telc exam. Practice mock exams, vocabulary, and grammar for telc A1 through C1.",
+  openGraph: {
+    title: "Fastrack Deutsch — German Exam Prep",
+    description:
+      "Spend X hours. Pass the telc exam. Practice mock exams, vocabulary, and grammar for telc A1 through C1.",
+    type: "website",
+  },
 };
 
 export default function RootLayout({
@@ -32,9 +38,9 @@ function NavHeader() {
     <header className="sticky top-0 z-50 border-b border-[#e0e0e0] bg-white/95 backdrop-blur-sm">
       <nav className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <a href="/" className="flex items-center gap-2">
-          <span className="text-2xl font-bold text-brand-primary">telc</span>
+          <span className="text-2xl font-bold text-brand-primary">Fastrack</span>
           <span className="text-lg font-medium text-text-secondary">
-            FastTrack
+            Deutsch
           </span>
         </a>
 
@@ -80,7 +86,7 @@ function Footer() {
   return (
     <footer className="border-t border-[#e0e0e0] bg-white py-6">
       <div className="mx-auto max-w-7xl px-4 text-center text-sm text-text-secondary sm:px-6 lg:px-8">
-        telc FastTrack — German exam prep. Offline-first, content-driven.
+        Fastrack Deutsch — telc exam prep. Offline-first, content-driven.
       </div>
     </footer>
   );

--- a/apps/web/src/app/vocab/page.tsx
+++ b/apps/web/src/app/vocab/page.tsx
@@ -1,5 +1,5 @@
-import { LEVEL_CONFIG } from '@telc/config';
-import type { Level } from '@telc/types';
+import { LEVEL_CONFIG } from '@fastrack/config';
+import type { Level } from '@fastrack/types';
 import { loadVocabulary } from '@/lib/loadVocabulary';
 import { VocabPageClient } from './VocabPageClient';
 

--- a/apps/web/src/components/dashboard/Dashboard.tsx
+++ b/apps/web/src/components/dashboard/Dashboard.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import type { Level } from '@telc/types';
-import { LEVEL_CONFIG } from '@telc/config';
-import { getReadinessLevel } from '@telc/core';
-import { getMocksForLevel } from '@telc/content';
-import { SECTION_DURATIONS } from '@telc/core';
+import type { Level } from '@fastrack/types';
+import { LEVEL_CONFIG } from '@fastrack/config';
+import { getReadinessLevel } from '@fastrack/core';
+import { getMocksForLevel } from '@fastrack/content';
+import { SECTION_DURATIONS } from '@fastrack/core';
 import {
   getSession,
   hasAnySection,

--- a/apps/web/src/components/dashboard/ReadinessGauge.tsx
+++ b/apps/web/src/components/dashboard/ReadinessGauge.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ReadinessLevel } from '@telc/core';
+import type { ReadinessLevel } from '@fastrack/core';
 
 const READINESS_LABELS: Record<ReadinessLevel, string> = {
   building: 'Aufbau',

--- a/apps/web/src/components/exam/ExamResults.tsx
+++ b/apps/web/src/components/exam/ExamResults.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import type { Level } from '@telc/types';
+import type { Level } from '@fastrack/types';
 import { getSession, clearSession, hasAnySection } from '@/lib/examSession';
 import type { ExamSessionState, SectionResult } from '@/lib/examSession';
 

--- a/apps/web/src/components/exam/ExamTimer.tsx
+++ b/apps/web/src/components/exam/ExamTimer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { formatTime } from '@telc/core';
+import { formatTime } from '@fastrack/core';
 
 interface ExamTimerProps {
   totalSeconds: number;

--- a/apps/web/src/components/exam/ListeningExam.tsx
+++ b/apps/web/src/components/exam/ListeningExam.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
-import { SECTION_DURATIONS, calculateSectionScore } from '@telc/core';
-import type { ListeningSection, Level } from '@telc/types';
+import { SECTION_DURATIONS, calculateSectionScore } from '@fastrack/core';
+import type { ListeningSection, Level } from '@fastrack/types';
 import type { ExamPhase } from '@/lib/examTypes';
 import { saveSection } from '@/lib/examSession';
 import { ExamTimer } from './ExamTimer';

--- a/apps/web/src/components/exam/PrepTimer.tsx
+++ b/apps/web/src/components/exam/PrepTimer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { formatTime } from '@telc/core';
+import { formatTime } from '@fastrack/core';
 
 interface PrepTimerProps {
   totalSeconds: number;

--- a/apps/web/src/components/exam/ReadingExam.tsx
+++ b/apps/web/src/components/exam/ReadingExam.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
-import { SECTION_DURATIONS, calculateSectionScore } from '@telc/core';
-import type { ReadingSection, ReadingPart, Level } from '@telc/types';
+import { SECTION_DURATIONS, calculateSectionScore } from '@fastrack/core';
+import type { ReadingSection, ReadingPart, Level } from '@fastrack/types';
 import type { ExamPhase } from '@/lib/examTypes';
 import { saveSection } from '@/lib/examSession';
 import { ExamTimer } from './ExamTimer';

--- a/apps/web/src/components/exam/SpeakingExam.tsx
+++ b/apps/web/src/components/exam/SpeakingExam.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
-import { SECTION_DURATIONS } from '@telc/core';
-import type { SectionScore } from '@telc/core';
-import type { SpeakingSection, Level } from '@telc/types';
+import { SECTION_DURATIONS } from '@fastrack/core';
+import type { SectionScore } from '@fastrack/core';
+import type { SpeakingSection, Level } from '@fastrack/types';
 import type { ExamPhase } from '@/lib/examTypes';
 import { saveSection } from '@/lib/examSession';
 import { ExamTimer } from './ExamTimer';

--- a/apps/web/src/components/exam/SprachbausteineExam.tsx
+++ b/apps/web/src/components/exam/SprachbausteineExam.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
-import { SECTION_DURATIONS, scoreSprachbausteine } from '@telc/core';
+import { SECTION_DURATIONS, scoreSprachbausteine } from '@fastrack/core';
 import type {
   SprachbausteineSection,
   SprachbausteinePart,
   SprachbausteineQuestion,
   Level,
-} from '@telc/types';
+} from '@fastrack/types';
 import type { ExamPhase } from '@/lib/examTypes';
 import { saveSection } from '@/lib/examSession';
 import { ExamTimer } from './ExamTimer';

--- a/apps/web/src/components/exam/WritingExam.tsx
+++ b/apps/web/src/components/exam/WritingExam.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
-import { SECTION_DURATIONS } from '@telc/core';
-import type { SectionScore } from '@telc/core';
-import type { WritingSection, Level } from '@telc/types';
+import { SECTION_DURATIONS } from '@fastrack/core';
+import type { SectionScore } from '@fastrack/core';
+import type { WritingSection, Level } from '@fastrack/types';
 import type { ExamPhase } from '@/lib/examTypes';
 import { saveSection } from '@/lib/examSession';
 import { ExamTimer } from './ExamTimer';

--- a/apps/web/src/components/grammar/ExercisePlayer.tsx
+++ b/apps/web/src/components/grammar/ExercisePlayer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback, useMemo } from 'react';
-import type { GrammarExercise } from '@telc/types';
+import type { GrammarExercise } from '@fastrack/types';
 
 interface ExercisePlayerProps {
   exercises: GrammarExercise[];

--- a/apps/web/src/components/grammar/TopicCard.tsx
+++ b/apps/web/src/components/grammar/TopicCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import type { GrammarTopic } from '@telc/types';
+import type { GrammarTopic } from '@fastrack/types';
 
 interface TopicCardProps {
   topic: GrammarTopic;

--- a/apps/web/src/components/grammar/TopicDetail.tsx
+++ b/apps/web/src/components/grammar/TopicDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { GrammarTopic } from '@telc/types';
+import type { GrammarTopic } from '@fastrack/types';
 
 interface TopicDetailProps {
   topic: GrammarTopic;

--- a/apps/web/src/components/vocab/FlashcardSession.tsx
+++ b/apps/web/src/components/vocab/FlashcardSession.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState, useCallback, useMemo, useRef } from 'react';
-import { calculateNextReview, getQualityLabel } from '@telc/core';
-import type { SM2Result } from '@telc/core';
+import { calculateNextReview, getQualityLabel } from '@fastrack/core';
+import type { SM2Result } from '@fastrack/core';
 import type { VocabularyWord } from '@/lib/loadVocabulary';
 import { FlashCard } from './FlashCard';
 

--- a/apps/web/src/lib/examSession.ts
+++ b/apps/web/src/lib/examSession.ts
@@ -1,5 +1,5 @@
-import type { SectionScore } from '@telc/core';
-import type { Level } from '@telc/types';
+import type { SectionScore } from '@fastrack/core';
+import type { Level } from '@fastrack/types';
 
 export interface SectionResult {
   answers: Record<string, string>;

--- a/apps/web/src/lib/loadGrammar.ts
+++ b/apps/web/src/lib/loadGrammar.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'fs/promises';
 import path from 'path';
-import type { GrammarTopic } from '@telc/types';
+import type { GrammarTopic } from '@fastrack/types';
 
 const GRAMMAR_DIR =
   process.env.GRAMMAR_DIR ??

--- a/apps/web/src/lib/loadMockExam.ts
+++ b/apps/web/src/lib/loadMockExam.ts
@@ -1,8 +1,8 @@
 import { readFile } from 'fs/promises';
 import path from 'path';
 import { notFound } from 'next/navigation';
-import { validateMockExam } from '@telc/content';
-import type { MockExam } from '@telc/types';
+import { validateMockExam } from '@fastrack/content';
+import type { MockExam } from '@fastrack/types';
 
 // process.cwd() = apps/web/ when Next.js runs; ../mobile resolves to apps/mobile/
 const CONTENT_DIR =

--- a/fastrack-deutsch-implementation-plan.md
+++ b/fastrack-deutsch-implementation-plan.md
@@ -1,4 +1,6 @@
-# Telc-FastTrack — Complete Implementation Plan for Claude Code
+# Fastrack Deutsch — Complete Implementation Plan for Claude Code
+
+> **Note:** This product was formerly referred to as "Telc-FastTrack" in earlier drafts of this document. The brand is now **Fastrack Deutsch**. Historical references to the old name below are preserved for context.
 
 > **App Vision:** "Spend X hours. Pass telc." — A practical, exam-focused German language prep app that consolidates mock exams, drills, and resources so candidates can pass telc A1 through C1 with focused study.
 >

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "telc-fasttrack",
+  "name": "fastrack-deutsch",
   "private": true,
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",
-    "dev:web": "turbo run dev --filter=@telc/web",
-    "dev:mobile": "turbo run dev --filter=@telc/mobile",
+    "dev:web": "turbo run dev --filter=@fastrack/web",
+    "dev:mobile": "turbo run dev --filter=@fastrack/mobile",
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@telc/config",
+  "name": "@fastrack/config",
   "version": "0.0.1",
   "private": true,
   "main": "./src/index.ts",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@telc/content",
+  "name": "@fastrack/content",
   "version": "0.0.1",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "dependencies": {
-    "@telc/types": "workspace:*"
+    "@fastrack/types": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^5.8.0",

--- a/packages/content/src/catalog.ts
+++ b/packages/content/src/catalog.ts
@@ -1,4 +1,4 @@
-import type { Level } from '@telc/types';
+import type { Level } from '@fastrack/types';
 
 export interface MockExamEntry {
   id: string;

--- a/packages/content/src/validation.ts
+++ b/packages/content/src/validation.ts
@@ -1,4 +1,4 @@
-import type { MockExam } from '@telc/types';
+import type { MockExam } from '@fastrack/types';
 
 export function getMockId(level: string, mockNumber: number): string {
   const padded = String(mockNumber).padStart(2, '0');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@telc/core",
+  "name": "@fastrack/core",
   "version": "0.0.1",
   "private": true,
   "main": "./src/index.ts",
@@ -10,7 +10,7 @@
     "test:coverage": "vitest run --coverage --passWithNoTests"
   },
   "dependencies": {
-    "@telc/types": "workspace:*"
+    "@fastrack/types": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^5.8.0",

--- a/packages/core/src/scoring.ts
+++ b/packages/core/src/scoring.ts
@@ -3,7 +3,7 @@ import type {
   ListeningSection,
   ReadingSection,
   SprachbausteineSection,
-} from '@telc/types';
+} from '@fastrack/types';
 
 export interface SectionScore {
   earned: number;

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@telc/types",
+  "name": "@fastrack/types",
   "version": "0.0.1",
   "private": true,
   "main": "./src/index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,18 @@ importers:
       '@expo/vector-icons':
         specifier: ^15.0.3
         version: 15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      '@fastrack/config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@fastrack/content':
+        specifier: workspace:*
+        version: link:../../packages/content
+      '@fastrack/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@fastrack/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       '@jamsch/expo-speech-recognition':
         specifier: ^0.2.15
         version: 0.2.15(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
@@ -29,18 +41,6 @@ importers:
       '@react-navigation/native':
         specifier: ^7.0.0
         version: 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
-      '@telc/config':
-        specifier: workspace:*
-        version: link:../../packages/config
-      '@telc/content':
-        specifier: workspace:*
-        version: link:../../packages/content
-      '@telc/core':
-        specifier: workspace:*
-        version: link:../../packages/core
-      '@telc/types':
-        specifier: workspace:*
-        version: link:../../packages/types
       date-fns:
         specifier: ^3.0.0
         version: 3.6.0
@@ -117,16 +117,16 @@ importers:
 
   apps/web:
     dependencies:
-      '@telc/config':
+      '@fastrack/config':
         specifier: workspace:*
         version: link:../../packages/config
-      '@telc/content':
+      '@fastrack/content':
         specifier: workspace:*
         version: link:../../packages/content
-      '@telc/core':
+      '@fastrack/core':
         specifier: workspace:*
         version: link:../../packages/core
-      '@telc/types':
+      '@fastrack/types':
         specifier: workspace:*
         version: link:../../packages/types
       next:
@@ -190,7 +190,7 @@ importers:
 
   packages/content:
     dependencies:
-      '@telc/types':
+      '@fastrack/types':
         specifier: workspace:*
         version: link:../types
     devDependencies:
@@ -203,7 +203,7 @@ importers:
 
   packages/core:
     dependencies:
-      '@telc/types':
+      '@fastrack/types':
         specifier: workspace:*
         version: link:../types
     devDependencies:


### PR DESCRIPTION
Closes #48.

## Summary

Rebrands the product from **telc FastTrack** / `@telc/*` to **Fastrack Deutsch** / `@fastrack/*`. The domain `fastrack-deutsch.de` is acquired; the original brand risked trademark conflict with telc gGmbH since the repo is public. Descriptive "telc A1 / telc exam" references are preserved as fair use.

## Scope

- **Package names** (`packages/*/package.json`): `@telc/{types,core,config,content}` → `@fastrack/{types,core,config,content}`. Dir names unchanged.
- **Workspace deps**: every `"@telc/*": "workspace:*"` in `apps/web`, `apps/mobile`, and cross-package `package.json` now uses `@fastrack/*`.
- **Imports**: all `.ts` / `.tsx` / `.json` / `.js` in `apps/` and `packages/` swept from `@telc/` to `@fastrack/` (45 files).
- **Root `package.json`** name: `telc-fasttrack` → `fastrack-deutsch`. Scripts updated to new workspace filters.
- **Configs** updated to match: `apps/web/next.config.ts` `transpilePackages`, `apps/mobile/tsconfig.json` paths, `apps/mobile/package.json` jest `transformIgnorePatterns`, `.github/workflows/ci.yml` test filter.
- **User-facing strings** → "Fastrack Deutsch":
  - `apps/web/src/app/layout.tsx`: `<title>`, `description`, OG tags, nav header, footer.
  - `apps/mobile/app.json`: `name`, `slug`, `scheme`.
  - `apps/mobile/src/app/(tabs)/index.tsx`: hero title + subtitle.
  - `apps/mobile/src/services/database.ts`: DB filename `telcfasttrack.db` → `fastrackdeutsch.db` + source comment.
- **Doc rename** via `git mv`: `telc-fasttrack-implementation-plan.md` → `fastrack-deutsch-implementation-plan.md`; H1 updated with a note that the old name is preserved in historical body text.

## Out of scope

- `.planning/` historical archive — untouched.
- `CLAUDE.md` and `.claude/` agent configs — untouched (orchestrator updates separately).
- `apps/mobile/app.json` iOS `bundleIdentifier` / Android `package` (`com.telcfasttrack.app`) — left alone. Changing published app-store identifiers is a deliberate migration decision; flagged as follow-up.
- GitHub repo rename, Vercel project config, DNS — user handles post-merge.

## AC verification

- `pnpm install` — clean, lockfile regenerated.
- `pnpm typecheck` — 2/2 green (`@fastrack/web`, `@fastrack/mobile`).
- `pnpm turbo run test --filter='!@fastrack/mobile'` (CI's filter) — 152/152 web tests pass; `@fastrack/core` has no tests; `@fastrack/content` has no tests. Mobile test failures are pre-existing on `main` (expo-modules-core ESM parse issue) and filtered out of CI.
- `pnpm build` — web build green, 14 routes generated.
- `grep -r "@telc/" apps packages` → 0 results.
- `grep -rn "telc FastTrack\|Telc FastTrack\|Telc-FastTrack" apps packages` → 0 results.
- `grep -rn "telc A1\|telc A2\|telc exam" apps packages` → 26 descriptive mentions preserved.

## Risks

- `pnpm-lock.yaml` regenerated to reflect new package names — expected.
- Mobile Expo `scheme` changed from `telc-fasttrack` to `fastrack-deutsch` — any existing dev builds need a rebuild for deep links.
- Mobile SQLite filename changed from `telcfasttrack.db` to `fastrackdeutsch.db` — first-run will start with a fresh DB. No production users so no data migration concern.

## Test plan

- [ ] CI green on PR
- [ ] Vercel preview renders with "Fastrack Deutsch" in header, title, footer
- [ ] No `@telc/` import errors surface in build logs