### PR TITLE
feat(ui): design tokens + typography foundation (#50)

### DIFF
--- a/.planning/ACTIVITY-LOG.md
+++ b/.planning/ACTIVITY-LOG.md
@@ -39,3 +39,5 @@ HH:MM | agent-name | START/DONE/BLOCKED | work-item-id | description
 21:48 | ux-engineer | DONE | #33 | audio player for Listening section — PR #34, all 4 CI checks green
 16:09 | implementation-lead | START | #48 | rebrand to Fastrack Deutsch
 16:20 | implementation-lead | DONE  | #48 | rebrand complete — PR #49 all 4 CI checks green, handoff at .planning/handoffs/2026-04-20-rebrand-to-fastrack-deutsch-handoff.md
+17:05 | ux-engineer | START | #50 | Phase 1 — design tokens + typography foundation (worktree ui-upgrade-phase1-tokens-typography)
+17:45 | ux-engineer | DONE  | #50 | design tokens + typography foundation — typecheck+tests+build all green locally, 12 new token tests, 164 web tests passing

--- a/.planning/handoffs/2026-04-20-ux-phase1-tokens-typography.md
+++ b/.planning/handoffs/2026-04-20-ux-phase1-tokens-typography.md
@@ -1,0 +1,156 @@
+# UX Phase 1 — Tokens + Typography Foundation
+
+**Issue:** #50
+**Branch:** `ui-upgrade-phase1-tokens-typography`
+**Date:** 2026-04-20
+**Agent:** ux-engineer
+
+## What was built
+
+Replaced the web design token layer and wired proper fonts via `next/font`.
+No component visual redesign in this PR — this is the substrate phases 2–4
+build against. Existing screens (`/`, `/exam`, `/vocab`, `/grammar`) continue
+to render with the new palette applied.
+
+## What changed
+
+### `packages/config/src/theme.ts`
+
+- Structured `colors` export: `brand` (11-step), `neutral` (13-step including the
+  150 half-step), `level` (a1–c1 with `solid` / `surface` / `text` triple),
+  `semantic` (success/warning/error/info/pass/fail/timer/streak/readiness),
+  `text` (primary/secondary/tertiary/disabled/onBrand/onLevel), `surfaces`
+  (background/surface/surfaceRaised/surfaceContainer/surfaceContainerHi),
+  `borders` (default/hover/focus).
+- Structured group names are `surfaces` / `borders` (plural) instead of
+  `surface` / `border` — the singular names clash with the flat legacy keys
+  that the mobile app reads (`colors.surface`, `colors.border`). Noted in
+  the token file; the orchestrator can decide whether to migrate the mobile
+  app off the flat keys later, which would free up the singular names.
+- Legacy flat keys (`primary`, `primaryLight`, `levelA1`, `textPrimary`, etc.)
+  kept and re-pointed at the new palette values — zero mobile breakage.
+- `streakFire`, `streakText`, `streakBackground` marked `@deprecated` via
+  JSDoc and remapped to brand-tint values (no more orange fire color).
+- `typography.fontFamily` now references CSS variables
+  (`var(--font-sans)` / `var(--font-display)` / `var(--font-mono)`).
+- `typography.fontSize` gained named keys (`display`, `h1`, `h2`, …, `mono`)
+  per tokens.md; legacy numeric keys retained for mobile.
+- `typography.lineHeight` + `typography.letterSpacing` expanded per spec.
+- `spacing` gained `2xs: 2` and `6xl: 80`.
+- New exports: `shadow` (web CSS strings: `sm`/`md`/`lg`/`xl`),
+  `duration` (motion tokens in ms), `easing` (cubic-bezier strings).
+- `LEVEL_CONFIG` entries now also carry `surface` and `textColor` alongside
+  the existing `color`.
+
+### `apps/web/src/app/globals.css`
+
+- Full `@theme` rewrite per tokens.md: all brand, neutral, level,
+  surface, border, text, interactive, status, pass/fail, timer, streak,
+  and readiness CSS variables declared.
+- `--font-sans` / `--font-display` / `--font-mono` chains declared with
+  system fallbacks. next/font exposes `--font-sans-var` etc. which feed
+  into those chains, so Google Font failure still renders readably.
+- Dark-mode block via `@media (prefers-color-scheme: dark)` — remaps
+  semantic surface/text/border/interactive tokens, palette stays static.
+  (No toggle in-product for Phase 1; system preference only.)
+- `color-scheme: light dark` on `:root` so form controls track the scheme.
+- German hyphenation: `[lang="de"] { hyphens: auto }`, headings opt out
+  to prevent breaks in compound words.
+- `.font-display` and `.font-mono` utility classes emitted.
+- Legacy Tailwind tokens kept (`--color-brand-primary`,
+  `--color-text-primary`, `--color-level-a1`, etc.) so existing utility
+  classes across all components continue to resolve without component
+  changes — just remapped to new hex values.
+
+### `apps/web/src/app/layout.tsx`
+
+- `DM_Sans` (weights 400/500/600), `Instrument_Serif` (400), and
+  `JetBrains_Mono` (400) wired via `next/font/google`; all `display: 'swap'`.
+- CSS variables `--font-sans-var` / `--font-display-var` / `--font-mono-var`
+  applied to `<html>`.
+- Hardcoded `bg-[#f5f5f5]` replaced with `bg-background` (resolves to the
+  new `--color-background` = `#f7f7f8`).
+- Hardcoded `border-[#e0e0e0]` on header and footer replaced with
+  `border-border` (resolves to `--color-border` = `#d9d9db`).
+- Wordmark weight changed from `font-bold` to `font-semibold` per
+  brand.md: "Fastrack" and "Deutsch" are equal partners in a single-
+  weight wordmark. Full logo mark (fd monogram) is deferred to a later
+  phase — brand.md explicitly says Phase 1 does not introduce the mark.
+
+### Tests
+
+- New `apps/web/src/__tests__/design-tokens.test.ts` — 12 assertions:
+  - globals.css emits `--color-brand-600: #1a3a5c` (anchor)
+  - globals.css emits `--color-level-a1-solid: #2d8a4e` (WCAG AA pass)
+  - Full brand scale (50–950) present
+  - Full neutral scale (0–950 including 150) present
+  - Every CEFR level has `solid`/`surface`/`text`
+  - `--font-sans` / `--font-display` / `--font-mono` chains wired
+  - Dark-mode `@media` block present
+  - German hyphenation rule present
+  - `@fastrack/config` exports the structured brand / level colors
+  - Legacy flat exports stay in sync (mobile compat)
+  - Readiness stages use the brand scale, not the deprecated orange
+
+## Files touched (6)
+
+1. `packages/config/src/theme.ts`
+2. `packages/config/src/index.ts`
+3. `apps/web/src/app/globals.css`
+4. `apps/web/src/app/layout.tsx`
+5. `apps/web/src/__tests__/design-tokens.test.ts` (new)
+6. `.planning/ACTIVITY-LOG.md`
+7. `.planning/handoffs/2026-04-20-ux-phase1-tokens-typography.md` (this file)
+
+## Verification
+
+- `pnpm typecheck` — green
+- `pnpm turbo run test --filter='!@fastrack/mobile'` — 164/164 passing
+  (12 new + 152 existing)
+- `pnpm --filter @fastrack/web build` — green, 7 routes prerendered,
+  total first-load JS unchanged materially by font injection
+- `pnpm --filter @fastrack/mobile test` — fails on both main and this
+  branch with the same `expo-modules-core` ESM parse error. Pre-existing,
+  and CI explicitly excludes mobile via `--filter='!@fastrack/mobile'`.
+
+## Follow-ups discovered
+
+1. **Tailwind utility renaming.** Current component call sites use legacy
+   utility names like `bg-brand-primary`, `text-text-primary`, `bg-level-a1`.
+   These still work because the legacy CSS variables are kept in `@theme`.
+   A future PR can migrate call sites to the new structured names
+   (`bg-brand-600`, `text-primary`, `bg-level-a1-solid`) and then remove
+   the legacy aliases. Not urgent — no functional gain, only ergonomic.
+2. **Mobile flat-key migration.** Mobile reads `colors.surface` and
+   `colors.border` directly. Keeping these forces the structured groups
+   to use plural `surfaces` / `borders`. Once mobile is migrated to a
+   different access pattern, we can rename back to singular.
+3. **Streak UI.** The streak visual (currently fire emoji + orange) still
+   uses the deprecated tokens. Token values have been remapped to a calm
+   brand tint, so the component looks different but still renders. The
+   full redesign (calendar-grid treatment per brand.md) belongs in the
+   next UI pass.
+4. **`@variant dark` instead of media query.** tokens.md notes a class-
+   based dark toggle would require `darkMode: 'class'` wiring and a UI
+   switch. Phase 1 uses the media query for zero-wire-up. When the app
+   gains a user preference toggle, swap in the `@variant` approach.
+5. **Font payload budget.** JetBrains Mono is loaded as the full Latin
+   subset, not digit-only. tokens.md recommended subsetting to
+   `U+0030-0039, U+003A` for the timer. `next/font` doesn't support
+   glyph-level subsetting out of the box; leaving as-is for now
+   (~45–60 KB gzipped total, within the spec tolerance).
+
+## Phases 2–4 unblocked
+
+- Phase 2 (#51 dashboard redesign) can consume
+  `bg-brand-50`, `text-brand-600`, `bg-level-a1-surface`,
+  `text-level-a1-text`, `text-success`, `bg-readiness-ready`, etc.
+  directly as Tailwind utilities.
+- Phase 3 (#52 mocks runner) can use `text-timer-default`, the new
+  `.font-mono` utility for the timer, and `bg-pass-surface` /
+  `bg-fail-surface` for results.
+- Phase 4 (#53 vocab + grammar + results) can use the `.font-display`
+  utility for the results hero and the full level token triple for
+  per-level theming.
+- Motion constants (`duration.slow`, `easing.spring`) are now importable
+  from `@fastrack/config` for the flashcard flip.

--- a/apps/web/src/__tests__/design-tokens.test.ts
+++ b/apps/web/src/__tests__/design-tokens.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { colors } from '@fastrack/config';
+
+/**
+ * Phase 1 design-token invariants.
+ *
+ * These assertions guard the tokens.md contract: hex values are not free to
+ * drift silently, and the CSS/TS sources must stay in sync.
+ */
+
+const cssPath = path.resolve(__dirname, '../app/globals.css');
+const css = readFileSync(cssPath, 'utf8');
+
+describe('globals.css design tokens', () => {
+  it('emits the brand palette anchor', () => {
+    expect(css).toMatch(/--color-brand-600:\s*#1a3a5c/);
+  });
+
+  it('emits the revised A1 level solid (WCAG AA pass)', () => {
+    expect(css).toMatch(/--color-level-a1-solid:\s*#2d8a4e/);
+  });
+
+  it('emits the full 10-step brand scale', () => {
+    for (const step of [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950]) {
+      expect(css).toMatch(new RegExp(`--color-brand-${step}:`));
+    }
+  });
+
+  it('emits the full neutral scale including the 150 step', () => {
+    for (const step of [0, 50, 100, 150, 200, 300, 400, 500, 600, 700, 800, 900, 950]) {
+      expect(css).toMatch(new RegExp(`--color-neutral-${step}:`));
+    }
+  });
+
+  it('emits level tokens for every CEFR level with solid/surface/text triple', () => {
+    for (const lvl of ['a1', 'a2', 'b1', 'b2', 'c1']) {
+      expect(css).toMatch(new RegExp(`--color-level-${lvl}-solid:`));
+      expect(css).toMatch(new RegExp(`--color-level-${lvl}-surface:`));
+      expect(css).toMatch(new RegExp(`--color-level-${lvl}-text:`));
+    }
+  });
+
+  it('wires next/font CSS variables through --font-sans/-display/-mono', () => {
+    expect(css).toMatch(/--font-sans:\s*var\(--font-sans-var\)/);
+    expect(css).toMatch(/--font-display:\s*var\(--font-display-var\)/);
+    expect(css).toMatch(/--font-mono:\s*var\(--font-mono-var\)/);
+  });
+
+  it('defines a dark-mode block that remaps semantic surface/text', () => {
+    expect(css).toMatch(/@media \(prefers-color-scheme: dark\)/);
+  });
+
+  it('applies German hyphenation with heading override', () => {
+    expect(css).toMatch(/\[lang="de"\][\s\S]*hyphens:\s*auto/);
+  });
+});
+
+describe('@fastrack/config colors export', () => {
+  it('exposes the structured brand scale', () => {
+    expect(colors.brand[600]).toBe('#1a3a5c');
+    expect(colors.brand[500]).toBe('#1e5599');
+  });
+
+  it('exposes WCAG-revised level solids', () => {
+    expect(colors.level.a1.solid).toBe('#2d8a4e');
+    expect(colors.level.b1.solid).toBe('#b86200');
+    expect(colors.level.c1.solid).toBe('#6b2fa0');
+  });
+
+  it('keeps legacy flat exports in sync for mobile consumers', () => {
+    expect(colors.primary).toBe(colors.brand[600]);
+    expect(colors.primaryLight).toBe(colors.brand[500]);
+    expect(colors.levelA1).toBe(colors.level.a1.solid);
+    expect(colors.textPrimary).toBe(colors.neutral[700]);
+  });
+
+  it('sets readiness stages that do not alias the deprecated streak-fire orange', () => {
+    expect(colors.readinessDeveloping).toBe(colors.brand[500]);
+    expect(colors.readinessReady).toBe(colors.semantic.success);
+  });
+});

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,63 +1,211 @@
 @import "tailwindcss";
 
+/* ------------------------------------------------------------------ */
+/* Fastrack Deutsch — Design Tokens (Phase 1)                         */
+/* Source: .planning/design-system/tokens.md                          */
+/* Palette tokens are static; semantic tokens remap in dark mode.     */
+/* ------------------------------------------------------------------ */
+
 @theme {
-  /* Brand */
-  --color-brand-primary: #1a3a5c;
-  --color-brand-primary-light: #2a5298;
-  --color-brand-primary-surface: #e8f0fe;
+  /* -- Fonts ------------------------------------------------------- */
+  --font-sans: var(--font-sans-var), system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-display: var(--font-display-var), Georgia, "Times New Roman", serif;
+  --font-mono: var(--font-mono-var), ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
 
-  /* Levels */
-  --color-level-a1: #4caf50;
-  --color-level-a2: #8bc34a;
-  --color-level-b1: #ff9800;
-  --color-level-b2: #ff5722;
-  --color-level-c1: #9c27b0;
+  /* -- Brand palette (Ink Navy) ------------------------------------ */
+  --color-brand-50: #eef2f8;
+  --color-brand-100: #d5e0ef;
+  --color-brand-200: #a8bfdf;
+  --color-brand-300: #7099c8;
+  --color-brand-400: #3d72b0;
+  --color-brand-500: #1e5599;
+  --color-brand-600: #1a3a5c;
+  --color-brand-700: #152e4a;
+  --color-brand-800: #0e2038;
+  --color-brand-900: #081527;
+  --color-brand-950: #040c18;
 
-  /* Semantic */
-  --color-success: #2e7d32;
-  --color-success-light: #e8f5e9;
-  --color-warning: #f57c00;
-  --color-warning-light: #fff3e0;
-  --color-error: #c62828;
-  --color-error-light: #ffebee;
+  /* -- Neutral palette --------------------------------------------- */
+  --color-neutral-0: #ffffff;
+  --color-neutral-50: #f7f7f8;
+  --color-neutral-100: #f0f0f1;
+  --color-neutral-150: #e8e8ea;
+  --color-neutral-200: #d9d9db;
+  --color-neutral-300: #c0c0c3;
+  --color-neutral-400: #9a9a9e;
+  --color-neutral-500: #6b6b70;
+  --color-neutral-600: #48484e;
+  --color-neutral-700: #2e2e34;
+  --color-neutral-800: #1c1c21;
+  --color-neutral-900: #101013;
+  --color-neutral-950: #08080a;
 
-  /* Pass / Fail */
-  --color-pass: #2e7d32;
-  --color-fail: #c62828;
-  --color-pass-light: #e8f5e9;
-  --color-fail-light: #ffebee;
+  /* -- CEFR level colors (WCAG AA on white text) ------------------- */
+  --color-level-a1-solid: #2d8a4e;
+  --color-level-a1-surface: #eaf7ef;
+  --color-level-a1-text: #1a5c34;
+  --color-level-a2-solid: #5e8a1a;
+  --color-level-a2-surface: #f1f7e6;
+  --color-level-a2-text: #3d5c10;
+  --color-level-b1-solid: #b86200;
+  --color-level-b1-surface: #fff4e6;
+  --color-level-b1-text: #7a4200;
+  --color-level-b2-solid: #c0390b;
+  --color-level-b2-surface: #fdeee9;
+  --color-level-b2-text: #8a2608;
+  --color-level-c1-solid: #6b2fa0;
+  --color-level-c1-surface: #f3ecfa;
+  --color-level-c1-text: #4a1f70;
 
-  /* Neutral surfaces */
+  /* -- Semantic: Surfaces ------------------------------------------ */
+  --color-background: #f7f7f8;
   --color-surface: #ffffff;
-  --color-surface-container: #f0f4f8;
-  --color-surface-container-high: #e4e8ec;
+  --color-surface-raised: #ffffff;
+  --color-surface-container: #f0f0f1;
+  --color-surface-container-hi: #e8e8ea;
+  /* Legacy alias used by existing components */
+  --color-surface-container-high: #e8e8ea;
 
-  /* Text */
-  --color-text-primary: #1a1a2e;
-  --color-text-secondary: #5f6368;
-  --color-text-disabled: #9e9e9e;
+  /* -- Semantic: Borders ------------------------------------------- */
+  --color-border: #d9d9db;
+  --color-border-hover: #c0c0c3;
+  --color-border-focus: #1e5599;
 
-  /* Timer */
+  /* -- Semantic: Text ---------------------------------------------- */
+  --color-text-primary: #2e2e34;
+  --color-text-secondary: #6b6b70;
+  --color-text-tertiary: #9a9a9e;
+  --color-text-disabled: #9a9a9e;
+  --color-text-on-brand: #ffffff;
+  --color-text-on-level: #ffffff;
+
+  /* -- Semantic: Interactive --------------------------------------- */
+  --color-interactive-primary: #1a3a5c;
+  --color-interactive-primary-hover: #152e4a;
+  --color-interactive-primary-focus: #1e5599;
+
+  /* -- Semantic: Status -------------------------------------------- */
+  --color-success: #1e6e36;
+  --color-success-surface: #eaf7ef;
+  --color-warning: #9a5200;
+  --color-warning-surface: #fff4e6;
+  --color-error: #b91c1c;
+  --color-error-surface: #fdecea;
+  --color-info: #1e5599;
+  --color-info-surface: #eef2f8;
+
+  /* -- Semantic: Pass / Fail (exam) -------------------------------- */
+  --color-pass: #1e6e36;
+  --color-pass-surface: #eaf7ef;
+  --color-fail: #b91c1c;
+  --color-fail-surface: #fdecea;
+
+  /* -- Semantic: Timer (never red — amber is max alarm) ------------ */
+  --color-timer-default: #1a3a5c;
+  --color-timer-warning: #9a5200;
+  --color-timer-warning-surface: #fff4e6;
+
+  /* -- Semantic: Streak (calm brand tint, no fire) ----------------- */
+  --color-streak: #1e5599;
+  --color-streak-surface: #eef2f8;
+
+  /* -- Semantic: Readiness stages ---------------------------------- */
+  --color-readiness-building: #9a9a9e;
+  --color-readiness-developing: #1e5599;
+  --color-readiness-almost: #9a5200;
+  --color-readiness-ready: #1e6e36;
+
+  /* ---------------------------------------------------------------- */
+  /* Legacy aliases — kept so existing Tailwind utilities (e.g.       */
+  /* `bg-brand-primary`, `text-text-primary`) continue to resolve     */
+  /* without component churn. These point at the new values above.   */
+  /* ---------------------------------------------------------------- */
+  --color-brand-primary: #1a3a5c;
+  --color-brand-primary-light: #1e5599;
+  --color-brand-primary-surface: #eef2f8;
+
+  --color-level-a1: #2d8a4e;
+  --color-level-a2: #5e8a1a;
+  --color-level-b1: #b86200;
+  --color-level-b2: #c0390b;
+  --color-level-c1: #6b2fa0;
+
+  --color-success-light: #eaf7ef;
+  --color-warning-light: #fff4e6;
+  --color-error-light: #fdecea;
+  --color-pass-light: #eaf7ef;
+  --color-fail-light: #fdecea;
+
   --color-timer-normal: #1a3a5c;
-  --color-timer-warning: #f57c00;
 
-  /* Readiness */
-  --color-readiness-building: #78909c;
-  --color-readiness-developing: #1565c0;
-  --color-readiness-almost: #f57c00;
-  --color-readiness-ready: #2e7d32;
+  --color-streak-fire: #1e5599;
+  --color-streak-bg: #eef2f8;
+}
 
-  /* Streak */
-  --color-streak-fire: #ff6d00;
-  --color-streak-bg: #fff3e0;
+/* ------------------------------------------------------------------ */
+/* Dark mode — remap semantic tokens only; palette stays static.      */
+/* Activated by system preference; no in-product toggle in Phase 1.   */
+/* ------------------------------------------------------------------ */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-background: #08080a;
+    --color-surface: #101013;
+    --color-surface-raised: #1c1c21;
+    --color-surface-container: #1c1c21;
+    --color-surface-container-hi: #2e2e34;
+    --color-surface-container-high: #2e2e34;
 
-  /* Border */
-  --color-border: #e0e0e0;
-  --color-border-hover: #bdbdbd;
+    --color-border: #2e2e34;
+    --color-border-hover: #48484e;
+
+    --color-text-primary: #f7f7f8;
+    --color-text-secondary: #9a9a9e;
+    --color-text-tertiary: #6b6b70;
+    --color-text-disabled: #48484e;
+
+    --color-interactive-primary: #3d72b0;
+    --color-interactive-primary-hover: #7099c8;
+
+    --color-level-a1-surface: #0e2a18;
+    --color-level-a2-surface: #1a2208;
+    --color-level-b1-surface: #2a1800;
+    --color-level-b2-surface: #2a0e06;
+    --color-level-c1-surface: #1a0e2a;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Base element styling                                               */
+/* ------------------------------------------------------------------ */
+:root {
+  color-scheme: light dark;
 }
 
 body {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family: var(--font-sans);
   color: var(--color-text-primary);
-  background-color: #f5f5f5;
+  background-color: var(--color-background);
+}
+
+/* German text: long compound words may hyphenate in body copy,
+ * but never in headings where the break breaks the visual rhythm. */
+[lang="de"] {
+  hyphens: auto;
+}
+h1,
+h2,
+h3 {
+  hyphens: none;
+}
+
+/* Display face for editorial headings (dashboard readiness, results hero). */
+.font-display {
+  font-family: var(--font-display);
+  font-feature-settings: "ss01";
+}
+
+/* Monospace face for the exam timer — tabular digits prevent jitter. */
+.font-mono {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,28 @@
 import type { Metadata } from "next";
+import { DM_Sans, Instrument_Serif, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
+
+const sans = DM_Sans({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-sans-var",
+  display: "swap",
+});
+
+const display = Instrument_Serif({
+  subsets: ["latin"],
+  weight: "400",
+  style: "normal",
+  variable: "--font-display-var",
+  display: "swap",
+});
+
+const mono = JetBrains_Mono({
+  subsets: ["latin"],
+  weight: "400",
+  variable: "--font-mono-var",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "Fastrack Deutsch — German Exam Prep",
@@ -19,8 +42,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="de">
-      <body className="min-h-screen bg-[#f5f5f5] antialiased">
+    <html
+      lang="de"
+      className={`${sans.variable} ${display.variable} ${mono.variable}`}
+    >
+      <body className="min-h-screen bg-background antialiased">
         <div className="flex min-h-screen flex-col">
           <NavHeader />
           <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-6 sm:px-6 lg:px-8">
@@ -35,10 +61,12 @@ export default function RootLayout({
 
 function NavHeader() {
   return (
-    <header className="sticky top-0 z-50 border-b border-[#e0e0e0] bg-white/95 backdrop-blur-sm">
+    <header className="sticky top-0 z-50 border-b border-border bg-white/95 backdrop-blur-sm">
       <nav className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <a href="/" className="flex items-center gap-2">
-          <span className="text-2xl font-bold text-brand-primary">Fastrack</span>
+          <span className="text-2xl font-semibold text-brand-primary">
+            Fastrack
+          </span>
           <span className="text-lg font-medium text-text-secondary">
             Deutsch
           </span>
@@ -84,7 +112,7 @@ function NavLink({
 
 function Footer() {
   return (
-    <footer className="border-t border-[#e0e0e0] bg-white py-6">
+    <footer className="border-t border-border bg-white py-6">
       <div className="mx-auto max-w-7xl px-4 text-center text-sm text-text-secondary sm:px-6 lg:px-8">
         Fastrack Deutsch — telc exam prep. Offline-first, content-driven.
       </div>

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,1 +1,12 @@
-export { colors, typography, spacing, borderRadius, shadows, MIN_TOUCH_TARGET, LEVEL_CONFIG } from './theme';
+export {
+  colors,
+  typography,
+  spacing,
+  borderRadius,
+  shadows,
+  shadow,
+  duration,
+  easing,
+  MIN_TOUCH_TARGET,
+  LEVEL_CONFIG,
+} from './theme';

--- a/packages/config/src/theme.ts
+++ b/packages/config/src/theme.ts
@@ -1,72 +1,203 @@
+/**
+ * Fastrack Deutsch — Design Tokens
+ *
+ * Authoritative source per `.planning/design-system/tokens.md` (2026-04-20).
+ * Web consumes these via CSS variables declared in `apps/web/src/app/globals.css`;
+ * React Native (mobile) imports the flat named exports directly.
+ *
+ * Structure:
+ *   - `colors`: structured palette (brand, neutral, level, semantic, text, surface, border)
+ *   - Flat legacy exports (primary, levelA1, textPrimary, …) point at the new values
+ *     so the mobile app keeps compiling unchanged. Do not remove until mobile is
+ *     migrated off `@fastrack/config` flat names.
+ */
+
+/* Brand — Ink Navy scale (identity color) */
+const brand = {
+  50: '#eef2f8',
+  100: '#d5e0ef',
+  200: '#a8bfdf',
+  300: '#7099c8',
+  400: '#3d72b0',
+  500: '#1e5599',
+  600: '#1a3a5c',
+  700: '#152e4a',
+  800: '#0e2038',
+  900: '#081527',
+  950: '#040c18',
+} as const;
+
+/* Neutral — pure greyscale, no blue/purple cast */
+const neutral = {
+  0: '#ffffff',
+  50: '#f7f7f8',
+  100: '#f0f0f1',
+  150: '#e8e8ea',
+  200: '#d9d9db',
+  300: '#c0c0c3',
+  400: '#9a9a9e',
+  500: '#6b6b70',
+  600: '#48484e',
+  700: '#2e2e34',
+  800: '#1c1c21',
+  900: '#101013',
+  950: '#08080a',
+} as const;
+
+/* CEFR level colors — WCAG AA passing with white text on solid */
+const level = {
+  a1: { solid: '#2d8a4e', surface: '#eaf7ef', text: '#1a5c34' },
+  a2: { solid: '#5e8a1a', surface: '#f1f7e6', text: '#3d5c10' },
+  b1: { solid: '#b86200', surface: '#fff4e6', text: '#7a4200' },
+  b2: { solid: '#c0390b', surface: '#fdeee9', text: '#8a2608' },
+  c1: { solid: '#6b2fa0', surface: '#f3ecfa', text: '#4a1f70' },
+} as const;
+
+/* Semantic tokens — what components should consume */
+const semantic = {
+  success: '#1e6e36',
+  successSurface: '#eaf7ef',
+  warning: '#9a5200',
+  warningSurface: '#fff4e6',
+  error: '#b91c1c',
+  errorSurface: '#fdecea',
+  info: brand[500],
+  infoSurface: brand[50],
+
+  pass: '#1e6e36',
+  passSurface: '#eaf7ef',
+  fail: '#b91c1c',
+  failSurface: '#fdecea',
+
+  /* Timer never turns red — warning amber is the max alarm state. */
+  timerDefault: brand[600],
+  timerWarning: '#9a5200',
+  timerWarningSurface: '#fff4e6',
+
+  /* Streak — calendar-grid treatment in brand tint, no fire imagery. */
+  streak: brand[500],
+  streakSurface: brand[50],
+
+  readinessBuilding: neutral[400],
+  readinessDeveloping: brand[500],
+  readinessAlmost: '#9a5200',
+  readinessReady: '#1e6e36',
+} as const;
+
+const text = {
+  primary: neutral[700],
+  secondary: neutral[500],
+  tertiary: neutral[400],
+  disabled: neutral[400],
+  onBrand: neutral[0],
+  onLevel: neutral[0],
+} as const;
+
+const surfaces = {
+  background: neutral[50],
+  surface: neutral[0],
+  surfaceRaised: neutral[0],
+  surfaceContainer: neutral[100],
+  surfaceContainerHi: neutral[150],
+} as const;
+
+const borders = {
+  default: neutral[200],
+  hover: neutral[300],
+  focus: brand[500],
+} as const;
+
 export const colors = {
-  // Brand
-  primary: '#1a3a5c',
-  primaryLight: '#2a5298',
-  primarySurface: '#e8f0fe',
+  brand,
+  neutral,
+  level,
+  semantic,
+  text,
+  surfaces,
+  borders,
 
-  // Levels
-  levelA1: '#4caf50',
-  levelA2: '#8bc34a',
-  levelB1: '#ff9800',
-  levelB2: '#ff5722',
-  levelC1: '#9c27b0',
+  /* ------------------------------------------------------------------ */
+  /* Legacy flat exports — kept for mobile app backward compatibility.  */
+  /* These map onto the structured palette above; do not re-add new     */
+  /* call sites against these names in new code.                        */
+  /* ------------------------------------------------------------------ */
 
-  // Semantic
-  success: '#2e7d32',
-  successLight: '#e8f5e9',
-  warning: '#f57c00',
-  warningLight: '#fff3e0',
-  error: '#c62828',
-  errorLight: '#ffebee',
-  info: '#1565c0',
-  infoLight: '#e3f2fd',
+  primary: brand[600],
+  primaryLight: brand[500],
+  primarySurface: brand[50],
 
-  // Pass / Fail
-  pass: '#2e7d32',
-  fail: '#c62828',
-  passLight: '#e8f5e9',
-  failLight: '#ffebee',
+  levelA1: level.a1.solid,
+  levelA2: level.a2.solid,
+  levelB1: level.b1.solid,
+  levelB2: level.b2.solid,
+  levelC1: level.c1.solid,
 
-  // Neutrals
-  white: '#ffffff',
-  background: '#f5f5f5',
-  surface: '#ffffff',
-  surfaceContainer: '#f0f4f8',
-  surfaceContainerHigh: '#e4e8ec',
-  border: '#e0e0e0',
-  divider: '#f0f0f0',
+  success: semantic.success,
+  successLight: semantic.successSurface,
+  warning: semantic.warning,
+  warningLight: semantic.warningSurface,
+  error: semantic.error,
+  errorLight: semantic.errorSurface,
+  info: semantic.info,
+  infoLight: semantic.infoSurface,
 
-  // Text
-  textPrimary: '#1a1a2e',
-  textSecondary: '#5f6368',
-  textDisabled: '#9e9e9e',
-  textOnPrimary: '#ffffff',
-  textOnSuccess: '#ffffff',
-  textOnError: '#ffffff',
+  pass: semantic.pass,
+  fail: semantic.fail,
+  passLight: semantic.passSurface,
+  failLight: semantic.failSurface,
 
-  // Timer
-  timerNormal: '#1a3a5c',
-  timerWarning: '#f57c00',
+  white: neutral[0],
+  background: surfaces.background,
+  surface: surfaces.surface,
+  surfaceContainer: surfaces.surfaceContainer,
+  surfaceContainerHigh: surfaces.surfaceContainerHi,
+  border: borders.default,
+  divider: neutral[100],
 
-  // Streaks / gamification
-  streakFire: '#ff6d00',
-  streakText: '#e65100',
-  streakBackground: '#fff3e0',
+  textPrimary: text.primary,
+  textSecondary: text.secondary,
+  textDisabled: text.disabled,
+  textOnPrimary: text.onBrand,
+  textOnSuccess: neutral[0],
+  textOnError: neutral[0],
 
-  // Score readiness stages
-  readinessBuilding: '#78909c',
-  readinessDeveloping: '#1565c0',
-  readinessAlmost: '#f57c00',
-  readinessReady: '#2e7d32',
+  timerNormal: semantic.timerDefault,
+  timerWarning: semantic.timerWarning,
+
+  /** @deprecated Fire-emoji streak was replaced with a calm calendar-grid treatment in brand tint. Kept only for mobile backward compat; remove after mobile migration. */
+  streakFire: semantic.streak,
+  /** @deprecated See `streakFire`. */
+  streakText: brand[700],
+  /** @deprecated See `streakFire`. */
+  streakBackground: semantic.streakSurface,
+
+  readinessBuilding: semantic.readinessBuilding,
+  readinessDeveloping: semantic.readinessDeveloping,
+  readinessAlmost: semantic.readinessAlmost,
+  readinessReady: semantic.readinessReady,
 } as const;
 
 export const typography = {
   fontFamily: {
-    regular: 'System',
-    medium: 'System',
-    bold: 'System',
+    regular: 'var(--font-sans)',
+    medium: 'var(--font-sans)',
+    bold: 'var(--font-sans)',
+    display: 'var(--font-display)',
+    mono: 'var(--font-mono)',
   },
+  /* Web sizes in px per tokens.md. Legacy numeric keys retained for mobile
+   * StyleSheet usages; they are due for reconciliation in a mobile-scoped
+   * follow-up (out of Phase 1 scope). */
   fontSize: {
+    display: 36,
+    h1: 30,
+    h2: 24,
+    h3: 20,
+    h4: 18,
+    body: 16,
+    bodySm: 14,
+    caption: 12,
+    mono: 14,
     xs: 11,
     sm: 13,
     base: 15,
@@ -84,13 +215,34 @@ export const typography = {
     bold: '700' as const,
   },
   lineHeight: {
+    display: 1.15,
+    h1: 1.2,
+    h2: 1.25,
+    h3: 1.3,
+    h4: 1.35,
+    body: 1.55,
+    bodySm: 1.5,
+    caption: 1.4,
+    mono: 1.0,
     tight: 1.2,
     normal: 1.5,
     relaxed: 1.75,
   },
+  letterSpacing: {
+    display: '-0.02em',
+    h1: '-0.01em',
+    h2: '-0.01em',
+    h3: '0',
+    h4: '0',
+    body: '0',
+    bodySm: '0',
+    caption: '0.01em',
+    mono: '0',
+  },
 } as const;
 
 export const spacing = {
+  '2xs': 2,
   xs: 4,
   sm: 8,
   md: 12,
@@ -101,6 +253,7 @@ export const spacing = {
   '3xl': 40,
   '4xl': 48,
   '5xl': 64,
+  '6xl': 80,
 } as const;
 
 export const borderRadius = {
@@ -112,6 +265,7 @@ export const borderRadius = {
   full: 9999,
 } as const;
 
+/* React Native-style shadow objects (consumed by mobile). */
 export const shadows = {
   sm: {
     shadowColor: '#000',
@@ -136,35 +290,70 @@ export const shadows = {
   },
 } as const;
 
+/* Web box-shadow strings. Consumed by Tailwind class map and inline styles. */
+export const shadow = {
+  sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+  md: '0 2px 8px 0 rgb(0 0 0 / 0.07), 0 1px 2px 0 rgb(0 0 0 / 0.04)',
+  lg: '0 4px 16px 0 rgb(0 0 0 / 0.08), 0 2px 4px 0 rgb(0 0 0 / 0.04)',
+  xl: '0 8px 32px 0 rgb(0 0 0 / 0.10), 0 4px 8px 0 rgb(0 0 0 / 0.05)',
+} as const;
+
+/* Motion tokens — durations in milliseconds. */
+export const duration = {
+  instant: 0,
+  fast: 120,
+  base: 200,
+  moderate: 300,
+  slow: 500,
+  deliberate: 800,
+} as const;
+
+export const easing = {
+  standard: 'cubic-bezier(0.4, 0, 0.2, 1)',
+  decelerate: 'cubic-bezier(0, 0, 0.2, 1)',
+  accelerate: 'cubic-bezier(0.4, 0, 1, 1)',
+  spring: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
+} as const;
+
 export const MIN_TOUCH_TARGET = 44;
 
 export const LEVEL_CONFIG = {
   A1: {
-    color: colors.levelA1,
+    color: colors.level.a1.solid,
+    surface: colors.level.a1.surface,
+    textColor: colors.level.a1.text,
     label: 'Start Deutsch 1',
     targetHours: 20,
     passThreshold: 0.6,
   },
   A2: {
-    color: colors.levelA2,
+    color: colors.level.a2.solid,
+    surface: colors.level.a2.surface,
+    textColor: colors.level.a2.text,
     label: 'Start Deutsch 2',
     targetHours: 30,
     passThreshold: 0.6,
   },
   B1: {
-    color: colors.levelB1,
+    color: colors.level.b1.solid,
+    surface: colors.level.b1.surface,
+    textColor: colors.level.b1.text,
     label: 'Zertifikat Deutsch',
     targetHours: 40,
     passThreshold: 0.6,
   },
   B2: {
-    color: colors.levelB2,
+    color: colors.level.b2.solid,
+    surface: colors.level.b2.surface,
+    textColor: colors.level.b2.text,
     label: 'telc Deutsch B2',
     targetHours: 50,
     passThreshold: 0.6,
   },
   C1: {
-    color: colors.levelC1,
+    color: colors.level.c1.solid,
+    surface: colors.level.c1.surface,
+    textColor: colors.level.c1.text,
     label: 'telc Deutsch C1 Hochschule',
     targetHours: 60,
     passThreshold: 0.6,


### PR DESCRIPTION
## Summary

- **#50**: Web design tokens rewritten per `.planning/design-system/tokens.md` — structured brand/neutral/level/semantic scales, revised CEFR level hexes that clear WCAG AA with white text, `next/font` wired for DM Sans + Instrument Serif + JetBrains Mono, dark-mode semantic remap via `prefers-color-scheme`. No component visual redesign.
- Legacy flat color exports preserved so the mobile app keeps compiling unchanged; legacy Tailwind utility names kept in `@theme` so existing web components render with the new values without a migration.
- 12 new design-token invariant tests (`apps/web/src/__tests__/design-tokens.test.ts`), 164 web tests total, all passing.

## Quality Gates

| Gate | Result |
|------|--------|
| spec-tracker | n/a (tokens spec already ratified at `.planning/design-system/tokens.md`) |
| compliance-guardian | n/a (no auth UI touched) |
| language-checker | n/a (no new UI copy) |
| pnpm typecheck | PASS |
| pnpm test (web + packages) | PASS — 164/164 |
| pnpm build (Next.js production) | PASS — 7 routes prerendered |

## Test plan

- [ ] CI green (typecheck + tests)
- [ ] Preview deploy renders `/`, `/exam`, `/vocab`, `/grammar` with the new palette + DM Sans body font
- [ ] devtools confirms `--color-brand-600: #1a3a5c` and `--color-level-a1-solid: #2d8a4e` on `:root`
- [ ] German text on `/exam/A1_mock_01` renders umlauts/ß cleanly
- [ ] product-owner sign-off after merge