### PR TITLE
feat(ui): mocks list + exam runner (#52)

### DIFF
--- a/.planning/handoffs/2026-04-20-ux-phase3-mocks-runner.md
+++ b/.planning/handoffs/2026-04-20-ux-phase3-mocks-runner.md
@@ -1,0 +1,75 @@
+# UX Phase 3 Handoff — Mocks List + Section Hub + Exam Runner
+
+**Issue:** #52
+**Branch:** `ui-upgrade-phase3-mocks-runner` (based on `ui-upgrade-phase1-tokens-typography`)
+**Date:** 2026-04-20
+**Agent:** ux-engineer
+
+## What landed
+
+### Critical: ExamTimer never turns red
+`apps/web/src/components/exam/ExamTimer.tsx` now collapses warning (<5 min) and expired (0:00) into a single amber tone (`bg-warning-surface` + `text-warning`). Default is `bg-surface-container` + `text-text-secondary`. Icon swapped to `lucide-react Clock`. Tests explicitly assert no `bg-error`, `text-error`, `bg-fail`, `text-fail`, `red`, or red hex at any state.
+
+### Mocks list `/exam`
+- Level info strip now uses `bg-level-{n}-surface` + `text-level-{n}-text` (no hex-opacity hack).
+- New `MockCard` component with 4 states, distinguished structurally (not by color alone):
+  - **not-started:** white, 1px border, chevron on hover only.
+  - **in-progress:** 2px left accent bar in level color, 3px bottom progress track, "N von 4 Abschnitten" footer.
+  - **completed:** `bg-surface-container` recessed, score pill in `bg-pass-surface/text-pass` (passed) or `bg-fail-surface/text-fail` (failed), "Vollständig" footer.
+  - **coming-soon:** renders as `<div>` not `<a>`, text-tertiary, desaturated badge, "Bald verfügbar", `cursor-default`.
+- Empty state: single centered line `{Level} Übungstests sind bald verfügbar.` — no skeletons.
+- Chevron: `lucide-react ChevronRight` with `opacity-0 group-hover:opacity-100`.
+
+### Section hub `/exam/[mockId]`
+- Sections split into labeled groups: **Schriftlich — min. 60% zum Bestehen** and **Mündlich — min. 60% zum Bestehen**.
+- Emoji icons replaced with `lucide-react`: `Headphones` (Hören), `FileText` (Lesen), `Puzzle` (Sprachbausteine), `Pencil` (Schreiben), `Mic` (Sprechen). 20px @ strokeWidth 1.75.
+- Status dot (not a text badge) per row: `bg-text-tertiary` (not started), level color (in progress), `bg-pass` (completed).
+- Bottom CTA renamed from "Vollständige Prüfung starten" to **"Mit Hören starten"** / "Weiter mit {section}" when something in progress. `bg-brand-600`.
+
+### Exam runner (all 5 *Exam.tsx components)
+- Unified `ExamRunnerHeader` (56px flex row, 1px bottom border) — X icon + "Prüfung beenden" (opens confirm dialog), center section + Teil label, right-aligned amber-only `ExamTimer`.
+- 3px progress bar below header, fills to level color.
+- New `AnswerOption` component for MCQ/true-false/matching rows:
+  - Default: 1px border, white bg.
+  - Selected: 4px **left** accent in `border-l-brand-500` + `bg-surface-container` — explicitly **not** full brand-background fill.
+  - Review correct: `bg-pass-surface` + `border-l-pass` + `Check` icon.
+  - Review wrong: `bg-fail-surface` + `border-l-fail` + `X` icon. Correct option also highlighted.
+- `ExamSubmitButton`: 52px full-width, `bg-brand-600`, disabled until selection.
+- `SectionIntro` now takes a lucide `Icon` component prop instead of an emoji string.
+
+## Design tokens used
+All component-level styling uses Phase 1 tokens:
+- `colors.brand[600]`, `border-l-brand-500`, `bg-brand-600`
+- `colors.level.{n}.solid` / `surface` / `text` (no opacity-hex hack)
+- `colors.semantic.warning` / `warningSurface`
+- Tailwind utilities: `bg-warning-surface`, `bg-pass-surface`, `bg-fail-surface`, `border-l-pass`, `border-l-fail`, `text-pass`, `text-fail`, `font-mono`
+- No hardcoded hex in touched components.
+
+## Tests
+- Unit: 182 vitest tests pass. New suites:
+  - `ExamTimer.test.tsx` — 10 tests, including explicit **no-red** assertions at 30:00, 4:59, 0:00, and after countdown to 0.
+  - `MockCard.test.tsx` — 5 tests, one per state.
+  - `SectionHub.test.tsx` — 5 tests, covers A1 (no Sprachbausteine), B1 (with it), CTA default copy, status dot neutrality.
+  - `AnswerOption.test.tsx` — 6 tests, covers default, selected, review correct/wrong/correctUnselected, click forwarding.
+- Updated: `SectionIntro.test.tsx` (Icon prop), `ListeningExam.test.tsx` (data-state selector).
+- Playwright: `exam-listening.spec.ts`, `exam-reading.spec.ts`, `exam-section-flow.spec.ts`, `exam-timer.spec.ts` updated for the new `data-state` attribute + amber-only assertions.
+
+## CI
+- `pnpm typecheck` — green.
+- `pnpm --filter @fastrack/web test` — green (182/182).
+- `pnpm --filter @fastrack/web build` — green; exam routes 3-5KB each.
+- Mobile jest pre-existing failure on `main` unrelated to this ticket.
+
+## Known follow-ups (out of scope for #52)
+- Phase 4: vocab / grammar / results screen redesign.
+- `SectionStatus.tsx` old `SectionActionButton` is still exported but no longer consumed — safe to delete in a cleanup PR.
+- Section transition interstitial (screens.md §Screen 3, "Hören abgeschlossen — Gut gemacht") — specced but deferred.
+
+## Files changed
+- Added: `apps/web/src/components/exam/{AnswerOption,ExamRunnerHeader,ExamSubmitButton,MockCard,MockCardList,SectionHub}.tsx`
+- Modified: `apps/web/src/components/exam/{ExamTimer,SectionIntro,PrepTimer,ListeningExam,ReadingExam,WritingExam,SpeakingExam,SprachbausteineExam,SectionStatus}.tsx`
+- Modified: `apps/web/src/app/exam/page.tsx`, `apps/web/src/app/exam/[mockId]/page.tsx`
+- Added tests: `apps/web/src/__tests__/exam/{MockCard,AnswerOption,SectionHub}.test.tsx`
+- Updated tests: `apps/web/src/__tests__/exam/{ExamTimer,ListeningExam,SectionIntro}.test.tsx`
+- Updated e2e: `apps/web/e2e/{exam-listening,exam-reading,exam-section-flow,exam-timer}.spec.ts`
+- `apps/web/package.json` — added `lucide-react`.

--- a/ACTIVITY-LOG.md
+++ b/ACTIVITY-LOG.md
@@ -1,0 +1,35 @@
+# Activity Log
+
+## 2026-04-20 — UX Phase 3: Mocks list + Section Hub + Exam Runner
+
+**Agent:** ux-engineer
+**Issue:** #52
+**Branch:** `ui-upgrade-phase3-mocks-runner`
+**Base:** `ui-upgrade-phase1-tokens-typography`
+
+### Start
+- Worktree created from `origin/ui-upgrade-phase1-tokens-typography`.
+- Added `lucide-react` to `apps/web`.
+- Read all exam runner components + screen specs + Phase 1 token API.
+
+### Build
+- ExamTimer rewritten: warning and expired states share amber treatment, no red anywhere. Tests assert absence of red/error/fail classes at every state.
+- New shared components: `MockCard`, `MockCardList` (client), `SectionHub`, `ExamRunnerHeader`, `AnswerOption`, `ExamSubmitButton`.
+- `/exam` page rebuilt: level info strip uses `level-surface` + `level-text` tokens (no opacity-hex hack); empty state for zero-content levels.
+- `/exam/[mockId]` page rebuilt: sections grouped into Schriftlich / Mündlich blocks with 60% threshold reminder, lucide icons replacing emoji.
+- All exam runners (Listening, Reading, Writing, Speaking, Sprachbausteine) now use the unified `ExamRunnerHeader` with the top 3px progress bar + amber-only timer.
+- `AnswerOption` component enforces the left-accent selection pattern — explicitly NOT a full brand-background fill.
+
+### Tests
+- 182 vitest tests pass (up from 176). New suites: ExamTimer (10 tests, never-red gate), MockCard (5 states), SectionHub (5 cases incl. A1 no-Sprachbausteine vs B1+ with it), AnswerOption (6 review states).
+- Updated SectionIntro test to pass `Icon` component prop.
+- Updated `ListeningExam` Vitest + 4 Playwright specs for the new `data-state` attribute + left-accent selectors.
+
+### CI
+- `pnpm typecheck` — green.
+- `pnpm --filter @fastrack/web test` — green.
+- `pnpm --filter @fastrack/web build` — green; exam routes 3-5KB per route.
+- Mobile jest suite fails pre-existing on main (expo-modules-core syntax error) — not in scope for web ticket.
+
+### Handoff
+- `.planning/handoffs/2026-04-20-ux-phase3-mocks-runner.md`

--- a/apps/web/e2e/exam-listening.spec.ts
+++ b/apps/web/e2e/exam-listening.spec.ts
@@ -9,9 +9,9 @@ test.describe('Listening MCQ answer selection and part tab progress', () => {
   });
 
   test('Part 1 tab is active; not yet complete', async ({ page }) => {
-    await expect(page.getByTestId('part-tab-1')).toHaveClass(/bg-brand-primary/);
-    await expect(page.getByTestId('part-tab-1')).not.toHaveClass(/bg-success-light/);
-    await expect(page.getByTestId('part-tab-2')).not.toHaveClass(/bg-brand-primary/);
+    await expect(page.getByTestId('part-tab-1')).toHaveClass(/bg-brand-600/);
+    await expect(page.getByTestId('part-tab-1')).not.toHaveClass(/bg-pass-surface/);
+    await expect(page.getByTestId('part-tab-2')).not.toHaveClass(/bg-brand-600/);
   });
 
   test('selecting an option applies selected classes; switching deselects previous', async ({ page }) => {
@@ -19,41 +19,38 @@ test.describe('Listening MCQ answer selection and part tab progress', () => {
     const optB = page.getByTestId('question-option-A1_m01_L1_q1-b');
 
     await optA.click();
-    await expect(optA).toHaveClass(/border-brand-primary/);
-    await expect(optA).toHaveClass(/bg-brand-primary-surface/);
-    await expect(optB).not.toHaveClass(/border-brand-primary/);
+    // Selected state is a 4px left accent, NOT a full brand fill.
+    await expect(optA).toHaveAttribute('data-state', 'selected');
+    await expect(optA).toHaveClass(/border-l-brand-500/);
+    await expect(optA).toHaveClass(/bg-surface-container/);
+    await expect(optB).toHaveAttribute('data-state', 'default');
 
     // Switch to b
     await optB.click();
-    await expect(optB).toHaveClass(/border-brand-primary/);
-    await expect(optA).not.toHaveClass(/border-brand-primary/);
+    await expect(optB).toHaveAttribute('data-state', 'selected');
+    await expect(optA).toHaveAttribute('data-state', 'default');
   });
 
-  test('completing Part 1 marks tab bg-success-light after navigating away', async ({ page }) => {
+  test('completing Part 1 marks tab bg-pass-surface after navigating away', async ({ page }) => {
     for (const qId of ['A1_m01_L1_q1', 'A1_m01_L1_q2', 'A1_m01_L1_q3']) {
       await page.getByTestId(`question-option-${qId}-a`).click();
     }
-    // Navigate away from Part 1 — success class only shows when tab is not active
     await page.getByTestId('section-nav-next').click();
-    await expect(page.getByTestId('part-tab-2')).toHaveClass(/bg-brand-primary/);
-    await expect(page.getByTestId('part-tab-1')).toHaveClass(/bg-success-light/);
-    await expect(page.getByTestId('part-tab-1')).toHaveClass(/text-success/);
+    await expect(page.getByTestId('part-tab-2')).toHaveClass(/bg-brand-600/);
+    await expect(page.getByTestId('part-tab-1')).toHaveClass(/bg-pass-surface/);
+    await expect(page.getByTestId('part-tab-1')).toHaveClass(/text-pass/);
   });
 
   test('answers persist across part navigation', async ({ page }) => {
-    // Answer all of Part 1
     for (const qId of ['A1_m01_L1_q1', 'A1_m01_L1_q2', 'A1_m01_L1_q3']) {
       await page.getByTestId(`question-option-${qId}-a`).click();
     }
 
-    // Go to Part 2
     await page.getByTestId('section-nav-next').click();
-    await expect(page.getByTestId('part-tab-2')).toHaveClass(/bg-brand-primary/);
+    await expect(page.getByTestId('part-tab-2')).toHaveClass(/bg-brand-600/);
 
-    // Come back to Part 1
     await page.getByTestId('part-tab-1').click();
-    // First question still marked
-    await expect(page.getByTestId('question-option-A1_m01_L1_q1-a')).toHaveClass(/border-brand-primary/);
+    await expect(page.getByTestId('question-option-A1_m01_L1_q1-a')).toHaveAttribute('data-state', 'selected');
   });
 
   test('prev button is disabled on Part 1', async ({ page }) => {
@@ -66,7 +63,7 @@ test.describe('Listening Part 2 true_false rendering and submission', () => {
     await page.goto(`/exam/${MOCK}/listening`);
     await page.getByTestId('section-start-btn').click();
     await page.getByTestId('section-nav-next').click();
-    await expect(page.getByTestId('part-tab-2')).toHaveClass(/bg-brand-primary/);
+    await expect(page.getByTestId('part-tab-2')).toHaveClass(/bg-brand-600/);
   });
 
   test('Part 2 renders richtig/falsch buttons instead of MCQ options', async ({ page }) => {
@@ -79,36 +76,32 @@ test.describe('Listening Part 2 true_false rendering and submission', () => {
     const falsch = page.getByTestId('question-option-A1_m01_L2_q1-falsch');
 
     await richtig.click();
-    await expect(richtig).toHaveClass(/border-brand-primary/);
-    await expect(richtig).toHaveClass(/bg-brand-primary-surface/);
-    await expect(falsch).not.toHaveClass(/border-brand-primary/);
+    await expect(richtig).toHaveAttribute('data-state', 'selected');
+    await expect(richtig).toHaveClass(/border-l-brand-500/);
+    await expect(richtig).toHaveClass(/bg-surface-container/);
+    await expect(falsch).toHaveAttribute('data-state', 'default');
   });
 
   test('answering all parts enables submit and shows results', async ({ page }) => {
-    // Answer Part 1 MCQ questions first
     await page.getByTestId('part-tab-1').click();
     for (const qId of ['A1_m01_L1_q1', 'A1_m01_L1_q2', 'A1_m01_L1_q3']) {
       await page.getByTestId(`question-option-${qId}-a`).click();
     }
 
-    // Answer Part 2 true_false questions
     await page.getByTestId('part-tab-2').click();
     for (const qId of ['A1_m01_L2_q1', 'A1_m01_L2_q2', 'A1_m01_L2_q3', 'A1_m01_L2_q4', 'A1_m01_L2_q5']) {
       await page.getByTestId(`question-option-${qId}-richtig`).click();
     }
 
-    // Answer Part 3 MCQ questions
     await page.getByTestId('section-nav-next').click();
     for (const qId of ['A1_m01_L3_q1', 'A1_m01_L3_q2', 'A1_m01_L3_q3']) {
       await page.getByTestId(`question-option-${qId}-a`).click();
     }
 
-    // Submit
     const submitBtn = page.getByTestId('submit-btn');
     await expect(submitBtn).not.toBeDisabled();
     await submitBtn.click();
 
-    // Results screen shows score
     await expect(page.getByText(/Bestanden|Nicht bestanden/)).toBeVisible();
     await expect(page.getByTestId('next-section-link')).toBeVisible();
   });

--- a/apps/web/e2e/exam-reading.spec.ts
+++ b/apps/web/e2e/exam-reading.spec.ts
@@ -16,12 +16,12 @@ test.describe('Reading question type rendering', () => {
     await expect(falsch).toBeVisible();
 
     await richtig.click();
-    await expect(richtig).toHaveClass(/border-brand-primary/);
-    await expect(falsch).not.toHaveClass(/border-brand-primary/);
+    await expect(richtig).toHaveAttribute('data-state', 'selected');
+    await expect(falsch).not.toHaveAttribute('data-state', 'selected');
 
     await falsch.click();
-    await expect(falsch).toHaveClass(/border-brand-primary/);
-    await expect(richtig).not.toHaveClass(/border-brand-primary/);
+    await expect(falsch).toHaveAttribute('data-state', 'selected');
+    await expect(richtig).not.toHaveAttribute('data-state', 'selected');
   });
 
   test('Part 2 — matching: tiles a–h visible; clicking marks selection', async ({ page }) => {
@@ -35,7 +35,7 @@ test.describe('Reading question type rendering', () => {
     // Click tile 'b' for first matching question
     const opt = page.getByTestId('question-option-A1_m01_R2_q1-b');
     await opt.click();
-    await expect(opt).toHaveClass(/border-brand-primary/);
+    await expect(opt).toHaveAttribute('data-state', 'selected');
   });
 
   test('Part 3 — true/false same pattern as Part 1', async ({ page }) => {
@@ -45,11 +45,11 @@ test.describe('Reading question type rendering', () => {
     const falsch = page.getByTestId('question-option-A1_m01_R3_q1-falsch');
 
     await richtig.click();
-    await expect(richtig).toHaveClass(/border-brand-primary/);
+    await expect(richtig).toHaveAttribute('data-state', 'selected');
 
     await falsch.click();
-    await expect(falsch).toHaveClass(/border-brand-primary/);
-    await expect(richtig).not.toHaveClass(/border-brand-primary/);
+    await expect(falsch).toHaveAttribute('data-state', 'selected');
+    await expect(richtig).not.toHaveAttribute('data-state', 'selected');
   });
 
   test('submit stays disabled until all 15 questions answered', async ({ page }) => {

--- a/apps/web/e2e/exam-section-flow.spec.ts
+++ b/apps/web/e2e/exam-section-flow.spec.ts
@@ -30,7 +30,9 @@ test.describe('1a — Hören section flow', () => {
 
     // Part 1 MCQ answers can be selected
     await page.getByTestId(`question-option-${L_PARTS[1][0]}-a`).click();
-    await expect(page.getByTestId(`question-option-${L_PARTS[1][0]}-a`)).toHaveClass(/border-brand-primary/);
+    await expect(
+      page.getByTestId(`question-option-${L_PARTS[1][0]}-a`),
+    ).toHaveAttribute('data-state', 'selected');
 
     // Part 2 has true_false questions without rendered radio options in this component —
     // expire the timer to auto-submit (mirrors telc exam behavior on time-out)

--- a/apps/web/e2e/exam-timer.spec.ts
+++ b/apps/web/e2e/exam-timer.spec.ts
@@ -5,8 +5,7 @@ const MOCK = 'A1_mock_01';
 const LISTENING_TOTAL_S = 20 * 60;
 
 test.describe('Timer warning threshold and expiry', () => {
-  test('neutral → warning at 5 min remaining → auto-submit on expiry', async ({ page }) => {
-    // Install fake clock BEFORE navigation so browser timers are intercepted from page load
+  test('neutral -> warning amber at 5 min -> NEVER red on expiry', async ({ page }) => {
     await page.clock.install({ time: Date.now() });
     await page.goto(`/exam/${MOCK}/listening`);
     await page.getByTestId('section-start-btn').click();
@@ -14,26 +13,28 @@ test.describe('Timer warning threshold and expiry', () => {
     const timer = page.getByTestId('exam-timer');
     await expect(timer).toBeVisible();
 
-    // Neutral state initially (well above 300s remaining)
-    await expect(timer).not.toHaveClass(/bg-warning-light/);
-    await expect(timer).not.toHaveClass(/bg-error-light/);
+    // Default tone at start — no warning, no red.
+    await expect(timer).not.toHaveClass(/bg-warning-surface/);
+    await expect(timer).not.toHaveClass(/bg-error/);
+    await expect(timer).not.toHaveClass(/bg-fail/);
 
-    // Advance to 899s elapsed → 301s remaining (1s before warning threshold)
+    // 301s remaining (one tick before warning threshold)
     await page.clock.runFor((LISTENING_TOTAL_S - 301) * 1000);
-    await expect(timer).not.toHaveClass(/bg-warning-light/);
+    await expect(timer).not.toHaveClass(/bg-warning-surface/);
 
-    // Run 1 more second → 300s remaining; warning styling kicks in
+    // 300s -> warning amber kicks in
     await page.clock.runFor(1000);
-    await expect(timer).toHaveClass(/bg-warning-light/);
+    await expect(timer).toHaveClass(/bg-warning-surface/);
     await expect(timer).toHaveClass(/text-warning/);
-    await expect(timer).not.toHaveClass(/bg-error-light/);
+    // Ethics gate: must never be red, anywhere.
+    await expect(timer).not.toHaveClass(/bg-error/);
+    await expect(timer).not.toHaveClass(/bg-fail/);
+    await expect(timer).not.toHaveClass(/text-error/);
+    await expect(timer).not.toHaveClass(/text-fail/);
 
-    // Run remaining 300s → timer hits 0; component calls onExpire → auto-submits
-    // The timer briefly shows bg-error-light before the parent unmounts it on submit,
-    // so assert the final state via the results screen instead.
+    // Run down to 0 -> auto-submit flips to the results screen.
     await page.clock.runFor(300 * 1000);
 
-    // Results screen rendered — auto-submit fired without user clicking submit-btn
     await expect(page.getByText(/\d+\/11/)).toBeVisible();
   });
 });

--- a/apps/web/e2e/vocab-flashcards.spec.ts
+++ b/apps/web/e2e/vocab-flashcards.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Vocabulary flashcard session', () => {
-  test('completes a 3-card session and reaches the end screen with honest stats', async ({
+  test('completes a full session and reaches the end screen with honest stats', async ({
     page,
   }) => {
     await page.goto('/vocab');
@@ -11,7 +11,8 @@ test.describe('Vocabulary flashcard session', () => {
     await page.getByTestId('start-review').click();
 
     // Progress label lives in the breadcrumb row, not on the card
-    await expect(page.getByTestId('card-progress')).toBeVisible();
+    const progress = page.getByTestId('card-progress');
+    await expect(progress).toBeVisible();
 
     // Flip hint is visible on the first card
     await expect(page.getByTestId('flashcard-flip-hint')).toBeVisible();
@@ -24,13 +25,24 @@ test.describe('Vocabulary flashcard session', () => {
     await expect(page.getByTestId('grade-2')).toHaveText('Noch lernen');
     await expect(page.getByTestId('grade-4')).toHaveText('Gewusst');
 
-    // Burn through three cards
+    // First card: grade known, then confirm the hint is gone for the rest.
     await page.getByTestId('grade-4').click();
     await expect(page.getByTestId('flashcard-flip-hint')).not.toBeVisible();
-    await page.getByTestId('flip-button').click();
-    await page.getByTestId('grade-2').click();
-    await page.getByTestId('flip-button').click();
-    await page.getByTestId('grade-4').click();
+
+    // Read the session size from the progress label ("Karte 1 von N") and
+    // burn through the remaining N-1 cards. The session size is hardcoded
+    // in FlashcardSession.tsx, but reading it from the DOM keeps the test
+    // resilient to future tweaks.
+    const match = (await progress.textContent())?.match(/von\s+(\d+)/);
+    const sessionSize = match ? Number(match[1]) : 20;
+    expect(sessionSize).toBeGreaterThan(1);
+
+    for (let i = 1; i < sessionSize; i++) {
+      await page.getByTestId('flip-button').click();
+      // Alternate grades so the summary has both "sicher" and "zum Wiederholen" buckets.
+      const testid = i % 2 === 0 ? 'grade-4' : 'grade-2';
+      await page.getByTestId(testid).click();
+    }
 
     // End of session — 3 honest stats, no percent, no confetti
     const summary = page.getByTestId('session-summary');

--- a/apps/web/src/__tests__/exam/AnswerOption.test.tsx
+++ b/apps/web/src/__tests__/exam/AnswerOption.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AnswerOption } from '../../components/exam/AnswerOption';
+
+describe('AnswerOption', () => {
+  it('default state: 1px border, white bg, no left accent', () => {
+    render(
+      <AnswerOption
+        name="q1"
+        value="a"
+        selected={false}
+        onChange={() => {}}
+        testId="opt"
+      >
+        Option A
+      </AnswerOption>,
+    );
+    const el = screen.getByTestId('opt');
+    expect(el.getAttribute('data-state')).toBe('default');
+    expect(el.className).toMatch(/border-border/);
+    expect(el.className).toMatch(/bg-white/);
+    expect(el.className).not.toMatch(/border-l-/);
+  });
+
+  it('selected: left accent (4px brand-500) + surface-container bg, NOT brand full fill', () => {
+    render(
+      <AnswerOption
+        name="q1"
+        value="a"
+        selected={true}
+        onChange={() => {}}
+        testId="opt"
+      >
+        Option A
+      </AnswerOption>,
+    );
+    const el = screen.getByTestId('opt');
+    expect(el.getAttribute('data-state')).toBe('selected');
+    expect(el.className).toMatch(/border-l-\[4px\]/);
+    expect(el.className).toMatch(/border-l-brand-500/);
+    expect(el.className).toMatch(/bg-surface-container/);
+    // The row must not be filled with the brand color — that's the banned pattern.
+    expect(el.className).not.toMatch(/bg-brand-500(?!\w)/);
+    expect(el.className).not.toMatch(/bg-brand-600(?!\w)/);
+  });
+
+  it('review correct: pass border + pass-surface + check icon', () => {
+    render(
+      <AnswerOption
+        name="q1"
+        value="a"
+        selected={true}
+        onChange={() => {}}
+        review={{ isCorrect: true, userPicked: true }}
+        testId="opt"
+      >
+        Option A
+      </AnswerOption>,
+    );
+    const el = screen.getByTestId('opt');
+    expect(el.getAttribute('data-state')).toBe('correct');
+    expect(el.className).toMatch(/bg-pass-surface/);
+    expect(el.className).toMatch(/border-l-pass/);
+  });
+
+  it('review wrong: fail border + fail-surface', () => {
+    render(
+      <AnswerOption
+        name="q1"
+        value="a"
+        selected={true}
+        onChange={() => {}}
+        review={{ isCorrect: false, userPicked: true }}
+        testId="opt"
+      >
+        Option A
+      </AnswerOption>,
+    );
+    const el = screen.getByTestId('opt');
+    expect(el.getAttribute('data-state')).toBe('wrong');
+    expect(el.className).toMatch(/bg-fail-surface/);
+    expect(el.className).toMatch(/border-l-fail/);
+  });
+
+  it('correct-but-not-picked: reveals the right answer in pass style', () => {
+    render(
+      <AnswerOption
+        name="q1"
+        value="b"
+        selected={false}
+        onChange={() => {}}
+        review={{ isCorrect: true, userPicked: false }}
+        testId="opt"
+      >
+        Option B
+      </AnswerOption>,
+    );
+    const el = screen.getByTestId('opt');
+    expect(el.getAttribute('data-state')).toBe('correctUnselected');
+    expect(el.className).toMatch(/bg-pass-surface/);
+  });
+
+  it('forwards change on click', async () => {
+    const onChange = vi.fn();
+    render(
+      <AnswerOption name="q1" value="a" selected={false} onChange={onChange} testId="opt">
+        Option A
+      </AnswerOption>,
+    );
+    await userEvent.click(screen.getByTestId('opt'));
+    expect(onChange).toHaveBeenCalledWith('a');
+  });
+});

--- a/apps/web/src/__tests__/exam/ExamTimer.test.tsx
+++ b/apps/web/src/__tests__/exam/ExamTimer.test.tsx
@@ -2,6 +2,34 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import { ExamTimer } from '../../components/exam/ExamTimer';
 
+/**
+ * Ethics gate: the timer must never render in red. Warning and expired both
+ * render in amber (`bg-warning-surface` + `text-warning`). The assertions below
+ * check both the className (Tailwind utility) and the serialized DOM against
+ * forbidden tokens (red hex / rgb, error/fail class fragments).
+ */
+const FORBIDDEN_COLOR_PATTERNS = [
+  /bg-error/i,
+  /text-error/i,
+  /bg-fail/i,
+  /text-fail/i,
+  /\bred\b/i,
+  /#b91c1c/i,
+  /#c62828/i,
+  /rgb\(\s*1[7-9][0-9]\s*,\s*[0-3][0-9]?\s*,/i, // crude catch for red rgb()
+];
+
+function assertNoRed(el: HTMLElement) {
+  for (const pattern of FORBIDDEN_COLOR_PATTERNS) {
+    expect(el.className).not.toMatch(pattern);
+  }
+  const outer = el.outerHTML;
+  expect(outer).not.toMatch(/bg-error/);
+  expect(outer).not.toMatch(/text-error/);
+  expect(outer).not.toMatch(/bg-fail/);
+  expect(outer).not.toMatch(/text-fail/);
+}
+
 describe('ExamTimer', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -11,53 +39,76 @@ describe('ExamTimer', () => {
     vi.useRealTimers();
   });
 
-  it('renders time in MM:SS format', () => {
+  it('renders time in M:SS / MM:SS format', () => {
     render(<ExamTimer totalSeconds={600} isRunning={false} />);
     const el = screen.getByTestId('exam-timer');
     expect(el.textContent).toContain('10:00');
   });
 
-  it('shows "Time up" in expired state when totalSeconds is 0', () => {
+  it('applies default tone (surface-container + text-secondary) at 30:00', () => {
+    render(<ExamTimer totalSeconds={30 * 60} isRunning={false} />);
+    const el = screen.getByTestId('exam-timer');
+    expect(el.className).toMatch(/bg-surface-container/);
+    expect(el.className).toMatch(/text-text-secondary/);
+    assertNoRed(el);
+  });
+
+  it('applies warning tone (amber, never red) at 4:59', () => {
+    render(<ExamTimer totalSeconds={299} isRunning={false} />);
+    const el = screen.getByTestId('exam-timer');
+    expect(el.className).toMatch(/bg-warning-surface/);
+    expect(el.className).toMatch(/text-warning/);
+    assertNoRed(el);
+  });
+
+  it('expired state uses warning amber (NOT red) at 0:00', () => {
     render(<ExamTimer totalSeconds={0} isRunning={false} />);
     const el = screen.getByTestId('exam-timer');
-    expect(el.textContent).toContain('Time up');
+    expect(el.textContent).toContain('Zeit abgelaufen');
+    expect(el.className).toMatch(/bg-warning-surface/);
+    expect(el.className).toMatch(/text-warning/);
+    assertNoRed(el);
   });
 
   it('does not tick when isRunning is false', () => {
     render(<ExamTimer totalSeconds={120} isRunning={false} />);
-    act(() => { vi.advanceTimersByTime(3000); });
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
     const el = screen.getByTestId('exam-timer');
     expect(el.textContent).toContain('2:00');
   });
 
   it('counts down when isRunning is true', () => {
     render(<ExamTimer totalSeconds={10} isRunning={true} />);
-    act(() => { vi.advanceTimersByTime(3000); });
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
     const el = screen.getByTestId('exam-timer');
     expect(el.textContent).toContain('0:07');
-  });
-
-  it('applies warning styling when remaining <= 300s', () => {
-    render(<ExamTimer totalSeconds={299} isRunning={false} />);
-    const el = screen.getByTestId('exam-timer');
-    expect(el.className).toMatch(/bg-warning-light/);
-    expect(el.className).toMatch(/text-warning/);
-  });
-
-  it('does not apply warning styling when remaining > 300s', () => {
-    render(<ExamTimer totalSeconds={301} isRunning={false} />);
-    const el = screen.getByTestId('exam-timer');
-    expect(el.className).not.toMatch(/bg-warning-light/);
   });
 
   it('calls onExpire exactly once when timer reaches 0', () => {
     const onExpire = vi.fn();
     render(<ExamTimer totalSeconds={2} isRunning={true} onExpire={onExpire} />);
-    act(() => { vi.advanceTimersByTime(3000); });
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
     expect(onExpire).toHaveBeenCalledTimes(1);
   });
 
-  it('useRef prevents stale closure — onExpire updated mid-run fires the latest callback', () => {
+  it('still amber (not red) after ticking down to 0 at runtime', () => {
+    render(<ExamTimer totalSeconds={2} isRunning={true} />);
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    const el = screen.getByTestId('exam-timer');
+    expect(el.textContent).toContain('Zeit abgelaufen');
+    expect(el.className).toMatch(/bg-warning-surface/);
+    assertNoRed(el);
+  });
+
+  it('useRef prevents stale closure — onExpire replaced mid-run fires latest', () => {
     const firstCb = vi.fn();
     const secondCb = vi.fn();
 
@@ -65,14 +116,24 @@ describe('ExamTimer', () => {
       <ExamTimer totalSeconds={3} isRunning={true} onExpire={firstCb} />,
     );
 
-    act(() => { vi.advanceTimersByTime(1000); });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
 
-    // Replace the callback — stale closure would fire firstCb, ref fires secondCb
     rerender(<ExamTimer totalSeconds={3} isRunning={true} onExpire={secondCb} />);
 
-    act(() => { vi.advanceTimersByTime(3000); });
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
 
     expect(firstCb).not.toHaveBeenCalled();
     expect(secondCb).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses font-mono + tabular-nums for stable digit width', () => {
+    render(<ExamTimer totalSeconds={600} isRunning={false} />);
+    const el = screen.getByTestId('exam-timer');
+    expect(el.className).toMatch(/font-mono/);
+    expect(el.className).toMatch(/tabular-nums/);
   });
 });

--- a/apps/web/src/__tests__/exam/ListeningExam.test.tsx
+++ b/apps/web/src/__tests__/exam/ListeningExam.test.tsx
@@ -131,9 +131,11 @@ describe('ListeningExam question type rendering', () => {
     const falsch = screen.getByTestId('question-option-tf1-falsch');
 
     await userEvent.click(richtig);
-    expect(richtig.className).toContain('border-brand-primary');
-    expect(richtig.className).toContain('bg-brand-primary-surface');
-    expect(falsch.className).not.toContain('border-brand-primary');
+    // Selection uses a 4px LEFT accent bar — not a full brand-filled background.
+    expect(richtig.getAttribute('data-state')).toBe('selected');
+    expect(richtig.className).toContain('border-l-brand-500');
+    expect(richtig.className).toContain('bg-surface-container');
+    expect(falsch.getAttribute('data-state')).toBe('default');
   });
 
   it('switching between part tabs renders correct UI per type', async () => {

--- a/apps/web/src/__tests__/exam/MockCard.test.tsx
+++ b/apps/web/src/__tests__/exam/MockCard.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MockCard } from '../../components/exam/MockCard';
+
+describe('MockCard', () => {
+  it('not-started state: no accent bar, no progress, chevron hidden at rest', () => {
+    render(
+      <MockCard
+        href="/exam/A1_mock_01"
+        level="A1"
+        mockNumber={1}
+        title="Alltag"
+        state="not-started"
+        testId="card"
+      />,
+    );
+    const card = screen.getByTestId('card');
+    expect(card.getAttribute('data-state')).toBe('not-started');
+    expect(screen.getByTestId('mock-card-footer').textContent).toMatch(/Noch nicht begonnen/);
+    expect(screen.queryByTestId('mock-card-progress')).toBeNull();
+    expect(screen.queryByTestId('mock-card-score')).toBeNull();
+  });
+
+  it('in-progress state: shows progress bar filled to percentage + section count footer', () => {
+    render(
+      <MockCard
+        href="/exam/A1_mock_02"
+        level="A1"
+        mockNumber={2}
+        title="Familie"
+        state="in-progress"
+        progress={0.5}
+        sectionsCompleted={2}
+        totalSections={4}
+        testId="card"
+      />,
+    );
+    const card = screen.getByTestId('card');
+    expect(card.getAttribute('data-state')).toBe('in-progress');
+    const bar = screen.getByTestId('mock-card-progress') as HTMLElement;
+    expect(bar.style.width).toBe('50%');
+    expect(screen.getByTestId('mock-card-footer').textContent).toMatch(/2 von 4 Abschnitten/);
+  });
+
+  it('completed + passed: surface-container bg + pass-colored score pill', () => {
+    render(
+      <MockCard
+        href="/exam/A1_mock_03"
+        level="A1"
+        mockNumber={3}
+        title="Wohnen"
+        state="completed"
+        score={0.78}
+        passed
+        testId="card"
+      />,
+    );
+    const card = screen.getByTestId('card');
+    expect(card.className).toMatch(/bg-surface-container/);
+    const pill = screen.getByTestId('mock-card-score');
+    expect(pill.textContent).toBe('78%');
+    expect(pill.className).toMatch(/bg-pass-surface/);
+    expect(pill.className).toMatch(/text-pass/);
+    expect(screen.getByTestId('mock-card-footer').textContent).toMatch(/Vollständig/);
+  });
+
+  it('completed + failed: score pill uses fail-surface + text-fail', () => {
+    render(
+      <MockCard
+        href="/exam/A1_mock_03"
+        level="A1"
+        mockNumber={3}
+        title="Wohnen"
+        state="completed"
+        score={0.42}
+        passed={false}
+        testId="card"
+      />,
+    );
+    const pill = screen.getByTestId('mock-card-score');
+    expect(pill.className).toMatch(/bg-fail-surface/);
+    expect(pill.className).toMatch(/text-fail/);
+  });
+
+  it('coming-soon: renders as a <div>, not an <a>; footer reads Bald verfügbar', () => {
+    render(
+      <MockCard
+        href="/exam/A1_mock_09"
+        level="A1"
+        mockNumber={9}
+        title="Reisen"
+        state="coming-soon"
+        testId="card"
+      />,
+    );
+    const card = screen.getByTestId('card');
+    expect(card.tagName.toLowerCase()).toBe('div');
+    expect(card.className).toMatch(/cursor-default/);
+    expect(screen.getByTestId('mock-card-footer').textContent).toMatch(/Bald verfügbar/);
+  });
+});

--- a/apps/web/src/__tests__/exam/SectionHub.test.tsx
+++ b/apps/web/src/__tests__/exam/SectionHub.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SectionHub, type HubSection } from '../../components/exam/SectionHub';
+
+const A1_WRITTEN: HubSection[] = [
+  { key: 'listening', name: 'Hören', route: 'listening', durationSec: 20 * 60 },
+  { key: 'reading', name: 'Lesen', route: 'reading', durationSec: 25 * 60 },
+  { key: 'writing', name: 'Schreiben', route: 'writing', durationSec: 20 * 60 },
+];
+
+const B1_WRITTEN: HubSection[] = [
+  { key: 'listening', name: 'Hören', route: 'listening', durationSec: 30 * 60 },
+  { key: 'reading', name: 'Lesen', route: 'reading', durationSec: 45 * 60 },
+  {
+    key: 'sprachbausteine',
+    name: 'Sprachbausteine',
+    route: 'sprachbausteine',
+    durationSec: 15 * 60,
+  },
+  { key: 'writing', name: 'Schreiben', route: 'writing', durationSec: 30 * 60 },
+];
+
+const ORAL: HubSection[] = [
+  { key: 'speaking', name: 'Sprechen', route: 'speaking', durationSec: 15 * 60 },
+];
+
+describe('SectionHub', () => {
+  beforeEach(() => {
+    // Reset sessionStorage between tests so status dots start grey.
+    sessionStorage.clear();
+  });
+
+  it('groups sections into Schriftlich and Mündlich blocks with pass-threshold reminder', () => {
+    render(
+      <SectionHub
+        mockId="A1_mock_01"
+        level="A1"
+        written={A1_WRITTEN}
+        oral={ORAL}
+        hasContent
+      />,
+    );
+
+    const schriftlich = screen.getByTestId('hub-group-schriftlich');
+    const muendlich = screen.getByTestId('hub-group-mündlich');
+
+    expect(schriftlich).toBeTruthy();
+    expect(muendlich).toBeTruthy();
+    expect(schriftlich.textContent).toMatch(/min\. 60% zum Bestehen/);
+    expect(muendlich.textContent).toMatch(/min\. 60% zum Bestehen/);
+  });
+
+  it('A1 mock: no Sprachbausteine row in the written block', () => {
+    render(
+      <SectionHub
+        mockId="A1_mock_01"
+        level="A1"
+        written={A1_WRITTEN}
+        oral={ORAL}
+        hasContent
+      />,
+    );
+    expect(screen.queryByTestId('hub-section-sprachbausteine')).toBeNull();
+    expect(screen.getByTestId('hub-section-listening')).toBeTruthy();
+    expect(screen.getByTestId('hub-section-reading')).toBeTruthy();
+    expect(screen.getByTestId('hub-section-writing')).toBeTruthy();
+    expect(screen.getByTestId('hub-section-speaking')).toBeTruthy();
+  });
+
+  it('B1 mock: Sprachbausteine row appears in the written block', () => {
+    render(
+      <SectionHub
+        mockId="B1_mock_01"
+        level="B1"
+        written={B1_WRITTEN}
+        oral={ORAL}
+        hasContent
+      />,
+    );
+    const row = screen.getByTestId('hub-section-sprachbausteine');
+    expect(row).toBeTruthy();
+    // The Schriftlich block should contain it (not the oral block).
+    const schriftlich = screen.getByTestId('hub-group-schriftlich');
+    expect(schriftlich.contains(row)).toBe(true);
+  });
+
+  it('default CTA reads "Mit Hören starten" when nothing has been attempted', () => {
+    render(
+      <SectionHub
+        mockId="A1_mock_01"
+        level="A1"
+        written={A1_WRITTEN}
+        oral={ORAL}
+        hasContent
+      />,
+    );
+    const cta = screen.getByTestId('section-hub-cta');
+    expect(cta.textContent).toMatch(/Mit Hören starten/);
+  });
+
+  it('status dot is grey (bg-text-tertiary) for not-started rows', () => {
+    render(
+      <SectionHub
+        mockId="A1_mock_01"
+        level="A1"
+        written={A1_WRITTEN}
+        oral={ORAL}
+        hasContent
+      />,
+    );
+    const dot = screen.getByTestId('hub-status-dot-listening');
+    expect(dot.getAttribute('data-status')).toBe('not-started');
+    expect(dot.className).toMatch(/bg-text-tertiary/);
+  });
+});

--- a/apps/web/src/__tests__/exam/SectionIntro.test.tsx
+++ b/apps/web/src/__tests__/exam/SectionIntro.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Headphones, FileText, Pencil, Mic } from 'lucide-react';
 import { SectionIntro } from '../../components/exam/SectionIntro';
 
 describe('SectionIntro', () => {
@@ -8,23 +9,24 @@ describe('SectionIntro', () => {
     render(
       <SectionIntro
         title="Hören"
-        icon="🎧"
+        Icon={Headphones}
         totalSeconds={1200}
         description="3 Teile · 18 Aufgaben"
         onStart={() => {}}
       />,
     );
 
-    expect(screen.getByText('🎧')).toBeTruthy();
     expect(screen.getByText('Hören')).toBeTruthy();
     expect(screen.getByText('3 Teile · 18 Aufgaben')).toBeTruthy();
+    // lucide renders an <svg> with class lucide-headphones
+    expect(document.querySelector('.lucide-headphones')).toBeTruthy();
   });
 
   it('shows time in minutes', () => {
     render(
       <SectionIntro
         title="Lesen"
-        icon="📖"
+        Icon={FileText}
         totalSeconds={1500}
         description="3 Teile"
         onStart={() => {}}
@@ -39,7 +41,7 @@ describe('SectionIntro', () => {
     render(
       <SectionIntro
         title="Schreiben"
-        icon="✍️"
+        Icon={Pencil}
         totalSeconds={1200}
         description="2 Aufgaben"
         onStart={onStart}
@@ -54,7 +56,7 @@ describe('SectionIntro', () => {
     render(
       <SectionIntro
         title="Sprechen"
-        icon="🗣️"
+        Icon={Mic}
         totalSeconds={900}
         description="3 Aufgaben"
         extraInfo="Vorbereitungszeit: 20 Minuten"
@@ -69,7 +71,7 @@ describe('SectionIntro', () => {
     render(
       <SectionIntro
         title="Test"
-        icon="📝"
+        Icon={FileText}
         totalSeconds={0}
         description="0 Aufgaben"
         onStart={() => {}}

--- a/apps/web/src/app/exam/[mockId]/page.tsx
+++ b/apps/web/src/app/exam/[mockId]/page.tsx
@@ -1,9 +1,11 @@
 import { notFound } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
 import { LEVEL_CONFIG } from "@fastrack/config";
-import { SECTION_DURATIONS, formatTime } from "@fastrack/core";
+import { SECTION_DURATIONS } from "@fastrack/core";
 import type { Level } from "@fastrack/types";
 import { loadMockExam, parseMockId } from "@/lib/loadMockExam";
-import { SectionStatusBadge, SectionActionButton, ViewResultsLink } from "@/components/exam/SectionStatus";
+import { SectionHub, type HubSection } from "@/components/exam/SectionHub";
+import { ViewResultsLink } from "@/components/exam/SectionStatus";
 
 export default async function MockExamDetailPage({
   params,
@@ -19,54 +21,62 @@ export default async function MockExamDetailPage({
   const level = levelStr as Level;
   const cfg = LEVEL_CONFIG[level];
 
-  // Check if actual content exists for this mock
   const exam = await loadMockExam(level, mockNumber);
   const hasContent = exam !== null;
-  const durations = SECTION_DURATIONS[level];
-
+  const durations = SECTION_DURATIONS[level] as Record<string, number | undefined>;
   const hasSprachbausteine = Boolean(exam?.sections.sprachbausteine);
 
-  const sections = [
-    { name: "Hören", key: "listening" as const, icon: "🎧", route: "listening" },
-    { name: "Lesen", key: "reading" as const, icon: "📖", route: "reading" },
+  const written: HubSection[] = [
+    {
+      key: "listening",
+      name: "Hören",
+      route: "listening",
+      durationSec: durations.listening ?? 0,
+    },
+    {
+      key: "reading",
+      name: "Lesen",
+      route: "reading",
+      durationSec: durations.reading ?? 0,
+    },
     ...(hasSprachbausteine
       ? [
           {
-            name: "Sprachbausteine",
             key: "sprachbausteine" as const,
-            icon: "🧩",
+            name: "Sprachbausteine",
             route: "sprachbausteine",
+            durationSec: durations.sprachbausteine ?? 0,
           },
         ]
       : []),
-    { name: "Schreiben", key: "writing" as const, icon: "✍️", route: "writing" },
-    { name: "Sprechen", key: "speaking" as const, icon: "🗣️", route: "speaking" },
+    {
+      key: "writing",
+      name: "Schreiben",
+      route: "writing",
+      durationSec: durations.writing ?? 0,
+    },
+  ];
+
+  const oral: HubSection[] = [
+    {
+      key: "speaking",
+      name: "Sprechen",
+      route: "speaking",
+      durationSec: durations.speaking ?? 0,
+    },
   ];
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
-      {/* Back link */}
       <a
         href={`/exam?level=${level}`}
-        className="inline-flex items-center gap-1 text-sm text-text-secondary hover:text-brand-primary"
+        className="inline-flex items-center gap-1.5 text-sm text-text-secondary transition-colors hover:text-text-primary"
       >
-        <svg
-          className="h-4 w-4"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M15 19l-7-7 7-7"
-          />
-        </svg>
-        Back to {level} exams
+        <ArrowLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+        Zurück zu {level}-Übungstests
       </a>
 
-      {/* Header */}
+      {/* Exam header */}
       <div className="rounded-xl border border-border bg-white p-6">
         <div className="flex items-center gap-3">
           <span
@@ -83,80 +93,22 @@ export default async function MockExamDetailPage({
           </div>
         </div>
 
-        <div className="mt-4 rounded-lg bg-surface-container p-4 text-sm text-text-secondary">
-          Bestehensgrenze: {cfg.passThreshold * 100}% in schriftlicher und
-          mündlicher Prüfung.
-        </div>
-
         {!hasContent && (
-          <div className="mt-3 rounded-lg border border-warning bg-warning-light px-4 py-2 text-sm text-warning">
+          <div className="mt-4 rounded-lg border border-warning bg-warning-surface px-4 py-2 text-sm text-warning">
             Inhalt noch nicht verfügbar — kommt bald.
           </div>
         )}
       </div>
 
-      {/* Sections */}
-      <div className="space-y-3">
-        <h2 className="text-lg font-semibold text-text-primary">Abschnitte</h2>
-        {sections.map((section) => {
-          const duration =
-            (durations as Record<string, number | undefined>)[section.key] ?? 0;
-          const href = `/exam/${mockId}/${section.route}`;
-          return (
-            <div
-              key={section.key}
-              className="flex items-center justify-between rounded-xl border border-border bg-white p-5"
-            >
-              <div className="flex items-center gap-3">
-                <span className="text-2xl" role="img" aria-hidden>
-                  {section.icon}
-                </span>
-                <div>
-                  <div className="flex items-center font-semibold text-text-primary">
-                    {section.name}
-                    {hasContent && (
-                      <SectionStatusBadge mockId={mockId} sectionKey={section.key} />
-                    )}
-                  </div>
-                  <div className="text-sm text-text-secondary">
-                    {duration > 0 ? `${Math.round(duration / 60)} Min.` : "—"}
-                  </div>
-                </div>
-              </div>
-              {hasContent ? (
-                <SectionActionButton
-                  mockId={mockId}
-                  sectionKey={section.key}
-                  href={href}
-                  color={cfg.color}
-                />
-              ) : (
-                <span className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-disabled">
-                  Bald
-                </span>
-              )}
-            </div>
-          );
-        })}
-      </div>
+      <SectionHub
+        mockId={mockId}
+        level={level}
+        written={written}
+        oral={oral}
+        hasContent={hasContent}
+      />
 
-      {/* View results (shown when at least one section completed) */}
       {hasContent && <ViewResultsLink mockId={mockId} />}
-
-      {/* Start full exam */}
-      {hasContent ? (
-        <a
-          href={`/exam/${mockId}/listening`}
-          className="block w-full rounded-xl py-4 text-center text-lg font-semibold text-white transition-colors hover:opacity-90"
-          style={{ backgroundColor: cfg.color }}
-        >
-          Vollständige Prüfung starten
-        </a>
-      ) : (
-        <div className="w-full rounded-xl py-4 text-center text-lg font-semibold text-text-disabled bg-surface-container">
-          Inhalt noch nicht verfügbar
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/src/app/exam/page.tsx
+++ b/apps/web/src/app/exam/page.tsx
@@ -1,6 +1,8 @@
 import { LEVEL_CONFIG } from "@fastrack/config";
 import { getMocksForLevel, getAvailableLevels } from "@fastrack/content";
 import type { Level } from "@fastrack/types";
+import { loadMockExam } from "@/lib/loadMockExam";
+import { MockCardList } from "@/components/exam/MockCardList";
 
 export default function ExamListPage({
   searchParams,
@@ -23,17 +25,34 @@ async function ExamListContent({
   const mocks = getMocksForLevel(activeLevel);
   const cfg = LEVEL_CONFIG[activeLevel];
 
+  // Determine which catalog entries actually have JSON content on disk. This
+  // is a cheap fs probe per mock; results are a few dozen per level at most.
+  const mocksWithAvailability = await Promise.all(
+    mocks.map(async (m) => {
+      const exam = await loadMockExam(activeLevel, m.mockNumber);
+      return {
+        id: m.id,
+        mockNumber: m.mockNumber,
+        title: m.title.split(": ")[1] ?? m.title,
+        hasContent: exam !== null,
+      };
+    }),
+  );
+
+  const anyContent = mocksWithAvailability.some((m) => m.hasContent);
+  const totalSections = 4; // Hören, Lesen, Schreiben, Sprechen — base count
+
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-text-primary">Mock Exams</h1>
+        <h1 className="text-2xl font-bold text-text-primary">Übungstests</h1>
         <p className="mt-1 text-sm text-text-secondary">
-          Full timed practice exams following the official telc format
+          Vollständige Prüfungssimulationen nach offiziellem telc-Format.
         </p>
       </div>
 
-      {/* Level tabs */}
-      <div className="flex flex-wrap gap-2">
+      {/* Level pills */}
+      <div className="flex flex-wrap gap-2" role="tablist" aria-label="CEFR-Stufen">
         {levels.map((lvl) => {
           const isActive = lvl === activeLevel;
           const lvlCfg = LEVEL_CONFIG[lvl];
@@ -41,10 +60,13 @@ async function ExamListContent({
             <a
               key={lvl}
               href={`/exam?level=${lvl}`}
+              role="tab"
+              aria-selected={isActive}
+              data-testid={`level-tab-${lvl}`}
               className={`rounded-full px-4 py-2 text-sm font-medium transition-colors ${
                 isActive
                   ? "text-white"
-                  : "border border-[#e0e0e0] bg-white text-text-secondary hover:border-[#bdbdbd]"
+                  : "border border-border bg-white text-text-secondary hover:border-border-hover"
               }`}
               style={isActive ? { backgroundColor: lvlCfg.color } : undefined}
             >
@@ -54,67 +76,39 @@ async function ExamListContent({
         })}
       </div>
 
-      {/* Level info */}
+      {/* Level info strip — uses level-surface + level-text (no hex-opacity hack). */}
       <div
         className="rounded-lg border-l-4 p-4"
-        style={{ borderColor: cfg.color, backgroundColor: `${cfg.color}10` }}
+        data-testid="level-info-strip"
+        style={{
+          borderColor: cfg.color,
+          backgroundColor: cfg.surface,
+          color: cfg.textColor,
+        }}
       >
-        <div className="font-semibold text-text-primary">{cfg.label}</div>
-        <div className="mt-1 text-sm text-text-secondary">
-          ~{cfg.targetHours} hours to exam ready &middot; {cfg.passThreshold * 100}%
-          pass threshold in both written and oral
+        <div className="font-semibold">{cfg.label}</div>
+        <div className="mt-1 text-sm opacity-90">
+          ~{cfg.targetHours} Stunden bis zur Prüfungsreife &middot;{" "}
+          {cfg.passThreshold * 100}% Bestehensgrenze in schriftlicher und
+          mündlicher Prüfung.
         </div>
       </div>
 
-      {/* Mock exam grid */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {mocks.map((mock) => (
-          <a
-            key={mock.id}
-            href={`/exam/${mock.id}`}
-            className="group rounded-xl border border-[#e0e0e0] bg-white p-5 transition-shadow hover:shadow-md"
-          >
-            <div className="flex items-start justify-between">
-              <div>
-                <span
-                  className="inline-block rounded-md px-2 py-0.5 text-xs font-semibold text-white"
-                  style={{ backgroundColor: cfg.color }}
-                >
-                  {activeLevel}
-                </span>
-                <h3 className="mt-2 font-semibold text-text-primary">
-                  Übungstest {mock.mockNumber}
-                </h3>
-                <p className="mt-1 text-sm text-text-secondary">
-                  {mock.title.split(": ")[1] || mock.title}
-                </p>
-              </div>
-              <svg
-                className="mt-1 h-5 w-5 text-text-disabled transition-colors group-hover:text-brand-primary"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M9 5l7 7-7 7"
-                />
-              </svg>
-            </div>
-            <div className="mt-4 flex gap-3 text-xs text-text-secondary">
-              <span>Hören</span>
-              <span>&middot;</span>
-              <span>Lesen</span>
-              <span>&middot;</span>
-              <span>Schreiben</span>
-              <span>&middot;</span>
-              <span>Sprechen</span>
-            </div>
-          </a>
-        ))}
-      </div>
+      {/* Mock grid or empty state */}
+      {anyContent ? (
+        <MockCardList
+          level={activeLevel}
+          mocks={mocksWithAvailability}
+          totalSections={totalSections}
+        />
+      ) : (
+        <div
+          className="rounded-xl border border-border bg-white py-12 text-center text-sm text-text-secondary"
+          data-testid="mocks-empty-state"
+        >
+          {activeLevel} Übungstests sind bald verfügbar.
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/exam/AnswerOption.tsx
+++ b/apps/web/src/components/exam/AnswerOption.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Check, X } from 'lucide-react';
+
+type AnswerState =
+  | 'default'
+  | 'selected'
+  | 'correct'
+  | 'wrong'
+  | 'correctUnselected';
+
+interface AnswerOptionProps {
+  name: string;
+  value: string;
+  selected: boolean;
+  onChange: (value: string) => void;
+  children: ReactNode;
+  testId?: string;
+  /** Post-submit state override. Leave undefined during active phase. */
+  review?: {
+    isCorrect: boolean;
+    userPicked: boolean;
+  };
+  disabled?: boolean;
+}
+
+/**
+ * Shared exam answer option. Selection uses a 4px left accent bar rather than
+ * filling the entire row — per `.planning/design-system/screens.md` §Screen 4
+ * the brand-filled approach was too heavy and read as a correctness signal.
+ *
+ * Post-submit states:
+ *  - correct + picked       → pass-surface + pass border + Check
+ *  - wrong + picked         → fail-surface + fail border + X
+ *  - correct + not picked   → pass-surface + pass border (reveals answer)
+ */
+export function AnswerOption({
+  name,
+  value,
+  selected,
+  onChange,
+  children,
+  testId,
+  review,
+  disabled,
+}: AnswerOptionProps) {
+  let state: AnswerState = 'default';
+  if (review) {
+    if (review.isCorrect && review.userPicked) state = 'correct';
+    else if (!review.isCorrect && review.userPicked) state = 'wrong';
+    else if (review.isCorrect && !review.userPicked) state = 'correctUnselected';
+  } else if (selected) {
+    state = 'selected';
+  }
+
+  const base =
+    'relative flex min-h-[48px] w-full cursor-pointer items-center gap-3 rounded-lg border px-4 py-3 pl-5 transition-colors';
+
+  const toneByState: Record<AnswerState, string> = {
+    default: 'border-border bg-white hover:border-border-hover',
+    selected:
+      'border-border bg-surface-container border-l-[4px] border-l-brand-500 pl-[calc(1.25rem-3px)]',
+    correct:
+      'border-border bg-pass-surface border-l-[4px] border-l-pass pl-[calc(1.25rem-3px)]',
+    wrong:
+      'border-border bg-fail-surface border-l-[4px] border-l-fail pl-[calc(1.25rem-3px)]',
+    correctUnselected:
+      'border-border bg-pass-surface border-l-[4px] border-l-pass pl-[calc(1.25rem-3px)]',
+  };
+
+  const isReviewing = Boolean(review);
+
+  return (
+    <label
+      data-testid={testId}
+      data-state={state}
+      className={`${base} ${toneByState[state]} ${
+        isReviewing || disabled ? 'cursor-default' : ''
+      }`}
+    >
+      <input
+        type="radio"
+        name={name}
+        value={value}
+        checked={selected}
+        onChange={() => onChange(value)}
+        disabled={isReviewing || disabled}
+        className="h-4 w-4 shrink-0 accent-brand-500"
+      />
+      <span className="flex-1 text-[15px] leading-snug text-text-primary">
+        {children}
+      </span>
+      {state === 'correct' && (
+        <Check className="h-5 w-5 shrink-0 text-pass" strokeWidth={2.25} aria-hidden />
+      )}
+      {state === 'wrong' && (
+        <X className="h-5 w-5 shrink-0 text-fail" strokeWidth={2.25} aria-hidden />
+      )}
+      {state === 'correctUnselected' && (
+        <Check className="h-5 w-5 shrink-0 text-pass" strokeWidth={2.25} aria-hidden />
+      )}
+    </label>
+  );
+}

--- a/apps/web/src/components/exam/AnswerOption.tsx
+++ b/apps/web/src/components/exam/AnswerOption.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import type { PropsWithChildren } from 'react';
 import { Check, X } from 'lucide-react';
 
 type AnswerState =
@@ -10,12 +10,11 @@ type AnswerState =
   | 'wrong'
   | 'correctUnselected';
 
-interface AnswerOptionProps {
+type AnswerOptionProps = PropsWithChildren<{
   name: string;
   value: string;
   selected: boolean;
   onChange: (value: string) => void;
-  children: ReactNode;
   testId?: string;
   /** Post-submit state override. Leave undefined during active phase. */
   review?: {
@@ -23,7 +22,7 @@ interface AnswerOptionProps {
     userPicked: boolean;
   };
   disabled?: boolean;
-}
+}>;
 
 /**
  * Shared exam answer option. Selection uses a 4px left accent bar rather than

--- a/apps/web/src/components/exam/ExamRunnerHeader.tsx
+++ b/apps/web/src/components/exam/ExamRunnerHeader.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import type { Level } from '@fastrack/types';
+import { LEVEL_CONFIG } from '@fastrack/config';
+import { ExamTimer } from './ExamTimer';
+
+interface ExamRunnerHeaderProps {
+  sectionName: string;
+  partLabel?: string;
+  totalSeconds: number;
+  isRunning: boolean;
+  onExpire?: () => void;
+  exitHref: string;
+  level: Level;
+  /** 0..1 — fills the 3px accent bar below the header. */
+  progress?: number;
+}
+
+/**
+ * Unified top chrome for the five *Exam runners. Single 3-column flex row
+ * (X + label | section | timer) over a 3px progress bar in the active
+ * level color. See `.planning/design-system/screens.md` §Screen 4.
+ */
+export function ExamRunnerHeader({
+  sectionName,
+  partLabel,
+  totalSeconds,
+  isRunning,
+  onExpire,
+  exitHref,
+  level,
+  progress = 0,
+}: ExamRunnerHeaderProps) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const levelCfg = LEVEL_CONFIG[level];
+  const pct = Math.max(0, Math.min(1, progress)) * 100;
+
+  return (
+    <div className="-mx-4 mb-6 border-b border-border bg-white sm:mx-0 sm:rounded-t-xl">
+      <div className="flex h-14 items-center justify-between gap-4 px-4">
+        <button
+          type="button"
+          onClick={() => setConfirmOpen(true)}
+          data-testid="exam-exit-btn"
+          className="inline-flex items-center gap-1.5 text-sm text-text-secondary transition-colors hover:text-text-primary"
+        >
+          <X className="h-4 w-4" strokeWidth={2} aria-hidden />
+          <span>Prüfung beenden</span>
+        </button>
+
+        <div
+          className="min-w-0 flex-1 truncate text-center text-sm font-medium text-text-primary"
+          data-testid="exam-header-title"
+        >
+          {sectionName}
+          {partLabel ? <span className="text-text-secondary"> — {partLabel}</span> : null}
+        </div>
+
+        <ExamTimer
+          totalSeconds={totalSeconds}
+          isRunning={isRunning}
+          onExpire={onExpire}
+        />
+      </div>
+
+      {/* 3px progress bar — fills in level color, no label. */}
+      <div
+        className="h-[3px] w-full rounded-full bg-surface-container"
+        aria-hidden
+      >
+        <div
+          data-testid="exam-progress-bar"
+          className="h-full rounded-full transition-[width] duration-200 ease-out"
+          style={{ width: `${pct}%`, backgroundColor: levelCfg.color }}
+        />
+      </div>
+
+      {confirmOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-950/40 p-4"
+          role="dialog"
+          aria-modal="true"
+          data-testid="exam-exit-dialog"
+        >
+          <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-lg">
+            <h2 className="text-base font-semibold text-text-primary">
+              Prüfung wirklich beenden?
+            </h2>
+            <p className="mt-2 text-sm text-text-secondary">
+              Dein Fortschritt in diesem Abschnitt geht verloren.
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmOpen(false)}
+                className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:border-border-hover"
+              >
+                Weitermachen
+              </button>
+              <a
+                href={exitHref}
+                data-testid="exam-exit-confirm"
+                className="rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
+              >
+                Beenden
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/exam/ExamRunnerHeader.tsx
+++ b/apps/web/src/components/exam/ExamRunnerHeader.tsx
@@ -39,6 +39,9 @@ export function ExamRunnerHeader({
 
   return (
     <div className="-mx-4 mb-6 border-b border-border bg-white sm:mx-0 sm:rounded-t-xl">
+      {/* Visually-hidden section heading — gives screen readers a proper
+          landmark to announce and keeps the role=heading contract for e2e. */}
+      <h1 className="sr-only">{sectionName}</h1>
       <div className="flex h-14 items-center justify-between gap-4 px-4">
         <button
           type="button"

--- a/apps/web/src/components/exam/ExamSubmitButton.tsx
+++ b/apps/web/src/components/exam/ExamSubmitButton.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import type { ButtonHTMLAttributes } from 'react';
+
+interface ExamSubmitButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'className'> {
+  label?: string;
+}
+
+export function ExamSubmitButton({
+  label = 'Antworten abgeben',
+  disabled,
+  ...rest
+}: ExamSubmitButtonProps) {
+  return (
+    <button
+      type="button"
+      data-testid="submit-btn"
+      disabled={disabled}
+      className="block h-[52px] w-full rounded-xl bg-brand-600 text-sm font-semibold text-white transition-colors hover:bg-brand-700 disabled:cursor-not-allowed disabled:bg-neutral-300 disabled:text-text-tertiary"
+      {...rest}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/web/src/components/exam/ExamTimer.tsx
+++ b/apps/web/src/components/exam/ExamTimer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { Clock } from 'lucide-react';
 import { formatTime } from '@fastrack/core';
 
 interface ExamTimerProps {
@@ -9,18 +10,24 @@ interface ExamTimerProps {
   onExpire?: () => void;
 }
 
+/**
+ * Exam-wide countdown timer.
+ *
+ * Ethics gate — the timer never turns red. The expired state uses the same
+ * amber warning palette as the <5-min state. A red timer at 0:00 triggers
+ * panic; we surface the state change through text only (`Zeit abgelaufen`).
+ * See `.planning/design-system/tokens.md` §Timer for the rationale.
+ */
 export function ExamTimer({ totalSeconds, isRunning, onExpire }: ExamTimerProps) {
   const [remaining, setRemaining] = useState(totalSeconds);
   const isExpired = remaining <= 0;
-  const isWarning = !isExpired && remaining <= 5 * 60;
+  const isWarning = remaining <= 5 * 60;
 
-  // Capture latest onExpire without re-triggering the interval effect
   const onExpireRef = useRef(onExpire);
   useEffect(() => {
     onExpireRef.current = onExpire;
   }, [onExpire]);
 
-  // Guard so onExpire fires at most once per timer session
   const expiredFiredRef = useRef(false);
 
   useEffect(() => {
@@ -49,28 +56,20 @@ export function ExamTimer({ totalSeconds, isRunning, onExpire }: ExamTimerProps)
     return () => clearInterval(id);
   }, [isRunning, isExpired]);
 
+  // Warning and expired share the same amber treatment — no red, ever.
+  const toneClass = isWarning
+    ? 'bg-warning-surface text-warning'
+    : 'bg-surface-container text-text-secondary';
+
   return (
     <div
       data-testid="exam-timer"
-      className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-mono font-semibold tabular-nums ${
-        isExpired
-          ? 'bg-error-light text-error'
-          : isWarning
-            ? 'bg-warning-light text-warning'
-            : 'bg-surface-container text-timer-normal'
-      }`}
+      role="timer"
+      aria-live="polite"
+      className={`inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-sm font-mono font-semibold tabular-nums ${toneClass}`}
     >
-      <svg
-        className="h-4 w-4 shrink-0"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <circle cx="12" cy="12" r="10" />
-        <path d="M12 6v6l4 2" />
-      </svg>
-      {isExpired ? 'Time up' : formatTime(remaining)}
+      <Clock className="h-3 w-3 shrink-0" strokeWidth={2} aria-hidden="true" />
+      <span>{isExpired ? 'Zeit abgelaufen' : formatTime(remaining)}</span>
     </div>
   );
 }

--- a/apps/web/src/components/exam/ListeningExam.tsx
+++ b/apps/web/src/components/exam/ListeningExam.tsx
@@ -1,14 +1,17 @@
 'use client';
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
+import { Headphones } from 'lucide-react';
 import { SECTION_DURATIONS, calculateSectionScore } from '@fastrack/core';
 import type { ListeningSection, Level } from '@fastrack/types';
 import type { ExamPhase } from '@/lib/examTypes';
 import { saveSection } from '@/lib/examSession';
-import { ExamTimer } from './ExamTimer';
+import { ExamRunnerHeader } from './ExamRunnerHeader';
 import { SectionIntro } from './SectionIntro';
 import { QuestionResultRow } from './QuestionResultRow';
 import { AudioPlayer } from './AudioPlayer';
+import { AnswerOption } from './AnswerOption';
+import { ExamSubmitButton } from './ExamSubmitButton';
 
 interface ListeningExamProps {
   mockId: string;
@@ -50,15 +53,18 @@ export function ListeningExam({ mockId, level, section }: ListeningExamProps) {
     [section.parts, answers],
   );
 
+  const totalQuestions = section.parts.reduce((n, p) => n + p.questions.length, 0);
+  const answeredCount = Object.keys(answers).length;
+  const progress = totalQuestions > 0 ? answeredCount / totalQuestions : 0;
+
   const part = section.parts[currentPart];
   const totalParts = section.parts.length;
-  const totalQuestions = section.parts.reduce((n, p) => n + p.questions.length, 0);
 
   if (phase === 'intro') {
     return (
       <SectionIntro
         title="Hören"
-        icon="🎧"
+        Icon={Headphones}
         totalSeconds={totalSeconds}
         description={`${totalParts} Teile · ${totalQuestions} Aufgaben`}
         onStart={handleStart}
@@ -72,7 +78,7 @@ export function ListeningExam({ mockId, level, section }: ListeningExamProps) {
       <div className="space-y-6">
         <div
           className={`rounded-xl border-2 p-6 text-center ${
-            score.passed ? 'border-pass bg-pass-light' : 'border-fail bg-fail-light'
+            score.passed ? 'border-pass bg-pass-surface' : 'border-fail bg-fail-surface'
           }`}
         >
           <div className={`text-4xl font-bold ${score.passed ? 'text-pass' : 'text-fail'}`}>
@@ -116,7 +122,7 @@ export function ListeningExam({ mockId, level, section }: ListeningExamProps) {
           <a
             data-testid="next-section-link"
             href={`/exam/${mockId}/reading`}
-            className="flex-1 rounded-xl bg-brand-primary py-3 text-center text-sm font-semibold text-white hover:opacity-90"
+            className="flex-1 rounded-xl bg-brand-600 py-3 text-center text-sm font-semibold text-white hover:bg-brand-700"
           >
             Weiter: Lesen
           </a>
@@ -126,159 +132,141 @@ export function ListeningExam({ mockId, level, section }: ListeningExamProps) {
   }
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-bold text-text-primary">Hören</h1>
-          <p className="text-sm text-text-secondary">
-            Teil {currentPart + 1} von {totalParts}
-          </p>
-        </div>
-        <ExamTimer
-          totalSeconds={totalSeconds}
-          isRunning={phase === 'active'}
-          onExpire={handleExpire}
-        />
-      </div>
-
-      <div className="flex gap-2">
-        {section.parts.map((p, i) => {
-          const partDone = p.questions.every((q) => answers[q.id] !== undefined);
-          return (
-            <button
-              key={p.partNumber}
-              data-testid={`part-tab-${p.partNumber}`}
-              onClick={() => setCurrentPart(i)}
-              className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
-                i === currentPart
-                  ? 'bg-brand-primary text-white'
-                  : partDone
-                    ? 'bg-success-light text-success'
-                    : 'border border-border bg-white text-text-secondary hover:border-border-hover'
-              }`}
-            >
-              Teil {p.partNumber}
-            </button>
-          );
-        })}
-      </div>
-
-      <div className="rounded-lg border border-border bg-white p-4">
-        <p className="text-sm font-medium text-text-primary">{part.instructions}</p>
-        {part.instructionsTranslation && (
-          <p className="mt-1 text-xs text-text-secondary">{part.instructionsTranslation}</p>
-        )}
-      </div>
-
-      <AudioPlayer
-        key={`audio-part-${part.partNumber}`}
-        audioFile={part.audioFile}
-        playCount={part.playCount}
-        transcript={
-          part.audioTranscript ??
-          [part.instructions, ...part.questions.map((q) => q.questionText)].join('. ')
-        }
+    <div>
+      <ExamRunnerHeader
+        sectionName="Hören"
+        partLabel={`Teil ${currentPart + 1}`}
+        totalSeconds={totalSeconds}
+        isRunning={phase === 'active'}
+        onExpire={handleExpire}
+        exitHref={`/exam/${mockId}`}
+        level={level}
+        progress={progress}
       />
 
-      <div className="space-y-4">
-        {part.questions.map((q, qi) => (
-          <div key={q.id} className="rounded-xl border border-border bg-white p-5">
-            <p className="mb-3 font-medium text-text-primary">
-              {qi + 1}. {q.questionText}
-            </p>
+      <div className="space-y-6">
+        <div className="flex gap-2">
+          {section.parts.map((p, i) => {
+            const partDone = p.questions.every((q) => answers[q.id] !== undefined);
+            return (
+              <button
+                key={p.partNumber}
+                data-testid={`part-tab-${p.partNumber}`}
+                onClick={() => setCurrentPart(i)}
+                className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                  i === currentPart
+                    ? 'bg-brand-600 text-white'
+                    : partDone
+                      ? 'bg-pass-surface text-pass'
+                      : 'border border-border bg-white text-text-secondary hover:border-border-hover'
+                }`}
+              >
+                Teil {p.partNumber}
+              </button>
+            );
+          })}
+        </div>
 
-            {q.type === 'true_false' && (
-              <div className="flex gap-3">
-                {['richtig', 'falsch'].map((opt) => {
-                  const selected = answers[q.id] === opt;
-                  return (
-                    <label
-                      key={opt}
-                      data-testid={`question-option-${q.id}-${opt}`}
-                      className={`flex cursor-pointer items-center gap-2 rounded-lg border px-5 py-2.5 transition-colors ${
-                        selected
-                          ? 'border-brand-primary bg-brand-primary-surface'
-                          : 'border-border bg-white hover:border-border-hover'
-                      }`}
-                    >
-                      <input
-                        type="radio"
-                        name={q.id}
-                        value={opt}
-                        checked={selected}
-                        onChange={() => handleAnswer(q.id, opt)}
-                        className="accent-brand-primary"
-                      />
-                      <span className="text-sm font-medium text-text-primary capitalize">
-                        {opt}
-                      </span>
-                    </label>
-                  );
-                })}
-              </div>
-            )}
+        <div className="rounded-lg border border-border bg-white p-4">
+          <p className="text-sm font-medium text-text-primary">{part.instructions}</p>
+          {part.instructionsTranslation && (
+            <p className="mt-1 text-xs text-text-secondary">{part.instructionsTranslation}</p>
+          )}
+        </div>
 
-            {q.type === 'mcq' && (
-              <div className="space-y-2">
-                {(q.options ?? []).map((opt) => {
-                  const value = opt.split(')')[0].trim();
-                  const selected = answers[q.id] === value;
-                  return (
-                    <label
+        <AudioPlayer
+          key={`audio-part-${part.partNumber}`}
+          audioFile={part.audioFile}
+          playCount={part.playCount}
+          transcript={
+            part.audioTranscript ??
+            [part.instructions, ...part.questions.map((q) => q.questionText)].join('. ')
+          }
+        />
+
+        <div className="space-y-4">
+          {part.questions.map((q, qi) => (
+            <div key={q.id} className="rounded-xl border border-border bg-white p-5">
+              <p className="mb-3 font-medium text-text-primary">
+                {qi + 1}. {q.questionText}
+              </p>
+
+              {q.type === 'true_false' && (
+                <div className="space-y-2">
+                  {['richtig', 'falsch'].map((opt) => (
+                    <AnswerOption
                       key={opt}
-                      data-testid={`question-option-${q.id}-${value}`}
-                      className={`flex cursor-pointer items-center gap-3 rounded-lg border px-4 py-3 transition-colors ${
-                        selected
-                          ? 'border-brand-primary bg-brand-primary-surface'
-                          : 'border-border bg-white hover:border-border-hover'
-                      }`}
+                      name={q.id}
+                      value={opt}
+                      selected={answers[q.id] === opt}
+                      onChange={(v) => handleAnswer(q.id, v)}
+                      testId={`question-option-${q.id}-${opt}`}
                     >
-                      <input
-                        type="radio"
+                      <span className="capitalize">{opt}</span>
+                    </AnswerOption>
+                  ))}
+                </div>
+              )}
+
+              {q.type === 'mcq' && (
+                <div className="space-y-2">
+                  {(q.options ?? []).map((opt) => {
+                    const value = opt.split(')')[0].trim();
+                    return (
+                      <AnswerOption
+                        key={opt}
                         name={q.id}
                         value={value}
-                        checked={selected}
-                        onChange={() => handleAnswer(q.id, value)}
-                        className="accent-brand-primary"
-                      />
-                      <span className="text-sm text-text-primary">{opt}</span>
-                    </label>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
+                        selected={answers[q.id] === value}
+                        onChange={(v) => handleAnswer(q.id, v)}
+                        testId={`question-option-${q.id}-${value}`}
+                      >
+                        {opt}
+                      </AnswerOption>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
 
-      <div className="flex items-center justify-between pt-2">
-        <button
-          data-testid="section-nav-prev"
-          onClick={() => setCurrentPart((p) => Math.max(0, p - 1))}
-          disabled={currentPart === 0}
-          className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary disabled:opacity-40 hover:border-border-hover"
-        >
-          Zurück
-        </button>
-        {currentPart < totalParts - 1 ? (
+        <div className="flex items-center justify-between pt-2">
           <button
-            data-testid="section-nav-next"
-            onClick={() => setCurrentPart((p) => p + 1)}
-            className="rounded-lg bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+            data-testid="section-nav-prev"
+            onClick={() => setCurrentPart((p) => Math.max(0, p - 1))}
+            disabled={currentPart === 0}
+            className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary disabled:opacity-40 hover:border-border-hover"
           >
-            Nächster Teil
+            Zurück
           </button>
-        ) : (
-          <button
-            data-testid="submit-btn"
-            onClick={handleSubmit}
-            disabled={!allAnswered}
-            className="rounded-lg bg-brand-primary px-6 py-2 text-sm font-semibold text-white disabled:opacity-50 hover:opacity-90"
-          >
-            Abgeben
-          </button>
-        )}
+          {currentPart < totalParts - 1 ? (
+            <button
+              data-testid="section-nav-next"
+              onClick={() => setCurrentPart((p) => p + 1)}
+              className="rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
+            >
+              Nächster Teil
+            </button>
+          ) : (
+            <ExamSubmitButtonInline disabled={!allAnswered} onClick={handleSubmit} />
+          )}
+        </div>
       </div>
+    </div>
+  );
+}
+
+function ExamSubmitButtonInline({
+  disabled,
+  onClick,
+}: {
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <div className="flex-1 pl-3">
+      <ExamSubmitButton disabled={disabled} onClick={onClick} label="Antworten abgeben" />
     </div>
   );
 }

--- a/apps/web/src/components/exam/MockCard.tsx
+++ b/apps/web/src/components/exam/MockCard.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { ChevronRight } from 'lucide-react';
+import type { Level } from '@fastrack/types';
+import { LEVEL_CONFIG } from '@fastrack/config';
+
+export type MockCardState = 'not-started' | 'in-progress' | 'completed' | 'coming-soon';
+
+interface MockCardProps {
+  href: string;
+  level: Level;
+  mockNumber: number;
+  title: string;
+  state: MockCardState;
+  /** 0..1 — drives the bottom progress bar in `in-progress` state. */
+  progress?: number;
+  /** 0..1 — shown as a score pill in `completed` state. */
+  score?: number;
+  /** Required for `completed` — whether the user passed both aggregates. */
+  passed?: boolean;
+  /** Count of completed sections vs. total, used for in-progress copy. */
+  sectionsCompleted?: number;
+  totalSections?: number;
+  testId?: string;
+}
+
+/**
+ * Single mock-exam card. Four visual states, distinguished without relying on
+ * color alone (left accent, progress bar, score pill, desaturation). See
+ * `.planning/design-system/screens.md` §Screen 2.
+ */
+export function MockCard({
+  href,
+  level,
+  mockNumber,
+  title,
+  state,
+  progress = 0,
+  score,
+  passed,
+  sectionsCompleted = 0,
+  totalSections = 4,
+  testId,
+}: MockCardProps) {
+  const cfg = LEVEL_CONFIG[level];
+  const isInteractive = state !== 'coming-soon';
+
+  // Card surface changes with state: completed recedes into surface-container,
+  // coming-soon goes near-empty, in-progress gets a left accent bar.
+  const baseWrap =
+    'group relative block overflow-hidden rounded-xl border border-border p-5 transition-shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500';
+  const stateWrap: Record<MockCardState, string> = {
+    'not-started': 'bg-white hover:shadow-md',
+    'in-progress': 'bg-white hover:shadow-md',
+    completed: 'bg-surface-container hover:shadow-md',
+    'coming-soon': 'bg-white cursor-default',
+  };
+
+  const pct = Math.max(0, Math.min(1, progress)) * 100;
+  const scorePct = score !== undefined ? Math.round(score * 100) : null;
+
+  const Tag: 'a' | 'div' = isInteractive ? 'a' : 'div';
+
+  return (
+    <Tag
+      {...(isInteractive ? { href } : {})}
+      data-testid={testId}
+      data-state={state}
+      className={`${baseWrap} ${stateWrap[state]}`}
+      aria-disabled={!isInteractive || undefined}
+    >
+      {/* Left accent bar for in-progress — 2px, level color, full height. */}
+      {state === 'in-progress' && (
+        <span
+          aria-hidden
+          className="absolute left-0 top-0 h-full w-[2px]"
+          style={{ backgroundColor: cfg.color }}
+        />
+      )}
+
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <span
+            data-testid="mock-card-level-badge"
+            className={`inline-block rounded-sm px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-white ${
+              state === 'coming-soon' ? 'opacity-50' : ''
+            }`}
+            style={{ backgroundColor: cfg.color }}
+          >
+            {level}
+          </span>
+          <h3
+            className={`mt-2 text-[17px] font-semibold ${
+              state === 'coming-soon' ? 'text-text-tertiary' : 'text-text-primary'
+            }`}
+          >
+            Übungstest {mockNumber}
+          </h3>
+          <p
+            className={`mt-1 line-clamp-2 text-sm ${
+              state === 'coming-soon' ? 'text-text-tertiary' : 'text-text-secondary'
+            }`}
+          >
+            {title}
+          </p>
+        </div>
+
+        {/* Score pill (completed) lives in the top-right slot. */}
+        {state === 'completed' && scorePct !== null && (
+          <span
+            data-testid="mock-card-score"
+            className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold ${
+              passed
+                ? 'bg-pass-surface text-pass'
+                : 'bg-fail-surface text-fail'
+            }`}
+          >
+            {scorePct}%
+          </span>
+        )}
+
+        {/* Chevron only on hover for the not-started / in-progress states. */}
+        {isInteractive && (
+          <ChevronRight
+            aria-hidden
+            strokeWidth={1.75}
+            className="mt-1 h-5 w-5 shrink-0 text-text-tertiary opacity-0 transition-opacity group-hover:opacity-100"
+          />
+        )}
+      </div>
+
+      {/* Footer line. */}
+      <div
+        data-testid="mock-card-footer"
+        className={`mt-4 text-xs ${
+          state === 'coming-soon' ? 'text-text-tertiary' : 'text-text-secondary'
+        }`}
+      >
+        {state === 'not-started' && 'Noch nicht begonnen'}
+        {state === 'in-progress' &&
+          `${sectionsCompleted} von ${totalSections} Abschnitten`}
+        {state === 'completed' && (
+          <span className="text-text-tertiary">Vollständig</span>
+        )}
+        {state === 'coming-soon' && 'Bald verfügbar'}
+      </div>
+
+      {/* 3px bottom progress track for in-progress. */}
+      {state === 'in-progress' && (
+        <div className="absolute inset-x-0 bottom-0 h-[3px] bg-surface-container" aria-hidden>
+          <div
+            data-testid="mock-card-progress"
+            className="h-full transition-[width] duration-200 ease-out"
+            style={{ width: `${pct}%`, backgroundColor: cfg.color }}
+          />
+        </div>
+      )}
+    </Tag>
+  );
+}

--- a/apps/web/src/components/exam/MockCardList.tsx
+++ b/apps/web/src/components/exam/MockCardList.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { Level } from '@fastrack/types';
+import { MockCard, type MockCardState } from './MockCard';
+import {
+  getSession,
+  hasAnySection,
+  isSessionComplete,
+  type ExamSessionState,
+} from '@/lib/examSession';
+
+interface MockEntry {
+  id: string;
+  mockNumber: number;
+  title: string;
+  hasContent: boolean;
+}
+
+interface MockCardListProps {
+  level: Level;
+  mocks: MockEntry[];
+  totalSections: number;
+}
+
+/**
+ * Reads `sessionStorage` for each mock and derives the card's visual state.
+ * Kept client-only because session data is per-device and not available at
+ * render time on the server.
+ */
+export function MockCardList({ level, mocks, totalSections }: MockCardListProps) {
+  const [sessions, setSessions] = useState<Record<string, ExamSessionState | null>>({});
+
+  useEffect(() => {
+    const next: Record<string, ExamSessionState | null> = {};
+    for (const m of mocks) {
+      next[m.id] = m.hasContent ? getSession(m.id) : null;
+    }
+    setSessions(next);
+  }, [mocks]);
+
+  return (
+    <div
+      className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
+      data-testid="mock-card-grid"
+    >
+      {mocks.map((mock) => {
+        const session = sessions[mock.id] ?? null;
+
+        let state: MockCardState = 'not-started';
+        let progress = 0;
+        let score: number | undefined;
+        let passed: boolean | undefined;
+        let completedSections = 0;
+
+        if (!mock.hasContent) {
+          state = 'coming-soon';
+        } else if (session) {
+          const sectionValues = Object.values(session.sections);
+          completedSections = sectionValues.length;
+          if (isSessionComplete(session)) {
+            state = 'completed';
+            const written = [
+              session.sections.listening,
+              session.sections.reading,
+              session.sections.sprachbausteine,
+              session.sections.writing,
+            ].filter(Boolean);
+            const oral = session.sections.speaking;
+            const aggregate = (subset: typeof written) => {
+              const earned = subset.reduce((n, s) => n + (s?.score.earned ?? 0), 0);
+              const max = subset.reduce((n, s) => n + (s?.score.max ?? 0), 0);
+              return max > 0 ? earned / max : 0;
+            };
+            const writtenPct = aggregate(written);
+            const oralPct = oral ? oral.score.percentage : 0;
+            const overallEarned = [...written, oral].reduce(
+              (n, s) => n + (s?.score.earned ?? 0),
+              0,
+            );
+            const overallMax = [...written, oral].reduce(
+              (n, s) => n + (s?.score.max ?? 0),
+              0,
+            );
+            score = overallMax > 0 ? overallEarned / overallMax : 0;
+            passed = writtenPct >= 0.6 && oralPct >= 0.6;
+          } else if (hasAnySection(session)) {
+            state = 'in-progress';
+            progress = totalSections > 0 ? completedSections / totalSections : 0;
+          }
+        }
+
+        return (
+          <MockCard
+            key={mock.id}
+            href={`/exam/${mock.id}`}
+            level={level}
+            mockNumber={mock.mockNumber}
+            title={mock.title}
+            state={state}
+            progress={progress}
+            score={score}
+            passed={passed}
+            sectionsCompleted={completedSections}
+            totalSections={totalSections}
+            testId={`mock-card-${mock.id}`}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/exam/PrepTimer.tsx
+++ b/apps/web/src/components/exam/PrepTimer.tsx
@@ -65,11 +65,9 @@ export function PrepTimer({ totalSeconds }: PrepTimerProps) {
           data-testid="prep-timer-clock"
           aria-live="polite"
           className={`rounded-lg px-3 py-1.5 text-sm font-mono font-semibold tabular-nums ${
-            expired
-              ? 'bg-fail-light text-fail'
-              : warning
-                ? 'bg-warning-light text-warning'
-                : 'bg-surface-container text-text-primary'
+            expired || warning
+              ? 'bg-warning-surface text-warning'
+              : 'bg-surface-container text-text-primary'
           }`}
         >
           {expired ? 'Zeit vorbei' : formatTime(remaining)}

--- a/apps/web/src/components/exam/ReadingExam.tsx
+++ b/apps/web/src/components/exam/ReadingExam.tsx
@@ -1,13 +1,16 @@
 'use client';
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
+import { FileText } from 'lucide-react';
 import { SECTION_DURATIONS, calculateSectionScore } from '@fastrack/core';
 import type { ReadingSection, ReadingPart, Level } from '@fastrack/types';
 import type { ExamPhase } from '@/lib/examTypes';
 import { saveSection } from '@/lib/examSession';
-import { ExamTimer } from './ExamTimer';
+import { ExamRunnerHeader } from './ExamRunnerHeader';
 import { SectionIntro } from './SectionIntro';
 import { QuestionResultRow } from './QuestionResultRow';
+import { AnswerOption } from './AnswerOption';
+import { ExamSubmitButton } from './ExamSubmitButton';
 
 interface ReadingExamProps {
   mockId: string;
@@ -47,15 +50,18 @@ export function ReadingExam({ mockId, level, section }: ReadingExamProps) {
     [section.parts, answers],
   );
 
+  const totalQuestions = section.parts.reduce((n, p) => n + p.questions.length, 0);
+  const answeredCount = Object.keys(answers).length;
+  const progress = totalQuestions > 0 ? answeredCount / totalQuestions : 0;
+
   const part = section.parts[currentPart];
   const totalParts = section.parts.length;
-  const totalQuestions = section.parts.reduce((n, p) => n + p.questions.length, 0);
 
   if (phase === 'intro') {
     return (
       <SectionIntro
         title="Lesen"
-        icon="📖"
+        Icon={FileText}
         totalSeconds={totalSeconds}
         description={`${totalParts} Teile · ${totalQuestions} Aufgaben`}
         extraInfo="Lesen Sie die Texte sorgfältig."
@@ -70,7 +76,7 @@ export function ReadingExam({ mockId, level, section }: ReadingExamProps) {
       <div className="space-y-6">
         <div
           className={`rounded-xl border-2 p-6 text-center ${
-            score.passed ? 'border-pass bg-pass-light' : 'border-fail bg-fail-light'
+            score.passed ? 'border-pass bg-pass-surface' : 'border-fail bg-fail-surface'
           }`}
         >
           <div className={`text-4xl font-bold ${score.passed ? 'text-pass' : 'text-fail'}`}>
@@ -115,7 +121,7 @@ export function ReadingExam({ mockId, level, section }: ReadingExamProps) {
                 ? `/exam/${mockId}/sprachbausteine`
                 : `/exam/${mockId}/writing`
             }
-            className="flex-1 rounded-xl bg-brand-primary py-3 text-center text-sm font-semibold text-white hover:opacity-90"
+            className="flex-1 rounded-xl bg-brand-600 py-3 text-center text-sm font-semibold text-white hover:bg-brand-700"
           >
             {level === 'B1' || level === 'B2' ? 'Weiter: Sprachbausteine' : 'Weiter: Schreiben'}
           </a>
@@ -125,72 +131,70 @@ export function ReadingExam({ mockId, level, section }: ReadingExamProps) {
   }
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-bold text-text-primary">Lesen</h1>
-          <p className="text-sm text-text-secondary">
-            Teil {currentPart + 1} von {totalParts}
-          </p>
+    <div>
+      <ExamRunnerHeader
+        sectionName="Lesen"
+        partLabel={`Teil ${currentPart + 1}`}
+        totalSeconds={totalSeconds}
+        isRunning={phase === 'active'}
+        onExpire={handleExpire}
+        exitHref={`/exam/${mockId}`}
+        level={level}
+        progress={progress}
+      />
+
+      <div className="space-y-6">
+        <div className="flex gap-2">
+          {section.parts.map((p, i) => {
+            const done = p.questions.every((q) => answers[q.id] !== undefined);
+            return (
+              <button
+                key={p.partNumber}
+                data-testid={`part-tab-${p.partNumber}`}
+                onClick={() => setCurrentPart(i)}
+                className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                  i === currentPart
+                    ? 'bg-brand-600 text-white'
+                    : done
+                      ? 'bg-pass-surface text-pass'
+                      : 'border border-border bg-white text-text-secondary hover:border-border-hover'
+                }`}
+              >
+                Teil {p.partNumber}
+              </button>
+            );
+          })}
         </div>
-        <ExamTimer
-          totalSeconds={totalSeconds}
-          isRunning={phase === 'active'}
-          onExpire={handleExpire}
-        />
-      </div>
 
-      <div className="flex gap-2">
-        {section.parts.map((p, i) => {
-          const done = p.questions.every((q) => answers[q.id] !== undefined);
-          return (
+        <PartView part={part} answers={answers} onAnswer={handleAnswer} />
+
+        <div className="flex items-center justify-between gap-3 pt-2">
+          <button
+            data-testid="section-nav-prev"
+            onClick={() => setCurrentPart((p) => Math.max(0, p - 1))}
+            disabled={currentPart === 0}
+            className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary disabled:opacity-40 hover:border-border-hover"
+          >
+            Zurück
+          </button>
+          {currentPart < totalParts - 1 ? (
             <button
-              key={p.partNumber}
-              data-testid={`part-tab-${p.partNumber}`}
-              onClick={() => setCurrentPart(i)}
-              className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
-                i === currentPart
-                  ? 'bg-brand-primary text-white'
-                  : done
-                    ? 'bg-success-light text-success'
-                    : 'border border-border bg-white text-text-secondary hover:border-border-hover'
-              }`}
+              data-testid="section-nav-next"
+              onClick={() => setCurrentPart((p) => p + 1)}
+              className="rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
             >
-              Teil {p.partNumber}
+              Nächster Teil
             </button>
-          );
-        })}
-      </div>
-
-      <PartView part={part} answers={answers} onAnswer={handleAnswer} />
-
-      <div className="flex items-center justify-between pt-2">
-        <button
-          data-testid="section-nav-prev"
-          onClick={() => setCurrentPart((p) => Math.max(0, p - 1))}
-          disabled={currentPart === 0}
-          className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary disabled:opacity-40 hover:border-border-hover"
-        >
-          Zurück
-        </button>
-        {currentPart < totalParts - 1 ? (
-          <button
-            data-testid="section-nav-next"
-            onClick={() => setCurrentPart((p) => p + 1)}
-            className="rounded-lg bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:opacity-90"
-          >
-            Nächster Teil
-          </button>
-        ) : (
-          <button
-            data-testid="submit-btn"
-            onClick={() => setPhase('submitted')}
-            disabled={!allAnswered}
-            className="rounded-lg bg-brand-primary px-6 py-2 text-sm font-semibold text-white disabled:opacity-50 hover:opacity-90"
-          >
-            Abgeben
-          </button>
-        )}
+          ) : (
+            <div className="flex-1 pl-3">
+              <ExamSubmitButton
+                disabled={!allAnswered}
+                onClick={() => setPhase('submitted')}
+                label="Antworten abgeben"
+              />
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -224,7 +228,7 @@ function PartView({
             .map((text) => (
               <div key={text.id} className="rounded-xl border border-border bg-white p-5">
                 {text.source && (
-                  <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-text-disabled">
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-text-tertiary">
                     {text.source}
                   </p>
                 )}
@@ -242,7 +246,7 @@ function PartView({
             .filter((t) => t.type === 'ad')
             .map((ad, i) => (
               <div key={ad.id} className="rounded-xl border border-border bg-surface-container p-4">
-                <span className="mb-2 inline-block rounded bg-brand-primary px-2 py-0.5 text-xs font-bold text-white">
+                <span className="mb-2 inline-block rounded bg-brand-600 px-2 py-0.5 text-xs font-bold text-white">
                   {String.fromCharCode(97 + i)}
                 </span>
                 <pre className="whitespace-pre-wrap font-sans text-sm text-text-primary">
@@ -261,62 +265,36 @@ function PartView({
             </p>
 
             {qType === 'true_false' && (
-              <div className="flex gap-3">
-                {['richtig', 'falsch'].map((opt) => {
-                  const selected = answers[q.id] === opt;
-                  return (
-                    <label
-                      key={opt}
-                      data-testid={`question-option-${q.id}-${opt}`}
-                      className={`flex cursor-pointer items-center gap-2 rounded-lg border px-5 py-2.5 transition-colors ${
-                        selected
-                          ? 'border-brand-primary bg-brand-primary-surface'
-                          : 'border-border bg-white hover:border-border-hover'
-                      }`}
-                    >
-                      <input
-                        type="radio"
-                        name={q.id}
-                        value={opt}
-                        checked={selected}
-                        onChange={() => onAnswer(q.id, opt)}
-                        className="accent-brand-primary"
-                      />
-                      <span className="text-sm font-medium text-text-primary capitalize">
-                        {opt}
-                      </span>
-                    </label>
-                  );
-                })}
+              <div className="space-y-2">
+                {['richtig', 'falsch'].map((opt) => (
+                  <AnswerOption
+                    key={opt}
+                    name={q.id}
+                    value={opt}
+                    selected={answers[q.id] === opt}
+                    onChange={(v) => onAnswer(q.id, v)}
+                    testId={`question-option-${q.id}-${opt}`}
+                  >
+                    <span className="capitalize">{opt}</span>
+                  </AnswerOption>
+                ))}
               </div>
             )}
 
             {qType === 'matching' && q.matchingSources && (
-              <div className="flex flex-wrap gap-2">
-                {q.matchingSources.map((src) => {
-                  const selected = answers[q.id] === src.label;
-                  return (
-                    <label
-                      key={src.id}
-                      data-testid={`question-option-${q.id}-${src.label}`}
-                      className={`flex cursor-pointer items-center gap-2 rounded-lg border px-4 py-2 transition-colors ${
-                        selected
-                          ? 'border-brand-primary bg-brand-primary-surface'
-                          : 'border-border bg-white hover:border-border-hover'
-                      }`}
-                    >
-                      <input
-                        type="radio"
-                        name={q.id}
-                        value={src.label}
-                        checked={selected}
-                        onChange={() => onAnswer(q.id, src.label)}
-                        className="accent-brand-primary"
-                      />
-                      <span className="text-sm font-bold text-text-primary">{src.label}</span>
-                    </label>
-                  );
-                })}
+              <div className="space-y-2">
+                {q.matchingSources.map((src) => (
+                  <AnswerOption
+                    key={src.id}
+                    name={q.id}
+                    value={src.label}
+                    selected={answers[q.id] === src.label}
+                    onChange={(v) => onAnswer(q.id, v)}
+                    testId={`question-option-${q.id}-${src.label}`}
+                  >
+                    <span className="font-bold">{src.label}</span>
+                  </AnswerOption>
+                ))}
               </div>
             )}
 
@@ -324,27 +302,17 @@ function PartView({
               <div className="space-y-2">
                 {q.options.map((opt) => {
                   const value = opt.split(')')[0].trim();
-                  const selected = answers[q.id] === value;
                   return (
-                    <label
+                    <AnswerOption
                       key={opt}
-                      data-testid={`question-option-${q.id}-${value}`}
-                      className={`flex cursor-pointer items-center gap-3 rounded-lg border px-4 py-3 transition-colors ${
-                        selected
-                          ? 'border-brand-primary bg-brand-primary-surface'
-                          : 'border-border bg-white hover:border-border-hover'
-                      }`}
+                      name={q.id}
+                      value={value}
+                      selected={answers[q.id] === value}
+                      onChange={(v) => onAnswer(q.id, v)}
+                      testId={`question-option-${q.id}-${value}`}
                     >
-                      <input
-                        type="radio"
-                        name={q.id}
-                        value={value}
-                        checked={selected}
-                        onChange={() => onAnswer(q.id, value)}
-                        className="accent-brand-primary"
-                      />
-                      <span className="text-sm text-text-primary">{opt}</span>
-                    </label>
+                      {opt}
+                    </AnswerOption>
                   );
                 })}
               </div>

--- a/apps/web/src/components/exam/SectionHub.tsx
+++ b/apps/web/src/components/exam/SectionHub.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Headphones, FileText, Puzzle, Pencil, Mic } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { Level } from '@fastrack/types';
+import { LEVEL_CONFIG } from '@fastrack/config';
+import { getSession, type ExamSessionState } from '@/lib/examSession';
+
+export type SectionKey =
+  | 'listening'
+  | 'reading'
+  | 'sprachbausteine'
+  | 'writing'
+  | 'speaking';
+
+export interface HubSection {
+  key: SectionKey;
+  name: string;
+  route: string;
+  durationSec: number;
+}
+
+interface SectionHubProps {
+  mockId: string;
+  level: Level;
+  written: HubSection[];
+  oral: HubSection[];
+  /** Whether the actual content JSON exists; when false we lock every row. */
+  hasContent: boolean;
+}
+
+const ICON_BY_KEY: Record<SectionKey, LucideIcon> = {
+  listening: Headphones,
+  reading: FileText,
+  sprachbausteine: Puzzle,
+  writing: Pencil,
+  speaking: Mic,
+};
+
+type Status = 'not-started' | 'in-progress' | 'completed';
+
+/**
+ * Section hub lives below the mock header. Groups sections into
+ * Schriftlich / Mündlich with pass-threshold sub-headings, and surfaces
+ * a single "Start with {next}" CTA at the bottom for quick continuation.
+ */
+export function SectionHub({
+  mockId,
+  level,
+  written,
+  oral,
+  hasContent,
+}: SectionHubProps) {
+  const [session, setSession] = useState<ExamSessionState | null>(null);
+
+  useEffect(() => {
+    if (hasContent) setSession(getSession(mockId));
+  }, [mockId, hasContent]);
+
+  const statusOf = (key: SectionKey): Status => {
+    const s = session?.sections[key];
+    if (!s) return 'not-started';
+    // We store per-section results on submission, so "in-progress" only
+    // surfaces after the orchestrator (exam runner) adds a partial marker.
+    // Today we treat any stored section as completed.
+    return 'completed';
+  };
+
+  const ordered = useMemo(() => [...written, ...oral], [written, oral]);
+  const nextSection = ordered.find((s) => statusOf(s.key) !== 'completed');
+  const inProgressExists = ordered.some((s) => statusOf(s.key) === 'in-progress');
+
+  const ctaLabel = nextSection
+    ? inProgressExists
+      ? `Weiter mit ${nextSection.name}`
+      : `Mit ${nextSection.name} starten`
+    : 'Alle Abschnitte abgeschlossen';
+
+  const ctaHref = nextSection
+    ? `/exam/${mockId}/${nextSection.route}`
+    : `/exam/${mockId}/results`;
+
+  return (
+    <div className="space-y-6">
+      <Group
+        title="Schriftlich"
+        threshold="min. 60% zum Bestehen"
+        sections={written}
+        mockId={mockId}
+        level={level}
+        statusOf={statusOf}
+        hasContent={hasContent}
+      />
+      <Group
+        title="Mündlich"
+        threshold="min. 60% zum Bestehen"
+        sections={oral}
+        mockId={mockId}
+        level={level}
+        statusOf={statusOf}
+        hasContent={hasContent}
+      />
+
+      {hasContent ? (
+        <a
+          href={ctaHref}
+          data-testid="section-hub-cta"
+          className="block w-full rounded-xl bg-brand-600 py-4 text-center text-base font-semibold text-white transition-colors hover:bg-brand-700"
+        >
+          {ctaLabel}
+        </a>
+      ) : (
+        <div className="w-full rounded-xl bg-surface-container py-4 text-center text-base font-semibold text-text-tertiary">
+          Inhalt noch nicht verfügbar
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Group({
+  title,
+  threshold,
+  sections,
+  mockId,
+  level,
+  statusOf,
+  hasContent,
+}: {
+  title: string;
+  threshold: string;
+  sections: HubSection[];
+  mockId: string;
+  level: Level;
+  statusOf: (key: SectionKey) => Status;
+  hasContent: boolean;
+}) {
+  const cfg = LEVEL_CONFIG[level];
+
+  return (
+    <section
+      data-testid={`hub-group-${title.toLowerCase()}`}
+      aria-label={`${title} — ${threshold}`}
+    >
+      <div className="mb-2 flex items-baseline justify-between gap-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-text-secondary">
+          {title}
+        </h2>
+        <span className="text-xs text-text-tertiary">{threshold}</span>
+      </div>
+      <div className="divide-y divide-border rounded-xl border border-border bg-white">
+        {sections.map((s) => {
+          const Icon = ICON_BY_KEY[s.key];
+          const status = statusOf(s.key);
+          const mins = Math.round(s.durationSec / 60);
+          const href = `/exam/${mockId}/${s.route}`;
+
+          const dotColor =
+            status === 'completed'
+              ? 'bg-pass'
+              : status === 'in-progress'
+                ? ''
+                : 'bg-text-tertiary';
+
+          const dotInlineColor =
+            status === 'in-progress' ? { backgroundColor: cfg.color } : undefined;
+
+          const buttonLabel =
+            status === 'completed'
+              ? 'Review'
+              : status === 'in-progress'
+                ? 'Continue'
+                : 'Start';
+
+          const buttonStyle =
+            status === 'completed'
+              ? 'border border-border text-text-primary hover:border-border-hover'
+              : status === 'in-progress'
+                ? 'bg-brand-500 text-white hover:bg-brand-600'
+                : 'text-white hover:opacity-90';
+
+          const inlineStyle =
+            status === 'not-started'
+              ? { backgroundColor: cfg.color }
+              : undefined;
+
+          return (
+            <div
+              key={s.key}
+              data-testid={`hub-section-${s.key}`}
+              className="flex items-center justify-between gap-4 px-5 py-4"
+            >
+              <div className="flex min-w-0 items-center gap-3">
+                <span
+                  aria-hidden
+                  className={`inline-block h-2 w-2 shrink-0 rounded-full ${dotColor}`}
+                  style={dotInlineColor}
+                  data-testid={`hub-status-dot-${s.key}`}
+                  data-status={status}
+                />
+                <Icon
+                  className="h-5 w-5 shrink-0 text-text-secondary"
+                  strokeWidth={1.75}
+                  aria-hidden
+                />
+                <div className="min-w-0">
+                  <div className="font-medium text-text-primary">{s.name}</div>
+                  <div className="text-xs text-text-secondary">
+                    {mins > 0 ? `${mins} Min.` : '—'}
+                  </div>
+                </div>
+              </div>
+              {hasContent ? (
+                <a
+                  href={href}
+                  data-testid={`hub-action-${s.key}`}
+                  className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${buttonStyle}`}
+                  style={inlineStyle}
+                >
+                  {buttonLabel}
+                </a>
+              ) : (
+                <span className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-tertiary">
+                  Bald
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/exam/SectionIntro.tsx
+++ b/apps/web/src/components/exam/SectionIntro.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import type { LucideIcon } from 'lucide-react';
+
 interface SectionIntroProps {
   title: string;
-  icon: string;
+  Icon: LucideIcon;
   totalSeconds: number;
   description: string;
   extraInfo?: string;
@@ -11,7 +13,7 @@ interface SectionIntroProps {
 
 export function SectionIntro({
   title,
-  icon,
+  Icon,
   totalSeconds,
   description,
   extraInfo,
@@ -21,7 +23,14 @@ export function SectionIntro({
 
   return (
     <div className="mx-auto max-w-lg space-y-6 py-12 text-center">
-      <div className="text-5xl">{icon}</div>
+      <div className="flex justify-center">
+        <span
+          className="flex h-14 w-14 items-center justify-center rounded-full bg-surface-container"
+          aria-hidden
+        >
+          <Icon className="h-7 w-7 text-text-secondary" strokeWidth={1.75} />
+        </span>
+      </div>
       <div>
         <h1 className="text-2xl font-bold text-text-primary">{title}</h1>
         <p className="mt-1 text-sm text-text-secondary">{description}</p>
@@ -39,7 +48,7 @@ export function SectionIntro({
       <button
         data-testid="section-start-btn"
         onClick={onStart}
-        className="w-full rounded-xl bg-brand-primary py-4 text-lg font-semibold text-white hover:opacity-90"
+        className="block h-[52px] w-full rounded-xl bg-brand-600 text-base font-semibold text-white transition-colors hover:bg-brand-700"
       >
         Abschnitt starten
       </button>

--- a/apps/web/src/components/exam/SectionStatus.tsx
+++ b/apps/web/src/components/exam/SectionStatus.tsx
@@ -79,7 +79,7 @@ export function ViewResultsLink({ mockId }: { mockId: string }) {
     <a
       data-testid="view-results-link"
       href={`/exam/${mockId}/results`}
-      className="block w-full rounded-xl border-2 border-brand-primary py-4 text-center text-lg font-semibold text-brand-primary transition-colors hover:bg-brand-primary hover:text-white"
+      className="block w-full rounded-xl border-2 border-brand-600 py-4 text-center text-base font-semibold text-brand-600 transition-colors hover:bg-brand-600 hover:text-white"
     >
       Ergebnisse anzeigen
     </a>

--- a/apps/web/src/components/exam/SpeakingExam.tsx
+++ b/apps/web/src/components/exam/SpeakingExam.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
+import { Mic } from 'lucide-react';
 import { SECTION_DURATIONS } from '@fastrack/core';
 import type { SectionScore } from '@fastrack/core';
 import type { SpeakingSection, Level } from '@fastrack/types';
 import type { ExamPhase } from '@/lib/examTypes';
 import { saveSection } from '@/lib/examSession';
-import { ExamTimer } from './ExamTimer';
+import { ExamRunnerHeader } from './ExamRunnerHeader';
 import { SectionIntro } from './SectionIntro';
 import { SpeakingRecorder } from './SpeakingRecorder';
 import { PrepTimer } from './PrepTimer';
+import { ExamSubmitButton } from './ExamSubmitButton';
 
 interface SpeakingExamProps {
   mockId: string;
@@ -62,7 +64,7 @@ export function SpeakingExam({ mockId, level, section }: SpeakingExamProps) {
     return (
       <SectionIntro
         title="Sprechen"
-        icon="🗣️"
+        Icon={Mic}
         totalSeconds={totalSeconds}
         description={`${totalParts} Aufgaben`}
         extraInfo={
@@ -78,7 +80,9 @@ export function SpeakingExam({ mockId, level, section }: SpeakingExamProps) {
     return (
       <div className="space-y-6">
         <div className="rounded-xl border border-border bg-white p-6 text-center">
-          <div className="text-4xl">🗣️</div>
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-surface-container">
+            <Mic className="h-6 w-6 text-text-secondary" strokeWidth={1.75} aria-hidden />
+          </div>
           <h2 className="mt-3 text-xl font-bold text-text-primary">Sprechen abgeschlossen</h2>
           <p className="mt-1 text-sm text-text-secondary">
             Der Sprechen-Abschnitt wird von einem Prüfer bewertet.
@@ -151,22 +155,22 @@ export function SpeakingExam({ mockId, level, section }: SpeakingExamProps) {
     );
   }
 
-  return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-bold text-text-primary">Sprechen</h1>
-          <p className="text-sm text-text-secondary">
-            Aufgabe {currentPart + 1} von {totalParts}
-          </p>
-        </div>
-        <ExamTimer
-          totalSeconds={totalSeconds}
-          isRunning={phase === 'active'}
-          onExpire={handleExpire}
-        />
-      </div>
+  const progress = totalParts > 0 ? (currentPart + 1) / totalParts : 0;
 
+  return (
+    <div>
+      <ExamRunnerHeader
+        sectionName="Sprechen"
+        partLabel={`Aufgabe ${currentPart + 1} von ${totalParts}`}
+        totalSeconds={totalSeconds}
+        isRunning={phase === 'active'}
+        onExpire={handleExpire}
+        exitHref={`/exam/${mockId}`}
+        level={level}
+        progress={progress}
+      />
+
+      <div className="space-y-6">
       {section.prepTimeMinutes > 0 && (
         <PrepTimer totalSeconds={section.prepTimeMinutes * 60} />
       )}
@@ -292,19 +296,19 @@ export function SpeakingExam({ mockId, level, section }: SpeakingExamProps) {
           <button
             data-testid="section-nav-next"
             onClick={() => setCurrentPart((p) => p + 1)}
-            className="rounded-lg bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+            className="rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
           >
             Nächste Aufgabe
           </button>
         ) : (
-          <button
-            data-testid="submit-btn"
-            onClick={() => setPhase('submitted')}
-            className="rounded-lg bg-brand-primary px-6 py-2 text-sm font-semibold text-white hover:opacity-90"
-          >
-            Abschnitt abschließen
-          </button>
+          <div className="flex-1 pl-3">
+            <ExamSubmitButton
+              onClick={() => setPhase('submitted')}
+              label="Abschnitt abschließen"
+            />
+          </div>
         )}
+      </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/exam/SprachbausteineExam.tsx
+++ b/apps/web/src/components/exam/SprachbausteineExam.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
+import { Puzzle } from 'lucide-react';
 import { SECTION_DURATIONS, scoreSprachbausteine } from '@fastrack/core';
 import type {
   SprachbausteineSection,
@@ -10,8 +11,9 @@ import type {
 } from '@fastrack/types';
 import type { ExamPhase } from '@/lib/examTypes';
 import { saveSection } from '@/lib/examSession';
-import { ExamTimer } from './ExamTimer';
+import { ExamRunnerHeader } from './ExamRunnerHeader';
 import { SectionIntro } from './SectionIntro';
+import { ExamSubmitButton } from './ExamSubmitButton';
 
 interface SprachbausteineExamProps {
   mockId: string;
@@ -129,7 +131,7 @@ export function SprachbausteineExam({ mockId, level, section }: SprachbausteineE
     return (
       <SectionIntro
         title="Sprachbausteine"
-        icon="🧩"
+        Icon={Puzzle}
         totalSeconds={totalSeconds}
         description={`${totalParts} Teile · ${totalQuestions} Lücken`}
         extraInfo="Wählen Sie für jede Lücke die passende Antwort."
@@ -150,22 +152,23 @@ export function SprachbausteineExam({ mockId, level, section }: SprachbausteineE
     );
   }
 
-  return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-bold text-text-primary">Sprachbausteine</h1>
-          <p className="text-sm text-text-secondary">
-            Teil {currentPart + 1} von {totalParts}
-          </p>
-        </div>
-        <ExamTimer
-          totalSeconds={totalSeconds}
-          isRunning={phase === 'active'}
-          onExpire={handleExpire}
-        />
-      </div>
+  const answeredCount = Object.keys(answers).length;
+  const progress = totalQuestions > 0 ? answeredCount / totalQuestions : 0;
 
+  return (
+    <div>
+      <ExamRunnerHeader
+        sectionName="Sprachbausteine"
+        partLabel={`Teil ${currentPart + 1} von ${totalParts}`}
+        totalSeconds={totalSeconds}
+        isRunning={phase === 'active'}
+        onExpire={handleExpire}
+        exitHref={`/exam/${mockId}`}
+        level={level}
+        progress={progress}
+      />
+
+      <div className="space-y-6">
       <div className="flex gap-2">
         {section.parts.map((p, i) => {
           const done = p.questions.every(
@@ -178,9 +181,9 @@ export function SprachbausteineExam({ mockId, level, section }: SprachbausteineE
               onClick={() => setCurrentPart(i)}
               className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
                 i === currentPart
-                  ? 'bg-brand-primary text-white'
+                  ? 'bg-brand-600 text-white'
                   : done
-                    ? 'bg-success-light text-success'
+                    ? 'bg-pass-surface text-pass'
                     : 'border border-border bg-white text-text-secondary hover:border-border-hover'
               }`}
             >
@@ -205,20 +208,20 @@ export function SprachbausteineExam({ mockId, level, section }: SprachbausteineE
           <button
             data-testid="section-nav-next"
             onClick={() => setCurrentPart((p) => p + 1)}
-            className="rounded-lg bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+            className="rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
           >
             Nächster Teil
           </button>
         ) : (
-          <button
-            data-testid="submit-btn"
-            onClick={() => setPhase('submitted')}
-            disabled={!allAnswered}
-            className="rounded-lg bg-brand-primary px-6 py-2 text-sm font-semibold text-white disabled:opacity-50 hover:opacity-90"
-          >
-            Abgeben
-          </button>
+          <div className="flex-1 pl-3">
+            <ExamSubmitButton
+              disabled={!allAnswered}
+              onClick={() => setPhase('submitted')}
+              label="Antworten abgeben"
+            />
+          </div>
         )}
+      </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/exam/WritingExam.tsx
+++ b/apps/web/src/components/exam/WritingExam.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
+import { Pencil } from 'lucide-react';
 import { SECTION_DURATIONS } from '@fastrack/core';
 import type { SectionScore } from '@fastrack/core';
 import type { WritingSection, Level } from '@fastrack/types';
 import type { ExamPhase } from '@/lib/examTypes';
 import { saveSection } from '@/lib/examSession';
-import { ExamTimer } from './ExamTimer';
+import { ExamRunnerHeader } from './ExamRunnerHeader';
 import { SectionIntro } from './SectionIntro';
+import { ExamSubmitButton } from './ExamSubmitButton';
 
 interface WritingExamProps {
   mockId: string;
@@ -61,7 +63,7 @@ export function WritingExam({ mockId, level, section }: WritingExamProps) {
     return (
       <SectionIntro
         title="Schreiben"
-        icon="✍️"
+        Icon={Pencil}
         totalSeconds={totalSeconds}
         description={`${section.tasks.length} Aufgabe${section.tasks.length !== 1 ? 'n' : ''}`}
         extraInfo="Schreiben Sie vollständige, korrekte Antworten."
@@ -83,37 +85,41 @@ export function WritingExam({ mockId, level, section }: WritingExamProps) {
     );
   }
 
+  const totalTasks = section.tasks.length;
+  const tasksTouched = Object.keys(taskAnswers).length;
+  const progress = totalTasks > 0 ? tasksTouched / totalTasks : 0;
+
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-xl font-bold text-text-primary">Schreiben</h1>
-        <ExamTimer
-          totalSeconds={totalSeconds}
-          isRunning={phase === 'active'}
-          onExpire={handleExpire}
+    <div>
+      <ExamRunnerHeader
+        sectionName="Schreiben"
+        totalSeconds={totalSeconds}
+        isRunning={phase === 'active'}
+        onExpire={handleExpire}
+        exitHref={`/exam/${mockId}`}
+        level={level}
+        progress={progress}
+      />
+
+      <div className="space-y-6">
+        {section.tasks.map((task) => {
+          const fields = taskAnswers[task.taskNumber] ?? {};
+
+          return (
+            <TaskCard
+              key={task.taskNumber}
+              task={task}
+              fields={fields}
+              onFieldChange={(field, value) => setFieldAnswer(task.taskNumber, field, value)}
+            />
+          );
+        })}
+
+        <ExamSubmitButton
+          onClick={() => setPhase('submitted')}
+          label="Aufgaben abgeben"
         />
       </div>
-
-      {section.tasks.map((task) => {
-        const fields = taskAnswers[task.taskNumber] ?? {};
-
-        return (
-          <TaskCard
-            key={task.taskNumber}
-            task={task}
-            fields={fields}
-            onFieldChange={(field, value) => setFieldAnswer(task.taskNumber, field, value)}
-          />
-        );
-      })}
-
-      <button
-        data-testid="submit-btn"
-        onClick={() => setPhase('submitted')}
-        className="w-full rounded-xl bg-brand-primary py-4 text-sm font-semibold text-white hover:opacity-90"
-      >
-        Aufgaben abgeben
-      </button>
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,11 @@
   },
   "engines": {
     "node": ">=22"
+  },
+  "pnpm": {
+    "overrides": {
+      "@types/react": "19.1.0",
+      "@types/react-dom": "19.1.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@types/react': 19.1.0
+  '@types/react-dom': 19.1.0
+
 importers:
 
   .:
@@ -19,7 +23,7 @@ importers:
     dependencies:
       '@expo/vector-icons':
         specifier: ^15.0.3
-        version: 15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+        version: 15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       '@fastrack/config':
         specifier: workspace:*
         version: link:../../packages/config
@@ -34,83 +38,83 @@ importers:
         version: link:../../packages/types
       '@jamsch/expo-speech-recognition':
         specifier: ^0.2.15
-        version: 0.2.15(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+        version: 0.2.15(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       '@react-navigation/bottom-tabs':
         specifier: ^7.0.0
-        version: 7.15.9(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+        version: 7.15.9(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       '@react-navigation/native':
         specifier: ^7.0.0
-        version: 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+        version: 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       date-fns:
         specifier: ^3.0.0
         version: 3.6.0
       expo:
         specifier: ^54.0.0
-        version: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+        version: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-audio:
         specifier: ~1.1.1
-        version: 1.1.1(expo-asset@12.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+        version: 1.1.1(expo-asset@12.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       expo-file-system:
         specifier: ~19.0.21
-        version: 19.0.21(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))
+        version: 19.0.21(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))
       expo-haptics:
         specifier: ~15.0.8
         version: 15.0.8(expo@54.0.33)
       expo-linking:
         specifier: ~8.0.11
-        version: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+        version: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       expo-notifications:
         specifier: ~0.32.16
-        version: 0.32.16(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+        version: 0.32.16(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-router:
         specifier: ~6.0.23
-        version: 6.0.23(9cc6cece1bb8f4bd3b8ee58f37622f24)
+        version: 6.0.23(@expo/metro-runtime@6.1.2)(@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@22.19.17))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0))(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.5(react@19.1.0))(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       expo-speech:
         specifier: ~14.0.8
         version: 14.0.8(expo@54.0.33)
       expo-sqlite:
         specifier: ~16.0.10
-        version: 16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+        version: 16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
       react-native:
         specifier: 0.81.5
-        version: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+        version: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
       react-native-gesture-handler:
         specifier: ~2.28.0
-        version: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+        version: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       react-native-reanimated:
         specifier: ~3.16.0
-        version: 3.16.7(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+        version: 3.16.7(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       react-native-safe-area-context:
         specifier: ~5.6.0
-        version: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+        version: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       react-native-screens:
         specifier: ~4.16.0
-        version: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+        version: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       react-native-svg:
         specifier: 15.12.1
-        version: 15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+        version: 15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.0
         version: 7.29.0
       '@testing-library/react-native':
         specifier: ^13.0.0
-        version: 13.3.3(jest@29.7.0(@types/node@22.19.17))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 13.3.3(jest@29.7.0(@types/node@22.19.17))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/react':
-        specifier: ~18.2.0
-        version: 18.2.79
+        specifier: 19.1.0
+        version: 19.1.0
       '@types/react-native':
         specifier: ~0.73.0
-        version: 0.73.0(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+        version: 0.73.0(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
       jest:
         specifier: ^29.0.0
         version: 29.7.0(@types/node@22.19.17)
       jest-expo:
         specifier: ~54.0.0
-        version: 54.0.17(@babel/core@7.29.0)(expo@54.0.33)(jest@29.7.0(@types/node@22.19.17))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+        version: 54.0.17(@babel/core@7.29.0)(expo@54.0.33)(jest@29.7.0(@types/node@22.19.17))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
@@ -153,7 +157,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.0.0
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@testing-library/user-event':
         specifier: ^14.5.0
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -161,11 +165,11 @@ importers:
         specifier: ^22.0.0
         version: 22.19.17
       '@types/react':
-        specifier: ^19.1.0
-        version: 19.2.14
+        specifier: 19.1.0
+        version: 19.1.0
       '@types/react-dom':
-        specifier: ^19.1.0
-        version: 19.2.3(@types/react@19.2.14)
+        specifier: 19.1.0
+        version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.3.0
         version: 4.7.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
@@ -1391,8 +1395,8 @@ packages:
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1404,7 +1408,7 @@ packages:
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1413,7 +1417,7 @@ packages:
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1422,8 +1426,8 @@ packages:
   '@radix-ui/react-dialog@1.1.15':
     resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1435,7 +1439,7 @@ packages:
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1444,8 +1448,8 @@ packages:
   '@radix-ui/react-dismissable-layer@1.1.11':
     resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1457,7 +1461,7 @@ packages:
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1466,8 +1470,8 @@ packages:
   '@radix-ui/react-focus-scope@1.1.7':
     resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1479,7 +1483,7 @@ packages:
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1488,8 +1492,8 @@ packages:
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1501,8 +1505,8 @@ packages:
   '@radix-ui/react-presence@1.1.5':
     resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1514,8 +1518,8 @@ packages:
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1527,8 +1531,8 @@ packages:
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1540,7 +1544,7 @@ packages:
   '@radix-ui/react-slot@1.2.0':
     resolution: {integrity: sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1549,7 +1553,7 @@ packages:
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1558,8 +1562,8 @@ packages:
   '@radix-ui/react-tabs@1.1.13':
     resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1571,7 +1575,7 @@ packages:
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1580,7 +1584,7 @@ packages:
   '@radix-ui/react-use-controllable-state@1.2.2':
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1589,7 +1593,7 @@ packages:
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1598,7 +1602,7 @@ packages:
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1607,7 +1611,7 @@ packages:
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1668,7 +1672,7 @@ packages:
     resolution: {integrity: sha512-UVXgV/db25OPIvwZySeToXD/9sKKhOdkcWmmf4Jh8iBZuyfML+/5CasaZ1E7Lqg6g3uqVQq75NqIwkYmORJMPw==}
     engines: {node: '>= 20.19.4'}
     peerDependencies:
-      '@types/react': ^19.1.0
+      '@types/react': 19.1.0
       react: '*'
       react-native: '*'
     peerDependenciesMeta:
@@ -1975,8 +1979,8 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@testing-library/dom': ^10.0.0
-      '@types/react': ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^18.0.0 || ^19.0.0
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
@@ -2070,23 +2074,17 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
-
-  '@types/react-dom@19.2.3':
-    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+  '@types/react-dom@19.1.0':
+    resolution: {integrity: sha512-21E2zejNNRtjG4hKIyJz4aWswGEcNFTgttA0bZIRGjj1HA/tbSUxIJnIcYbn98pwJck0cS1bsQhn6eaKqbcFWw==}
     peerDependencies:
-      '@types/react': ^19.2.0
+      '@types/react': 19.1.0
 
   '@types/react-native@0.73.0':
     resolution: {integrity: sha512-6ZRPQrYM72qYKGWidEttRe6M5DZBEV5F+MHMHqd4TTYx0tfkcdrUFGdef6CCxY0jXU7wldvd/zA/b0A/kTeJmA==}
     deprecated: This is a stub types definition. react-native provides its own type definitions, so you do not need this installed.
 
-  '@types/react@18.2.79':
-    resolution: {integrity: sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==}
-
-  '@types/react@19.2.14':
-    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+  '@types/react@19.1.0':
+    resolution: {integrity: sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -4315,7 +4313,7 @@ packages:
     engines: {node: '>= 20.19.4'}
     hasBin: true
     peerDependencies:
-      '@types/react': ^19.1.0
+      '@types/react': 19.1.0
       react: ^19.1.0
     peerDependenciesMeta:
       '@types/react':
@@ -4333,7 +4331,7 @@ packages:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
@@ -4343,7 +4341,7 @@ packages:
     resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -4353,7 +4351,7 @@ packages:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -4885,7 +4883,7 @@ packages:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -4900,7 +4898,7 @@ packages:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.1.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -5927,7 +5925,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@expo/cli@54.0.23(expo-router@6.0.23)(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(typescript@5.9.3)':
+  '@expo/cli@54.0.23(expo-router@6.0.23)(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(typescript@5.9.3)':
     dependencies:
       '@0no-co/graphql.web': 1.2.0
       '@expo/code-signing-certificates': 0.0.6
@@ -5961,7 +5959,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       env-editor: 0.4.2
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-server: 1.0.5
       freeport-async: 2.0.0
       getenv: 2.0.0
@@ -5994,8 +5992,8 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.20.0
     optionalDependencies:
-      expo-router: 6.0.23(9cc6cece1bb8f4bd3b8ee58f37622f24)
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      expo-router: 6.0.23(@expo/metro-runtime@6.1.2)(@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@22.19.17))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0))(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.5(react@19.1.0))(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
       - graphql
@@ -6053,12 +6051,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/devtools@0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)':
+  '@expo/devtools@0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
     dependencies:
       chalk: 4.1.2
     optionalDependencies:
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
 
   '@expo/env@2.0.11':
     dependencies:
@@ -6128,19 +6126,19 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@expo/metro-runtime@6.1.2(expo@54.0.33)(react-dom@19.2.5(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)':
+  '@expo/metro-runtime@6.1.2(expo@54.0.33)(react-dom@19.2.5(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
     dependencies:
       anser: 1.4.10
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       pretty-format: 29.7.0
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
     optionalDependencies:
@@ -6195,7 +6193,7 @@ snapshots:
       '@expo/json-file': 10.0.13
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -6223,11 +6221,11 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/vector-icons@15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)':
+  '@expo/vector-icons@15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      expo-font: 14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      expo-font: 14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -6352,11 +6350,11 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@jamsch/expo-speech-recognition@0.2.15(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)':
+  '@jamsch/expo-speech-recognition@0.2.15(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
 
   '@jest/console@29.7.0':
     dependencies:
@@ -6588,204 +6586,204 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.2.79)(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.0)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.2.5(react@19.1.0)
     optionalDependencies:
-      '@types/react': 18.2.79
-      '@types/react-dom': 19.2.3(@types/react@18.2.79)
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0(@types/react@19.1.0)
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@18.2.79)(react@19.1.0)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.0)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
-  '@radix-ui/react-context@1.1.2(@types/react@18.2.79)(react@19.1.0)':
+  '@radix-ui/react-context@1.1.2(@types/react@19.1.0)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
-  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.2.79)(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.0)(react@19.1.0)
       aria-hidden: 1.2.6
       react: 19.1.0
       react-dom: 19.2.5(react@19.1.0)
-      react-remove-scroll: 2.7.2(@types/react@18.2.79)(react@19.1.0)
+      react-remove-scroll: 2.7.2(@types/react@19.1.0)(react@19.1.0)
     optionalDependencies:
-      '@types/react': 18.2.79
-      '@types/react-dom': 19.2.3(@types/react@18.2.79)
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0(@types/react@19.1.0)
 
-  '@radix-ui/react-direction@1.1.1(@types/react@18.2.79)(react@19.1.0)':
+  '@radix-ui/react-direction@1.1.1(@types/react@19.1.0)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.2.79)(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.2.5(react@19.1.0)
-    optionalDependencies:
-      '@types/react': 18.2.79
-      '@types/react-dom': 19.2.3(@types/react@18.2.79)
-
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@18.2.79)(react@19.1.0)':
-    dependencies:
-      react: 19.1.0
-    optionalDependencies:
-      '@types/react': 18.2.79
-
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.2.79)(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.2.5(react@19.1.0)
-    optionalDependencies:
-      '@types/react': 18.2.79
-      '@types/react-dom': 19.2.3(@types/react@18.2.79)
-
-  '@radix-ui/react-id@1.1.1(@types/react@18.2.79)(react@19.1.0)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.2.79)(react@19.1.0)
-      react: 19.1.0
-    optionalDependencies:
-      '@types/react': 18.2.79
-
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.2.79)(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.2.5(react@19.1.0)
-    optionalDependencies:
-      '@types/react': 18.2.79
-      '@types/react-dom': 19.2.3(@types/react@18.2.79)
-
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.2.79)(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.2.5(react@19.1.0)
-    optionalDependencies:
-      '@types/react': 18.2.79
-      '@types/react-dom': 19.2.3(@types/react@18.2.79)
-
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.2.79)(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.2.5(react@19.1.0)
-    optionalDependencies:
-      '@types/react': 18.2.79
-      '@types/react-dom': 19.2.3(@types/react@18.2.79)
-
-  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-direction': 1.1.1(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.2.79)(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.0)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.2.5(react@19.1.0)
     optionalDependencies:
-      '@types/react': 18.2.79
-      '@types/react-dom': 19.2.3(@types/react@18.2.79)
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0(@types/react@19.1.0)
 
-  '@radix-ui/react-slot@1.2.0(@types/react@18.2.79)(react@19.1.0)':
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.1.0)(react@19.1.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.79)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
-  '@radix-ui/react-slot@1.2.3(@types/react@18.2.79)(react@19.1.0)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.79)(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.0)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.2.5(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0(@types/react@19.1.0)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.1.0)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.0)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
-  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.0)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.2.5(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0(@types/react@19.1.0)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.0)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.2.5(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0(@types/react@19.1.0)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.0)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.2.5(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0(@types/react@19.1.0)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-direction': 1.1.1(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.2.79)(react@19.1.0)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.0)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.2.5(react@19.1.0)
     optionalDependencies:
-      '@types/react': 18.2.79
-      '@types/react-dom': 19.2.3(@types/react@18.2.79)
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0(@types/react@19.1.0)
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.2.79)(react@19.1.0)':
+  '@radix-ui/react-slot@1.2.0(@types/react@19.1.0)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.0)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.0
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.1.0)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.0)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.0
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.0)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.2.5(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0(@types/react@19.1.0)
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.0)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.2.79)(react@19.1.0)':
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.1.0)(react@19.1.0)':
     dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.2.79)(react@19.1.0)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.0)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.2.79)(react@19.1.0)':
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.1.0)(react@19.1.0)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.2.79)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.0)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.2.79)(react@19.1.0)':
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.1.0)(react@19.1.0)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.2.79)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.0)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.2.79)(react@19.1.0)':
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.0)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
   '@react-native/assets-registry@0.81.5': {}
 
@@ -6897,24 +6895,24 @@ snapshots:
 
   '@react-native/normalize-colors@0.81.5': {}
 
-  '@react-native/virtualized-lists@0.81.5(@types/react@18.2.79)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)':
+  '@react-native/virtualized-lists@0.81.5(@types/react@19.1.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
-  '@react-navigation/bottom-tabs@7.15.9(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)':
+  '@react-navigation/bottom-tabs@7.15.9(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@react-navigation/elements': 2.9.14(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
-      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/elements': 2.9.14(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       color: 4.2.3
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
-      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
-      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       sf-symbols-typescript: 2.2.0
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
@@ -6931,38 +6929,38 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.1.0)
       use-sync-external-store: 1.6.0(react@19.1.0)
 
-  '@react-navigation/elements@2.9.14(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)':
+  '@react-navigation/elements@2.9.14(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       color: 4.2.3
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
-      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       use-latest-callback: 0.2.6(react@19.1.0)
       use-sync-external-store: 1.6.0(react@19.1.0)
 
-  '@react-navigation/native-stack@7.14.10(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)':
+  '@react-navigation/native-stack@7.14.10(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@react-navigation/elements': 2.9.14(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
-      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/elements': 2.9.14(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       color: 4.2.3
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
-      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
-      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       sf-symbols-typescript: 2.2.0
       warn-once: 0.1.1
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
-  '@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)':
+  '@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@react-navigation/core': 7.17.2(react@19.1.0)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
       nanoid: 3.3.11
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
       use-latest-callback: 0.2.6(react@19.1.0)
 
   '@react-navigation/routers@7.5.3':
@@ -7151,27 +7149,27 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@22.19.17))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@22.19.17))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       jest-matcher-utils: 30.3.0
       picocolors: 1.1.1
       pretty-format: 30.3.0
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
       react-test-renderer: 19.1.0(react@19.1.0)
       redent: 3.0.0
     optionalDependencies:
       jest: 29.7.0(@types/node@22.19.17)
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@testing-library/dom': 10.4.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.0(@types/react@19.1.0)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -7255,20 +7253,13 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/prop-types@15.7.15': {}
-
-  '@types/react-dom@19.2.3(@types/react@18.2.79)':
+  '@types/react-dom@19.1.0(@types/react@19.1.0)':
     dependencies:
-      '@types/react': 18.2.79
-    optional: true
+      '@types/react': 19.1.0
 
-  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+  '@types/react-native@0.73.0(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)':
     dependencies:
-      '@types/react': 19.2.14
-
-  '@types/react-native@0.73.0(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)':
-    dependencies:
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@react-native-community/cli'
@@ -7279,12 +7270,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@types/react@18.2.79':
-    dependencies:
-      '@types/prop-types': 15.7.15
-      csstype: 3.2.3
-
-  '@types/react@19.2.14':
+  '@types/react@19.1.0':
     dependencies:
       csstype: 3.2.3
 
@@ -7588,7 +7574,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -8136,62 +8122,62 @@ snapshots:
 
   expo-application@7.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
-  expo-asset@12.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+  expo-asset@12.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.13(typescript@5.9.3)
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-audio@1.1.1(expo-asset@12.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0):
+  expo-audio@1.1.1(expo-asset@12.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-asset: 12.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-asset: 12.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
 
-  expo-constants@18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)):
+  expo-constants@18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)):
     dependencies:
       '@expo/config': 12.0.13
       '@expo/env': 2.0.11
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-file-system@19.0.21(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)):
+  expo-file-system@19.0.21(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
 
-  expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0):
+  expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       fontfaceobserver: 2.3.0
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
 
   expo-haptics@15.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-keep-awake@15.0.8(expo@54.0.33)(react@19.1.0):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
 
-  expo-linking@8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0):
+  expo-linking@8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))
+      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))
       invariant: 2.2.4
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
     transitivePeerDependencies:
       - expo
       - supports-color
@@ -8204,43 +8190,43 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
 
-  expo-modules-core@3.0.29(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0):
+  expo-modules-core@3.0.29(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       invariant: 2.2.4
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
 
-  expo-notifications@0.32.16(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+  expo-notifications@0.32.16(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.13(typescript@5.9.3)
       '@ide/backoff': 1.0.0
       abort-controller: 3.0.0
       assert: 2.1.0
       badgin: 1.2.3
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-application: 7.0.8(expo@54.0.33)
-      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))
+      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-router@6.0.23(9cc6cece1bb8f4bd3b8ee58f37622f24):
+  expo-router@6.0.23(@expo/metro-runtime@6.1.2)(@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@22.19.17))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0))(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.5(react@19.1.0))(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@19.2.5(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@19.2.5(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       '@expo/schema-utils': 0.1.8
-      '@radix-ui/react-slot': 1.2.0(@types/react@18.2.79)(react@19.1.0)
-      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
-      '@react-navigation/bottom-tabs': 7.15.9(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
-      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
-      '@react-navigation/native-stack': 7.14.10(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.0(@types/react@19.1.0)(react@19.1.0)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@react-navigation/bottom-tabs': 7.15.9(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native-stack': 7.14.10(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       client-only: 0.0.1
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))
-      expo-linking: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))
+      expo-linking: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       expo-server: 1.0.5
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
@@ -8248,21 +8234,21 @@ snapshots:
       query-string: 7.1.3
       react: 19.1.0
       react-fast-compare: 3.2.2
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
-      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
-      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       semver: 7.6.3
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
       shallowequal: 1.1.0
       use-latest-callback: 0.2.6(react@19.1.0)
-      vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      vaul: 1.1.2(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
     optionalDependencies:
-      '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@22.19.17))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
+      '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@22.19.17))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
       react-dom: 19.2.5(react@19.1.0)
-      react-native-gesture-handler: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
-      react-native-reanimated: 3.16.7(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      react-native-gesture-handler: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      react-native-reanimated: 3.16.7(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
       - '@types/react'
@@ -8273,42 +8259,42 @@ snapshots:
 
   expo-speech@14.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
-  expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0):
+  expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       await-lock: 2.2.2
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
 
-  expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+  expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@expo/cli': 54.0.23(expo-router@6.0.23)(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(typescript@5.9.3)
+      '@expo/cli': 54.0.23(expo-router@6.0.23)(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(typescript@5.9.3)
       '@expo/config': 12.0.13
       '@expo/config-plugins': 54.0.4
-      '@expo/devtools': 0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      '@expo/devtools': 0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       '@expo/fingerprint': 0.15.4
       '@expo/metro': 54.2.0
       '@expo/metro-config': 54.0.14(expo@54.0.33)
-      '@expo/vector-icons': 15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      '@expo/vector-icons': 15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       '@ungap/structured-clone': 1.3.0
       babel-preset-expo: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.33)(react-refresh@0.14.2)
-      expo-asset: 12.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))
-      expo-file-system: 19.0.21(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))
-      expo-font: 14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      expo-asset: 12.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))
+      expo-file-system: 19.0.21(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))
+      expo-font: 14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       expo-keep-awake: 15.0.8(expo@54.0.33)(react@19.1.0)
       expo-modules-autolinking: 3.0.24
-      expo-modules-core: 3.0.29(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      expo-modules-core: 3.0.29(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       pretty-format: 29.7.0
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
       react-refresh: 0.14.2
       whatwg-url-without-unicode: 8.0.0-3
     optionalDependencies:
-      '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@19.2.5(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@19.2.5(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -8792,21 +8778,21 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@54.0.17(@babel/core@7.29.0)(expo@54.0.33)(jest@29.7.0(@types/node@22.19.17))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0):
+  jest-expo@54.0.17(@babel/core@7.29.0)(expo@54.0.33)(jest@29.7.0(@types/node@22.19.17))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@expo/config': 12.0.13
       '@expo/json-file': 10.0.13
       '@jest/create-cache-key-function': 29.7.0
       '@jest/globals': 29.7.0
       babel-jest: 29.7.0(@babel/core@7.29.0)
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       jest-environment-jsdom: 29.7.0
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
       jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@22.19.17))
       json5: 2.2.3
       lodash: 4.18.1
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
       react-test-renderer: 19.1.0(react@19.1.0)
       server-only: 0.0.1
       stacktrace-js: 2.0.2
@@ -9980,20 +9966,20 @@ snapshots:
 
   react-is@19.2.5: {}
 
-  react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0):
+  react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
 
-  react-native-is-edge-to-edge@1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0):
+  react-native-is-edge-to-edge@1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
 
-  react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0):
+  react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -10008,32 +9994,32 @@ snapshots:
       convert-source-map: 2.0.0
       invariant: 2.2.4
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
-  react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0):
+  react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
 
-  react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0):
+  react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-freeze: 1.0.4(react@19.1.0)
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       warn-once: 0.1.1
 
-  react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0):
+  react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       css-select: 5.2.2
       css-tree: 1.1.3
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0)
       warn-once: 0.1.1
 
-  react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0):
+  react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.81.5
@@ -10042,7 +10028,7 @@ snapshots:
       '@react-native/gradle-plugin': 0.81.5
       '@react-native/js-polyfills': 0.81.5
       '@react-native/normalize-colors': 0.81.5
-      '@react-native/virtualized-lists': 0.81.5(@types/react@18.2.79)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.2.79)(react@19.1.0))(react@19.1.0)
+      '@react-native/virtualized-lists': 0.81.5(@types/react@19.1.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -10071,7 +10057,7 @@ snapshots:
       ws: 6.2.3
       yargs: 17.7.2
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@react-native-community/cli'
@@ -10084,32 +10070,32 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
-  react-remove-scroll-bar@2.3.8(@types/react@18.2.79)(react@19.1.0):
+  react-remove-scroll-bar@2.3.8(@types/react@19.1.0)(react@19.1.0):
     dependencies:
       react: 19.1.0
-      react-style-singleton: 2.2.3(@types/react@18.2.79)(react@19.1.0)
+      react-style-singleton: 2.2.3(@types/react@19.1.0)(react@19.1.0)
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
-  react-remove-scroll@2.7.2(@types/react@18.2.79)(react@19.1.0):
+  react-remove-scroll@2.7.2(@types/react@19.1.0)(react@19.1.0):
     dependencies:
       react: 19.1.0
-      react-remove-scroll-bar: 2.3.8(@types/react@18.2.79)(react@19.1.0)
-      react-style-singleton: 2.2.3(@types/react@18.2.79)(react@19.1.0)
+      react-remove-scroll-bar: 2.3.8(@types/react@19.1.0)(react@19.1.0)
+      react-style-singleton: 2.2.3(@types/react@19.1.0)(react@19.1.0)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@18.2.79)(react@19.1.0)
-      use-sidecar: 1.1.3(@types/react@18.2.79)(react@19.1.0)
+      use-callback-ref: 1.3.3(@types/react@19.1.0)(react@19.1.0)
+      use-sidecar: 1.1.3(@types/react@19.1.0)(react@19.1.0)
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
-  react-style-singleton@2.2.3(@types/react@18.2.79)(react@19.1.0):
+  react-style-singleton@2.2.3(@types/react@19.1.0)(react@19.1.0):
     dependencies:
       get-nonce: 1.0.1
       react: 19.1.0
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
   react-test-renderer@19.1.0(react@19.1.0):
     dependencies:
@@ -10640,24 +10626,24 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  use-callback-ref@1.3.3(@types/react@18.2.79)(react@19.1.0):
+  use-callback-ref@1.3.3(@types/react@19.1.0)(react@19.1.0):
     dependencies:
       react: 19.1.0
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
   use-latest-callback@0.2.6(react@19.1.0):
     dependencies:
       react: 19.1.0
 
-  use-sidecar@1.1.3(@types/react@18.2.79)(react@19.1.0):
+  use-sidecar@1.1.3(@types/react@19.1.0)(react@19.1.0):
     dependencies:
       detect-node-es: 1.1.0
       react: 19.1.0
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.1.0
 
   use-sync-external-store@1.6.0(react@19.1.0):
     dependencies:
@@ -10685,9 +10671,9 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0):
+  vaul@1.1.2(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@18.2.79))(@types/react@18.2.79)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.2.5(react@19.1.0)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
Phase 3 of the UI upgrade — mocks list, section hub, and exam runner, built on the Phase 1 token foundation. Ethics gate: the exam timer never turns red at any state.

Closes #52. Depends on #50 (Phase 1 tokens).

## What changed

### Mocks list (`/exam`)
- Four distinct card states — not-started / in-progress / completed / coming-soon — distinguished structurally, not by color alone.
- Level info strip uses `bg-level-{n}-surface` + `text-level-{n}-text` tokens; no more opacity-hex hack.
- Chevron appears only on hover. Empty state is a single centered line, no skeletons.

### Section hub (`/exam/[mockId]`)
- Sections grouped into **Schriftlich** / **Mündlich** blocks, each with the 60% pass threshold surfaced once.
- Emoji icons replaced with `lucide-react` (Headphones, FileText, Puzzle, Pencil, Mic) at stroke 1.75.
- Status dots replace text badges.
- CTA: "Mit Hören starten" / "Weiter mit {section}".

### Exam runner (all 5 section runners)
- Unified `ExamRunnerHeader`: X + "Prüfung beenden" confirm dialog, centered label, right-aligned amber-only `ExamTimer`, 3px level-colored progress bar.
- New `AnswerOption` uses a **4px left accent** on selection + `bg-surface-container` — explicitly NOT a full brand-filled row.
- `ExamSubmitButton` shared across runners (52px, `bg-brand-600`, disabled until ready).

### ExamTimer (ethics gate)
- Warning (`<5 min`) and expired (`0:00`) share `bg-warning-surface` + `text-warning`. No red anywhere. Tests assert the absence of `bg-error`, `text-error`, `bg-fail`, `text-fail`, and red hex at every state.
- Digits render in `font-mono` + `tabular-nums` for stable width.

## Test plan
- [x] `pnpm typecheck` green (all packages)
- [x] `pnpm --filter @fastrack/web test` — 182 / 182 pass (6 new tests — MockCard, SectionHub, AnswerOption; ExamTimer suite expanded with explicit no-red assertions at 30:00, 4:59, 0:00, after countdown)
- [x] `pnpm --filter @fastrack/web build` green; exam routes 3–5 KB each
- [x] E2E specs updated for new `data-state` selectors and amber-only timer
- [ ] Manual QA: start mock, verify timer amber at 4:59 and at 0:00 (never red); verify answer selection shows left-accent not full fill; verify completed mock cards recede into surface-container

## Token usage
All styling uses Phase 1 tokens — no hardcoded hex:
- `bg-brand-600`, `border-l-brand-500`
- `bg-level-{n}-surface`, `text-level-{n}-text`
- `bg-warning-surface`, `text-warning`, `bg-pass-surface`, `bg-fail-surface`
- `font-mono`, `tabular-nums`

## Handoff
See `.planning/handoffs/2026-04-20-ux-phase3-mocks-runner.md` for the full file list, follow-ups, and rationale.