### PR TITLE
content(B2): author mock_01 — Beruf & Arbeitswelt (worked example) (#60)

### DIFF
--- a/.planning/audio-prompts/B2_mock01_listening_part1.ssml
+++ b/.planning/audio-prompts/B2_mock01_listening_part1.ssml
@@ -1,0 +1,96 @@
+<speak>
+  <!-- B2 Mock 01 — Teil 1 (5 True/False, playCount=1) -->
+  <!-- Narrator: de-DE-Wavenet-C (female, neutral) — announcer voice -->
+  <!-- News speakers rotate: de-DE-Wavenet-B (male), de-DE-Wavenet-A (female), de-DE-Wavenet-D (male) -->
+  <!-- B2 spec: natural speed 1.0x, no pedagogical slowing, played ONCE -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">
+      Hörverstehen, Teil 1. Sie hören fünf kurze Nachrichtenmeldungen.
+      Entscheiden Sie bei jeder Aussage: richtig oder falsch?
+      Sie hören jeden Text nur einmal.
+    </prosody>
+    <break time="10s"/>
+  </voice>
+
+  <!-- Aufgabe 1: Fachkräftemangel verschärft sich -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Aufgabe 1.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="1.0">
+      Eine neue Erhebung der Industrie- und Handelskammern zeigt: Der Fachkräftemangel
+      im verarbeitenden Gewerbe hat sich im zweiten Jahr in Folge verschärft.
+      Betroffen sind vor allem technische Berufe. Mehr als sechzig Prozent der Betriebe melden,
+      offene Stellen monatelang nicht besetzen zu können.
+    </prosody>
+  </voice>
+  <break time="5s"/>
+
+  <!-- Aufgabe 2: Weiterbildungsgesetz -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Aufgabe 2.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="1.0">
+      Das neue Weiterbildungsgesetz tritt zum ersten Juli in Kraft. Nach dem Gesetz sollen
+      die Kosten für Qualifizierungsmaßnahmen zwischen der Bundesagentur für Arbeit und
+      den Betrieben geteilt werden. Ziel ist es, insbesondere kleinere Unternehmen beim Umgang
+      mit dem digitalen Wandel zu unterstützen.
+    </prosody>
+  </voice>
+  <break time="5s"/>
+
+  <!-- Aufgabe 3: Bundesamt empfiehlt 5 Weiterbildungstage -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Aufgabe 3.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="1.0">
+      Das Bundesamt für Arbeitsforschung hat heute eine Empfehlung veröffentlicht: Arbeitgeber
+      sollten ihren Beschäftigten jährlich mindestens fünf bezahlte Weiterbildungstage anbieten.
+      Derzeit liegt der Durchschnitt in deutschen Unternehmen bei lediglich zwei bis drei Tagen
+      pro Jahr.
+    </prosody>
+  </voice>
+  <break time="5s"/>
+
+  <!-- Aufgabe 4: DB Tarifverhandlungen -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Aufgabe 4.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="1.0">
+      Nach sieben Verhandlungsrunden bleiben die Deutsche Bahn und die Gewerkschaft
+      weiterhin uneinig; ein Abschluss ist bislang nicht in Sicht. Die Gewerkschaft schließt
+      weitere Warnstreiks im Fern- und Regionalverkehr nicht aus. Reisende müssen daher auch
+      in den kommenden Wochen mit Behinderungen rechnen.
+    </prosody>
+  </voice>
+  <break time="5s"/>
+
+  <!-- Aufgabe 5: Homeoffice Studie stagniert -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Aufgabe 5.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="1.0">
+      Laut einer aktuellen Studie der Hans-Böckler-Stiftung stagniert der Anteil der
+      Beschäftigten im Homeoffice seit eineinhalb Jahren bei rund vierundzwanzig Prozent.
+      Die Autoren führen dies auf eine zunehmende Zahl von Rückrufaktionen großer Unternehmen
+      zurück, die auf mehr Präsenz im Büro drängen.
+    </prosody>
+  </voice>
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Das ist das Ende von Teil 1.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B2_mock01_listening_part2.ssml
+++ b/.planning/audio-prompts/B2_mock01_listening_part2.ssml
@@ -1,0 +1,181 @@
+<speak>
+  <!-- B2 Mock 01 — Teil 2 (10 True/False, playCount=1) -->
+  <!-- Moderator: de-DE-Wavenet-E (male) — interviewer -->
+  <!-- Expert Dr. Richter: de-DE-Wavenet-F (female) — guest -->
+  <!-- B2 spec: natural speed 1.0x, continuous interview, no item-level pauses, played ONCE -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">
+      Hörverstehen, Teil 2. Sie hören ein Interview zum Thema Weiterbildung im Beruf.
+      Entscheiden Sie, ob die folgenden zehn Aussagen richtig oder falsch sind.
+      Sie hören das Interview nur einmal.
+    </prosody>
+    <break time="10s"/>
+  </voice>
+
+  <!-- Intro and speaker presentation -->
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Guten Morgen, liebe Hörerinnen und Hörer. In unserer heutigen Sendung sprechen wir
+      über berufliche Weiterbildung in Deutschland. Mein Gast ist Frau Dr. Sabine Richter,
+      Leiterin des Instituts für Berufsbildungsforschung in Bonn. Herzlich willkommen,
+      Frau Dr. Richter.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="1.0">
+      Vielen Dank für die Einladung – ich freue mich, hier zu sein.
+    </prosody>
+  </voice>
+  <break time="1s"/>
+
+  <!-- Q2 context: international comparison -->
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Frau Dr. Richter, wenn wir uns im internationalen Vergleich ansehen: Wo steht
+      Deutschland beim Thema betriebliche Weiterbildung?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="1.0">
+      Da muss ich ehrlich sein: Im internationalen Vergleich hinken deutsche Betriebe den
+      skandinavischen Ländern nach wie vor deutlich hinterher. In Schweden und Dänemark
+      beispielsweise investieren Unternehmen im Schnitt doppelt so viel pro Mitarbeiter
+      in Qualifizierung. Da haben wir erheblichen Nachholbedarf.
+    </prosody>
+  </voice>
+  <break time="1s"/>
+
+  <!-- Q3 context: hedging trap — small businesses don't reject training -->
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Man hört ja immer wieder die Kritik, dass vor allem kleine Betriebe kein Interesse
+      an Weiterbildung hätten.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="1.0">
+      Das stimmt so pauschal nicht. Man hört oft, kleine Betriebe würden Weiterbildung
+      ablehnen – unsere Daten zeigen ein anderes Bild. Viele wollen, können aber ihre
+      Mitarbeiter schlicht nicht freistellen. Wenn in einem Handwerksbetrieb mit fünf Leuten
+      einer eine Woche in der Schulung sitzt, dann fehlt ein Fünftel der Produktion.
+      Das ist ein strukturelles Problem, kein Einstellungsproblem.
+    </prosody>
+  </voice>
+  <break time="1s"/>
+
+  <!-- Q4: self-assessment -->
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Studien zeigen auch, dass viele Beschäftigte ihren eigenen Qualifizierungsbedarf eher
+      zu niedrig einschätzen. Wie kommt das?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="1.0">
+      Das ist in der Tat paradox. Viele glauben, solange sie ihren Job erledigen können,
+      sei alles in Ordnung. Aber die Halbwertszeit beruflichen Wissens sinkt – gerade in
+      digitalen Bereichen. Wer heute gut ist, muss in drei Jahren nicht mehr gut sein.
+    </prosody>
+  </voice>
+  <break time="1s"/>
+
+  <!-- Q5: digitalization -->
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Apropos Digitalisierung: Bringt die nicht auch eher zusätzliche Belastung mit sich?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="1.0">
+      Ja, die Digitalisierung bringt zweifellos Belastungen mit sich – das kann ich nicht
+      bestreiten. Aber überwiegend sehe ich enorme Chancen, vor allem durch orts- und
+      zeitflexible Lernformate. Eine Pflegekraft in einem ländlichen Pflegeheim kann heute
+      Abend um neun Uhr einen Fortbildungskurs besuchen – das war vor zehn Jahren völlig
+      undenkbar.
+    </prosody>
+  </voice>
+  <break time="1s"/>
+
+  <!-- Q6: online vs blended -->
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Bedeutet das, reine Online-Kurse sind die Zukunft?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="1.0">
+      Da muss ich differenzieren. Blended Learning, also die Kombination aus Online- und
+      Präsenzphasen, erzielt nachweislich die besten Lerneffekte – reine Online-Formate
+      allein nicht. Der persönliche Austausch, die Diskussion mit anderen Lernenden,
+      das lässt sich durch eine Videokonferenz nicht vollständig ersetzen.
+    </prosody>
+  </voice>
+  <break time="1s"/>
+
+  <!-- Q7: work time -->
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Welche Bedingungen müssen Arbeitgeber schaffen, damit Weiterbildung tatsächlich gelingt?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="1.0">
+      Entscheidend ist, dass Weiterbildung als Arbeitszeit gilt und nicht in die Freizeit
+      verlagert wird – sonst brechen gerade Beschäftigte mit Familie schnell ab.
+      Das ist der wichtigste Punkt.
+    </prosody>
+  </voice>
+  <break time="1s"/>
+
+  <!-- Q8: gender gap -->
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Wie sieht es denn mit der Teilnahme von Frauen aus?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="1.0">
+      Leider zeigen unsere Daten, dass Frauen, vor allem in der Familienphase, deutlich
+      seltener an betrieblichen Weiterbildungen teilnehmen als ihre männlichen Kollegen.
+      Das hat mit Teilzeitarbeit, Kinderbetreuung und auch mit subtilen Ausschlussmechanismen
+      in den Unternehmen zu tun. Hier besteht dringender Handlungsbedarf.
+    </prosody>
+  </voice>
+  <break time="1s"/>
+
+  <!-- Q9: Bildungsprämie -->
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Die Bundesregierung hat die Bildungsprämie gerade erhöht – wie bewerten Sie das?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="1.0">
+      Die Bildungsprämie ist ein Schritt in die richtige Richtung, auch wenn sie noch zu
+      niedrig angesetzt ist. Wir müssen hier deutlich nachlegen, wenn wir den internationalen
+      Anschluss nicht verlieren wollen. Aber grundsätzlich: ja, richtiges Signal.
+    </prosody>
+  </voice>
+  <break time="1s"/>
+
+  <!-- Q10: closing without conference -->
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Frau Dr. Richter, herzlichen Dank für das aufschlussreiche Gespräch. Mehr zu diesem
+      Thema finden Sie auf unserer Website. Von hier aus wünsche ich Ihnen einen schönen Tag.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="1.0">
+      Ihnen auch, vielen Dank.
+    </prosody>
+  </voice>
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Das ist das Ende von Teil 2.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B2_mock01_listening_part3.ssml
+++ b/.planning/audio-prompts/B2_mock01_listening_part3.ssml
@@ -1,0 +1,100 @@
+<speak>
+  <!-- B2 Mock 01 — Teil 3 (5 MCQ, playCount=1) -->
+  <!-- Narrator: de-DE-Wavenet-C (female) — announcer -->
+  <!-- Varied voices per announcement: B (male), A (female), D (male), F (female), E (male) -->
+  <!-- B2 spec: natural speed 1.0x, short announcements/voicemails, played ONCE -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">
+      Hörverstehen, Teil 3. Sie hören fünf kurze Ansagen oder Nachrichten aus dem
+      beruflichen Alltag. Was ist richtig? Kreuzen Sie an: a, b oder c.
+      Sie hören jeden Text nur einmal.
+    </prosody>
+    <break time="10s"/>
+  </voice>
+
+  <!-- Aufgabe 1: Weber ruft Kollegen an wegen Unterlagen fürs Vorstellungsgespräch -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Aufgabe 1.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="1.0">
+      Hi Thomas, hier ist Michael Weber. Du, ich habe morgen um zehn Uhr das Vorstellungsgespräch
+      bei Siemens – du erinnerst dich? Könntest du bitte die aktualisierte Projektliste und
+      die Zeugniskopien mitbringen, wenn du heute Abend noch kurz bei mir vorbeikommst?
+      Ohne die kann ich im Gespräch nicht sinnvoll argumentieren. Meine sind leider noch
+      beim Steuerberater. Das wäre super. Ruf mich kurz zurück, wenn es nicht passt. Danke!
+    </prosody>
+  </voice>
+  <break time="5s"/>
+
+  <!-- Aufgabe 2: Personalabteilung — neue Weiterbildungsplattform -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Aufgabe 2.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="1.0">
+      Liebe Kolleginnen und Kollegen, hier spricht die Personalabteilung. Ab Montag,
+      dem zwölften Mai, finden Sie alle internen Schulungen auf unserer neuen Lernplattform
+      Talento. Die bisherige Seite wird abgeschaltet. Bitte melden Sie sich mit Ihrer
+      Firmen-Mail-Adresse an und schließen Sie laufende Kurse bis zum zehnten Mai ab.
+      Bei Fragen wenden Sie sich an Frau Bauer von der Personalentwicklung.
+    </prosody>
+  </voice>
+  <break time="5s"/>
+
+  <!-- Aufgabe 3: Karriereberaterin empfiehlt Gespräch mit Vorgesetzter -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Aufgabe 3.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="1.0">
+      Frau Sommer, ich habe mir Ihre Situation angehört. Mein Rat wäre folgender: Bevor Sie
+      über eine Kündigung nachdenken, würde ich Ihnen dringend raten, zunächst das offene
+      Gespräch mit Ihrer Vorgesetzten zu suchen. Oft stellen sich Konflikte als Missverständnis
+      heraus, und Sie hätten immerhin schon einmal dokumentiert, dass Sie eine Klärung versucht
+      haben. Melden Sie sich gerne wieder, sobald das Gespräch stattgefunden hat.
+    </prosody>
+  </voice>
+  <break time="5s"/>
+
+  <!-- Aufgabe 4: Kunde beschwert sich wegen mangelhafter Ware -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Aufgabe 4.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="1.0">
+      Guten Tag, hier spricht Markus Zimmermann von der Firma Elektrotechnik Zimmermann.
+      Die Lieferung vom vergangenen Montag ist leider mangelhaft: Drei der gelieferten Geräte
+      weisen erhebliche Mängel auf. Ich erwarte bis Ende der Woche eine Ersatzlieferung
+      oder eine vollständige Gutschrift. Bitte rufen Sie mich unter der bekannten Nummer
+      zurück – das ist dringend.
+    </prosody>
+  </voice>
+  <break time="5s"/>
+
+  <!-- Aufgabe 5: Tagungshotel — Kaffeepause im Wintergarten -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Aufgabe 5.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Liebe Teilnehmerinnen und Teilnehmer der Fachkonferenz Zukunft Arbeit, eine kurze
+      organisatorische Durchsage: Die Kaffeepause findet heute ausnahmsweise nicht im Foyer,
+      sondern im Wintergarten im Erdgeschoss statt. Die Zeiten bleiben unverändert.
+      Die folgenden Workshops beginnen pünktlich um vierzehn Uhr wie geplant. Vielen Dank.
+    </prosody>
+  </voice>
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Das ist das Ende von Teil 3 und damit das Ende des Hörverstehens.</prosody>
+  </voice>
+</speak>

--- a/.planning/handoffs/2026-04-20-impl-b2-mock-01.md
+++ b/.planning/handoffs/2026-04-20-impl-b2-mock-01.md
@@ -1,0 +1,134 @@
+# Handoff — #60 — B2 mock_01 (Beruf & Arbeitswelt) worked example
+
+**Date:** 2026-04-20
+**Agent:** implementation-lead
+**Branch:** `b2-mock-01`
+**PR:** https://github.com/kirankbs/fastrack-deutsch/pull/61
+
+## What was built
+
+First real B2 mock exam — the **worked example** that the remaining 9 B2 mocks will copy in structure. Theme: **Beruf & Arbeitswelt** (Bewerbung, Weiterbildung, Homeoffice, Work-Life-Balance).
+
+Replaces the 372-byte `_stub: true` placeholder at `apps/mobile/assets/content/B2/mock_01.json` with ~94 KB of authored content that matches the telc B2 exam format spec (`.planning/research/B2-exam-format.md`).
+
+### Sections authored
+
+- **Hören** — 3 parts / 20 items / 75 pts. All `playCount: 1` (B2 single-play rule).
+  - Teil 1: 5 broadcast news bulletins (Fachkräftemangel, Weiterbildungsgesetz, Bundesamt-Empfehlung, Bahn-Tarifverhandlungen, Homeoffice-Studie) — richtig/falsch.
+  - Teil 2: 10 r/f on a ~4–5 min interview with Dr. Sabine Richter (Institut für Berufsbildungsforschung Bonn) — hedging-trap items included.
+  - Teil 3: 5 MCQ on short workplace announcements/voicemails.
+- **Lesen** — 3 parts / 20 items / 75 pts / 90 min shared block.
+  - Teil 1: 5 texts (~120–150 words each) matched to 10 headings (5 distractors).
+  - Teil 2: ~500-word feature article "Digital, aber nicht entmenschlicht" with 5 inference MCQ.
+  - Teil 3: 10 situations matched to 12 Weiterbildungs-/Beratungsangebote, including 1 `"x"` no-match situation (Assessment Center simulation).
+- **Sprachbausteine** — 2 parts / 20 items / 30 pts.
+  - Teil 1: ~220-word HR announcement with 10 gaps, **4 options each (a/b/c/d) — KEY B2 diff from B1**. Tests Passiv-Perfekt, Partizipialattribute, Nominalisierung, Genitiv-Präpositionen (angesichts), Funktionsverbgefüge (in Anspruch nehmen), Inversion nach Konditionalsatz.
+  - Teil 2: ~220-word Bewerbungsratgeber with 10 gaps, 15-option word bank. Tests B2 discourse markers, pronominal adverbs (dazu, darin), idiomatic collocations (goldene Regel, aufzufliegen).
+- **Schreiben** — 1 task / 2 prompts (choose 1) / 45 pts / 30 min.
+  - Aufgabe A: Beschwerdebrief über mangelhaften Weiterbildungskurs (890 €, drei konkrete Mängel + Forderung + Frist).
+  - Aufgabe B: Leserbrief-Stellungnahme zu "Homeoffice macht Karrieren unsichtbar".
+  - Full sample answer for A (B2-register + Konjunktiv II + Nominalisierung); scoring rubric documents D-in-I-or-III → 0 pts total.
+- **Sprechen** — 3 parts / 75 pts / 15 min + 20 min prep.
+  - Teil 1 Präsentation: dual topic cards (A = Weiterbildung, B = Homeoffice).
+  - Teil 2 Diskussion: "Bewerbungen sollten anonym sein" — provocative prompt with 4 Leitfragen.
+  - Teil 3 Gemeinsam Planen: Willkommenstag für neue Kollegin Daria Kowalski — 5 planning dimensions.
+
+### Audio
+
+- 3 SSML scripts under `.planning/audio-prompts/B2_mock01_listening_part{1,2,3}.ssml` following B1 mock_01 convention (`rate="1.0"` for B2 natural speed, multi-voice Wavenet assignments, 10s initial pause for statement reading).
+- MP3 paths (`assets/audio/B2/mock01/listening_part{1,2,3}.mp3`) wired in JSON — actual MP3 generation is a separate issue.
+
+## Files changed
+
+- `apps/mobile/assets/content/B2/mock_01.json` — **stub → 936 lines / ~94 KB** of authored content.
+- `packages/content/src/catalog.ts` — B2 titles array updated to real mock themes (`mock_01` now "Beruf & Arbeitswelt" instead of "Wissenschaft").
+- `.planning/audio-prompts/B2_mock01_listening_part1.ssml` — new (Teil 1 news bulletins, 5 rotating voices).
+- `.planning/audio-prompts/B2_mock01_listening_part2.ssml` — new (Teil 2 interview, Moderator + Dr. Richter, continuous flow, no item pauses).
+- `.planning/audio-prompts/B2_mock01_listening_part3.ssml` — new (Teil 3 announcements, 5 different speakers).
+
+## Tests
+
+- **Unit (web):** 210/210 tests pass via `pnpm --filter @fastrack/web test`.
+- **Unit (mobile):** skipped — pre-existing Jest/expo-modules-core config failure on main, unrelated to this PR.
+- **Typecheck:** clean across all 6 workspace packages.
+- **Structural validation:** 40 unique question IDs across listening+reading (+20 more blankNumbers in Sprachbausteine); every MCQ/matching/cloze has `explanation`; `_stub` removed; schema validates via `validateMockExam`.
+- **Sprachbausteine format:** Teil 1 = 10/10 items with exactly 4 options; Teil 2 = 10/10 items with exactly 15 options.
+- **Timing:** Listening 20 / Reading 90 / Writing 30 / Speaking 15 + 20 prep — all match B2 spec.
+- **E2E (Playwright):** PASS on CI (57s).
+
+## Quality gates
+
+| Gate | Status |
+|------|--------|
+| compliance-guardian | n/a (content-only, no auth/PII) |
+| language-checker | requested post-merge |
+| exam-tester (layer A + B) | structural layer A passed manually; code-test layer B requested |
+| pedagogy-director 6-dim review | **HARD GATE** — self-assessment posted on PR #61 (comment 4283699602); pedagogy-director still required to post the binding review before merge |
+| spec-tracker `mode=sync` | requested |
+
+Self-assessment: 5 of 6 dimensions scored A, 1 scored B (CEFR calibration — conservative about borderline C1 vocabulary in `explanation` fields). No blocking issues identified.
+
+## CI status (PR #61)
+
+All 5 checks green:
+- E2E Tests — PASS (57s)
+- Typecheck + Tests — PASS (40s)
+- Vercel Preview Comments — PASS
+- Vercel fastrack-deutsch — PASS
+- Vercel telc-fasttrack-web — PASS
+
+## Calibration notes for B2 mocks 02–10 (follow this pattern)
+
+1. **Always 4 options (a/b/c/d) in Sprachbausteine Teil 1.** This is the #1 structural difference from B1 and must be consistent.
+2. **Always `playCount: 1`** on every listening part (single-play is the B2 rule).
+3. **Include exactly 1 `"x"` no-match situation in Lesen Teil 3** — but make it close to one existing ad (not obviously orphaned). This mock uses an Assessment Center simulation as the "x" anchor.
+4. **Writing: 2 prompts (A + B).** Candidate chooses one. Do not fall back to a single-prompt B1 layout.
+5. **Speaking Teil 1: different topic cards for A and B.** Pair dynamics depend on this.
+6. **Sprachbausteine explanations should name the grammar feature being tested** (Passiv-Perfekt, Partizipialattribut, Funktionsverbgefüge, Inversion nach Konditionalsatz, etc.). This turns the mock into a teaching artefact.
+7. **Every above-B2 word must be glossed in the `explanation` field.** No exceptions.
+8. **Distractors must be text-derived.** Use vocabulary from the source text but combine it into a claim the text does not make. See R2_q4 (inversion of the Hoffmann logic) as the template.
+9. **SSML scripts:** `rate="1.0"` (no pedagogical slowing), multi-voice rotation for announcements, continuous flow for interview (no item-level pauses), 10s initial pause for statement-reading.
+10. **File size check:** A worked B2 mock should land around 90–100 KB / ~900+ lines of JSON. Significantly shorter mocks are likely under-developed.
+
+## Known follow-ups (not in this PR)
+
+- Generate MP3 audio from the 3 SSML scripts (separate issue — audio-engineer agent)
+- ~~pedagogy-director binding review comment on PR #61~~ DONE (2026-04-20)
+- language-checker + exam-tester layer B + spec-tracker `mode=sync` runs
+- B2 mocks 02–10 authoring (9 more mocks, use this mock as structural template)
+- B2 vocabulary JSON population (~4000 entries; currently empty)
+- B2 grammar JSON population (~15 topics; currently empty)
+
+---
+
+## Pedagogy Director — Binding Review Verdict (2026-04-20)
+
+**Overall: PASS (with 3 corrections applied)**
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Content Accuracy | 4.5/5 | Two items corrected: SB T1 gap 5 (dual-correct distractor) and SB T2 gap 20 (unnatural collocation). After fixes, all 60+ items have unambiguous correct answers. |
+| CEFR Level (B2) | 5/5 | Vocabulary and grammar strictly within B2 ceiling. Metalinguistic terms in explanations appropriately above-level. No C1 leakage in exam-facing text. |
+| Distractor Quality | 4.5/5 | Strong across sections. Hedging traps in Hoeren Teil 2 are textbook B2 discrimination. R2_q4 distractor (logic inversion) is excellent. SB T1 gap 5 "Wegen" replaced with "Mangels" to eliminate dual-correct risk. |
+| Explanation Quality | 5/5 | Every item has a substantive explanation citing specific text, naming grammar rules, and analyzing distractors. B2-trap labels included. Teaching quality is high. |
+| Format Fidelity | 5/5 | All item counts, timing, playCount, option counts (4-option SB T1, 15-option SB T2), 2-prompt writing, 3-part speaking match telc B2 spec exactly. |
+| Topic Coverage | 3.5/5 | ADVISORY: entire mock is Arbeit/Beruf domain. "angesichts" tested twice (SB gaps 5+18). Acceptable for a themed mock but mocks 02-10 MUST diversify across the 16 telc B2 topic domains. |
+
+### Corrections Applied (3 rewrites)
+
+1. **SB T1 gap 5:** Replaced distractor "Wegen" with "Mangels" — "Wegen" was semantically defensible alongside "Angesichts," creating dual-correct risk. "Mangels" contradicts the context (investments ARE being made, not lacking). [PEDAGOGY-REWRITE]
+2. **SB T2 gap 20:** Restructured sentence from "auf diese Weise entscheidend plant" to "auf diese Weise plant, kann seine Chancen entscheidend verbessern" — "entscheidend planen" is not a natural German collocation; "entscheidend verbessern" is. [PEDAGOGY-REWRITE]
+3. **R3_q10 explanation:** Added missing ad i) (Kongress) to the list of unused distractor ads. Original mentioned only j) and l) but i) is also unused. [PEDAGOGY-REWRITE]
+
+### Calibration Rules for Mocks 02-10
+
+1. **No repeated vocabulary items across SB T1 and T2.** This mock tested "angesichts" in both parts — avoid in future mocks.
+2. **Diversify topic domains.** Each mock should touch at least 3 of the 16 telc B2 Wortgruppen categories across its sections. Do not repeat the same domain in Lesen T2 and Hoeren T2.
+3. **Sprachbausteine T1 distractor rule:** Every gap must have exactly ONE defensible correct answer. If a distractor is semantically and grammatically viable (even at a different register level), it must be replaced. Register alone is not a sufficient discriminator.
+4. **SB T2 collocation check:** After filling all gaps, read the completed text aloud. If any phrase sounds unnatural to a native ear, the gap construction is flawed. Fix the sentence, not the word.
+5. **Lesen T3 unused ad count:** With 1 "x" answer, there will be 3 unused ads (not 2). All three must be mentioned in the final question's explanation.
+6. **Maintain the 4-option SB T1 / 15-option SB T2 structure.** This is the #1 B2 format distinction from B1.
+7. **All listening playCount: 1.** No exceptions.
+8. **Writing: always 2 prompts from different text types** (complaint + opinion, request + opinion, etc.).
+9. **Speaking Teil 1: different topic cards for A and B.** Both topics should relate to the mock's theme but from different angles.
+10. **Explanation quality bar:** Every explanation must (a) cite the source text/audio phrase, (b) name the grammar/vocabulary rule being tested, (c) explain why at least 1 distractor is wrong. The standard set in this mock is the floor.

--- a/apps/mobile/assets/content/B2/mock_01.json
+++ b/apps/mobile/assets/content/B2/mock_01.json
@@ -600,7 +600,7 @@
                 { "id": "B2_m01_R3_ad_k", "label": "k" }, { "id": "B2_m01_R3_ad_l", "label": "l" }
               ],
               "correctAnswer": "x",
-              "explanation": "Keine der zwölf Anzeigen bietet eine mehrtägige Assessment-Center-Simulation. Anzeige c) deckt nur schriftliches Feedback auf Unterlagen ab, nicht das Auftreten. Anzeige i) ist ein Fachkongress zur Zukunft der Arbeit, keine AC-Simulation. Anzeige a) ist eine 90-minütige Einzelberatung – kein mehrtägiges Assessment. Die Situation erfordert also die Antwort 'x' (kein passendes Angebot). Anzeigen j) (VHS-Deutschkurs C1) und l) (Fernstudium Wirtschaftspsychologie) bleiben als Distraktoren in der Anzeigenliste übrig, passen zu keiner der zehn Situationen."
+              "explanation": "Keine der zwölf Anzeigen bietet eine mehrtägige Assessment-Center-Simulation. Anzeige c) deckt nur schriftliches Feedback auf Unterlagen ab, nicht das Auftreten. Anzeige i) ist ein Fachkongress zur Zukunft der Arbeit, keine AC-Simulation. Anzeige a) ist eine 90-minütige Einzelberatung – kein mehrtägiges Assessment. Die Situation erfordert also die Antwort 'x' (kein passendes Angebot). [PEDAGOGY-REWRITE] Anzeigen i) (Kongress 'Zukunft Arbeit 2026'), j) (VHS-Deutschkurs C1) und l) (Fernstudium Wirtschaftspsychologie) bleiben als die drei ungenutzten Distraktoren in der Anzeigenliste übrig."
             }
           ]
         }
@@ -618,7 +618,7 @@
               "type": "mcq",
               "options": ["a) durchgeführt", "b) durchführte", "c) durchzuführen", "d) durchführend"],
               "correctAnswer": "a",
-              "explanation": "Zustandspassiv/Passiv-Perfekt: 'die von der Personalabteilung durchgeführt worden ist' — Vorgangspassiv im Perfekt (wurde + Partizip II, hier mit 'ist worden' als Passiv-Perfekt). Das Partizip II 'durchgeführt' ist zwingend. Distraktoren: b) 'durchführte' wäre Aktiv-Präteritum (falsche Diathese), c) zu+Infinitiv passt grammatisch nicht zu 'ist worden', d) Partizip I signalisiert laufende Handlung und kombiniert nicht mit 'worden'. B2-Grammatik: Passiv-Perfekt."
+              "explanation": "Vorgangspassiv Perfekt: 'die von der Personalabteilung durchgeführt worden ist' — Bildung: sein + Partizip II + worden (nicht: Zustandspassiv, das 'sein + Partizip II' ohne 'worden' wäre). Das Partizip II 'durchgeführt' ist zwingend. Distraktoren: b) 'durchführte' wäre Aktiv-Präteritum (falsche Diathese), c) zu+Infinitiv passt grammatisch nicht zu 'ist worden', d) Partizip I signalisiert laufende Handlung und kombiniert nicht mit 'worden'. B2-Grammatik: Vorgangspassiv Perfekt."
             },
             {
               "blankNumber": 2,
@@ -644,9 +644,9 @@
             {
               "blankNumber": 5,
               "type": "mcq",
-              "options": ["a) Wegen", "b) Trotz", "c) Angesichts", "d) Außer"],
+              "options": ["a) Mangels", "b) Trotz", "c) Angesichts", "d) Außer"],
               "correctAnswer": "c",
-              "explanation": "Genitiv-Präposition mit passender Semantik: 'Angesichts der erheblichen Investitionen' = 'in Anbetracht, im Hinblick auf' – betont, dass die Investitionen die Erwartung rechtfertigen. Distraktoren: a) 'Wegen' wäre semantisch möglich, aber im formellen B2-Register ist 'angesichts' präziser und gehobener, b) 'Trotz' widerspricht der Logik (Erwartung trotz Investitionen ergibt keinen Sinn), d) 'Außer' heißt 'mit Ausnahme von' – unsinnig. B2-Präposition mit Genitiv: 'angesichts' ist die erwartete Form."
+              "explanation": "[PEDAGOGY-REWRITE] Genitiv-Präposition mit passender Semantik: 'Angesichts der erheblichen Investitionen' = 'in Anbetracht, im Hinblick auf' – betont, dass die Investitionen die Erwartung rechtfertigen. Distraktoren: a) 'Mangels' (= für Mangel an) widerspricht dem Kontext – es WERDEN investiert, es fehlt nichts, b) 'Trotz' widerspricht der Logik (Erwartung trotz Investitionen ergibt keinen Sinn), d) 'Außer' heißt 'mit Ausnahme von' – unsinnig. Alle vier Optionen regieren den Genitiv, aber nur 'angesichts' passt semantisch. B2-Präposition mit Genitiv."
             },
             {
               "blankNumber": 6,
@@ -688,24 +688,24 @@
         {
           "partNumber": 2,
           "instructions": "Lesen Sie den folgenden Text. Welches Wort aus der Liste a–o passt in die Lücken? Jedes Wort passt nur einmal. Fünf Wörter bleiben übrig.",
-          "text": "Wer sich heute um eine anspruchsvolle Stelle bewirbt, steht unter hohem Erwartungsdruck. Die Zahl der Bewerberinnen und Bewerber ist in vielen Branchen erheblich, und Personalabteilungen sichten täglich __(11)__ Lebensläufe. Ein sorgfältig gestaltetes Anschreiben kann in __(12)__ Fällen den Unterschied zwischen Einladung und Absage ausmachen.\n\nAllerdings reicht es nicht aus, lediglich frühere Aufgaben zu beschreiben. Moderne Bewerbungsberatungen empfehlen __(13)__, die eigene Motivation klar zu benennen und konkrete Bezüge zur ausgeschriebenen Stelle herzustellen. __(14)__ gelingt es oft, aus einer Bewerbung eine einprägsame Geschichte zu machen, die Personalverantwortliche auch nach Hunderten anderer Unterlagen noch im Kopf behalten.\n\nEin weiterer wichtiger Punkt __(15)__ die realistische Selbsteinschätzung. Wer Kompetenzen übertreibt, fliegt spätestens im Vorstellungsgespräch __(16)__. Umgekehrt führen unnötige Bescheidenheit und das Herunterspielen eigener Leistungen dazu, dass vorhandenes Potenzial gar nicht erst wahrgenommen wird. Ein ehrlicher, präziser Ton gilt deshalb als goldene __(17)__.\n\n__(18)__ der hohen Belastung im Auswahlprozess setzen viele Unternehmen inzwischen auf strukturierte Interviews und digitale Vorauswahl. Das nimmt Bewerbenden zwar Spielraum, erhöht aber die Vergleichbarkeit der Ergebnisse. Fachleute sehen __(19)__ eine faire Tendenz – sofern die eingesetzten Verfahren transparent bleiben.\n\nWer seine Bewerbung auf diese Weise __(20)__ plant, vergrößert seine Chancen erheblich. Eine Bewerbung ist keine Formalität, sondern die erste berufliche Leistung für den potenziellen neuen Arbeitgeber.",
+          "text": "Wer sich heute um eine anspruchsvolle Stelle bewirbt, steht unter hohem Erwartungsdruck. Die Zahl der Bewerberinnen und Bewerber ist in vielen Branchen erheblich, und Personalabteilungen sichten täglich __(11)__ Lebensläufe. Ein sorgfältig gestaltetes Anschreiben kann in __(12)__ Fällen den Unterschied zwischen Einladung und Absage ausmachen.\n\nAllerdings reicht es nicht aus, lediglich frühere Aufgaben zu beschreiben. Moderne Bewerbungsberatungen raten __(13)__, die eigene Motivation klar zu benennen und konkrete Bezüge zur ausgeschriebenen Stelle herzustellen. __(14)__ gelingt es oft, aus einer Bewerbung eine einprägsame Geschichte zu machen, die Personalverantwortliche auch nach Hunderten anderer Unterlagen noch im Kopf behalten.\n\nEin weiterer wichtiger Punkt __(15)__ die realistische Selbsteinschätzung. Wer Kompetenzen übertreibt, fliegt spätestens im Vorstellungsgespräch __(16)__. Umgekehrt führen unnötige Bescheidenheit und das Herunterspielen eigener Leistungen dazu, dass vorhandenes Potenzial gar nicht erst wahrgenommen wird. Ein ehrlicher, präziser Ton gilt deshalb als goldene __(17)__.\n\n__(18)__ der hohen Belastung im Auswahlprozess setzen viele Unternehmen inzwischen auf strukturierte Interviews und digitale Vorauswahl. Das nimmt Bewerbenden zwar Spielraum, erhöht aber die Vergleichbarkeit der Ergebnisse. Fachleute sehen __(19)__ eine faire Tendenz – sofern die eingesetzten Verfahren transparent bleiben.\n\nWer seine Bewerbung auf diese Weise plant, kann seine Chancen __(20)__ verbessern. Eine Bewerbung ist keine Formalität, sondern die erste berufliche Leistung für den potenziellen neuen Arbeitgeber.",
           "questions": [
             {
               "blankNumber": 11,
               "type": "word_bank",
               "options": [
-                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "a) Hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
                 "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
                 "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
               ],
               "correctAnswer": "a",
-              "explanation": "'hunderte Lebensläufe' — indefinite Mengenangabe (Plural ohne Artikel). Distraktor o) 'wenigen' würde das Gegenteil bedeuten und widerspricht dem Kontext ('erheblich', 'täglich'). B2-Vokabular: 'hunderte' als großzügige Mengenangabe, typisch für Nachrichtensprache."
+              "explanation": "'Hunderte Lebensläufe' — indefinite Mengenangabe (Plural ohne Artikel). Als substantivierte Zahladjektiv-Form wird 'Hunderte' großgeschrieben. Distraktor o) 'wenigen' würde das Gegenteil bedeuten und widerspricht dem Kontext ('erheblich', 'täglich'). B2-Vokabular: 'Hunderte' als großzügige Mengenangabe, typisch für Nachrichtensprache."
             },
             {
               "blankNumber": 12,
               "type": "word_bank",
               "options": [
-                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "a) Hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
                 "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
                 "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
               ],
@@ -716,18 +716,18 @@
               "blankNumber": 13,
               "type": "word_bank",
               "options": [
-                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "a) Hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
                 "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
                 "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
               ],
               "correctAnswer": "c",
-              "explanation": "Feste Kombination: 'raten zu etwas' → hier als Pronominaladverb: 'empfehlen dazu, ... zu benennen' (auf das Folgende verweisend). 'dazu' verweist auf den zu+Infinitiv-Nebensatz. Distraktor i) 'darin' verweist eher auf 'in etwas', hier folgt aber 'zu+Infinitiv'. Pronominaladverb-Kenntnisse gehören zu B2."
+              "explanation": "Feste Kombination: 'jemandem raten zu etwas' → korrelatives Pronominaladverb 'dazu' verweist auf den nachfolgenden zu+Infinitiv-Satz: 'raten dazu, ... zu benennen'. Distraktor i) 'darin' verweist auf 'in etwas' und passt nicht zu einem zu+Infinitiv-Anschluss. Pronominaladverb-Kenntnisse gehören zu B2."
             },
             {
               "blankNumber": 14,
               "type": "word_bank",
               "options": [
-                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "a) Hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
                 "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
                 "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
               ],
@@ -738,7 +738,7 @@
               "blankNumber": 15,
               "type": "word_bank",
               "options": [
-                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "a) Hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
                 "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
                 "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
               ],
@@ -749,7 +749,7 @@
               "blankNumber": 16,
               "type": "word_bank",
               "options": [
-                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "a) Hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
                 "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
                 "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
               ],
@@ -760,7 +760,7 @@
               "blankNumber": 17,
               "type": "word_bank",
               "options": [
-                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "a) Hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
                 "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
                 "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
               ],
@@ -771,7 +771,7 @@
               "blankNumber": 18,
               "type": "word_bank",
               "options": [
-                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "a) Hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
                 "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
                 "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
               ],
@@ -782,7 +782,7 @@
               "blankNumber": 19,
               "type": "word_bank",
               "options": [
-                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "a) Hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
                 "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
                 "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
               ],
@@ -793,12 +793,12 @@
               "blankNumber": 20,
               "type": "word_bank",
               "options": [
-                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "a) Hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
                 "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
                 "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
               ],
               "correctAnswer": "l",
-              "explanation": "Adverbiale Funktion: 'entscheidend plant' = in einer entscheidenden Weise. 'entscheidend' als unflektiertes Adverb verstärkt das Verb 'plant' und fasst die zentrale Aussage des Textes zusammen (alle vorher genannten Punkte sind entscheidend für den Erfolg). Distraktoren: j) 'über' wäre Präposition ohne passenden Kontext (kein Objekt), k) 'bei' ebenso, m) 'jeden' wäre Determiner ohne nachfolgendes Substantiv, n) 'stellt' würde Verbdopplung erzeugen (neben 'plant'), o) 'wenigen' kehrt die positive Aussage unsinnig um. Die verbleibenden fünf Distraktoren (j, k, m, n, o) passen zu keiner Lücke im Text."
+              "explanation": "[PEDAGOGY-REWRITE] Adverbiale Funktion: 'kann seine Chancen entscheidend verbessern' — 'entscheidend' als unflektiertes Adverb verstärkt das Verb 'verbessern' und bildet eine natürliche Kollokation (vgl. 'entscheidend beitragen', 'entscheidend verändern'). Es fasst die zentrale Aussage des Textes zusammen. Distraktoren: j) 'über' wäre Präposition ohne passenden Kontext (kein Objekt), k) 'bei' ebenso, m) 'jeden' wäre Determiner ohne nachfolgendes Substantiv, n) 'stellt' würde Verbdopplung erzeugen, o) 'wenigen' kehrt die positive Aussage unsinnig um. Die verbleibenden fünf Distraktoren (j, k, m, n, o) passen zu keiner Lücke im Text."
             }
           ]
         }

--- a/apps/mobile/assets/content/B2/mock_01.json
+++ b/apps/mobile/assets/content/B2/mock_01.json
@@ -1,13 +1,935 @@
 {
   "id": "B2_mock_01",
   "level": "B2",
-  "title": "Übungstest 1",
-  "version": 0,
-  "_stub": true,
+  "title": "B2 Übungstest 1: Beruf & Arbeitswelt",
+  "version": 1,
   "sections": {
-    "listening": { "totalTimeMinutes": 20, "parts": [] },
-    "reading": { "totalTimeMinutes": 25, "parts": [] },
-    "writing": { "totalTimeMinutes": 20, "tasks": [] },
-    "speaking": { "totalTimeMinutes": 15, "prepTimeMinutes": 0, "parts": [] }
+    "listening": {
+      "totalTimeMinutes": 20,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Sie hören fünf kurze Nachrichtenmeldungen. Entscheiden Sie bei jeder Aussage: richtig oder falsch? Sie hören jeden Text nur einmal.",
+          "instructionsTranslation": "You will hear five short news bulletins. For each statement decide: correct or incorrect? You will hear each text only once.",
+          "audioFile": "assets/audio/B2/mock01/listening_part1.mp3",
+          "playCount": 1,
+          "questions": [
+            {
+              "id": "B2_m01_L1_q1",
+              "type": "true_false",
+              "questionText": "Laut der Meldung sinkt der Fachkräftemangel in der deutschen Industrie seit zwei Jahren.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Die Meldung sagt: 'Der Fachkräftemangel im verarbeitenden Gewerbe hat sich im zweiten Jahr in Folge verschärft – betroffen sind vor allem technische Berufe.' 'verschärft' bedeutet zugenommen, also ist die Aussage, dass er sinkt, falsch. B2-Falle: 'sinken' und 'sich verschärfen' klingen beide wie quantitative Aussagen, aber nur eine stimmt mit dem Audio überein.",
+              "audioTimestamp": 12
+            },
+            {
+              "id": "B2_m01_L1_q2",
+              "type": "true_false",
+              "questionText": "Das neue Weiterbildungsgesetz soll die Kosten für Qualifizierungsmaßnahmen komplett von den Arbeitgebern übernehmen lassen.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Die Nachricht formuliert: 'Nach dem neuen Gesetz sollen die Kosten zwischen Bundesagentur für Arbeit und Betrieb geteilt werden.' Nicht die Arbeitgeber allein tragen die Kosten, sondern sie werden geteilt. 'komplett' macht die Aussage falsch.",
+              "audioTimestamp": 48
+            },
+            {
+              "id": "B2_m01_L1_q3",
+              "type": "true_false",
+              "questionText": "Das Bundesamt empfiehlt Unternehmen, ihren Beschäftigten pro Jahr mindestens fünf Tage bezahlte Weiterbildung zu gewähren.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Die Sprecherin nennt die konkrete Empfehlung: 'Das Bundesamt rät Arbeitgebern, jährlich mindestens fünf bezahlte Weiterbildungstage pro Mitarbeiter anzubieten.' Die Zahl und das Adjektiv 'bezahlt' werden wörtlich genannt.",
+              "audioTimestamp": 85
+            },
+            {
+              "id": "B2_m01_L1_q4",
+              "type": "true_false",
+              "questionText": "Die Deutsche Bahn hat einen Tarifabschluss mit den Gewerkschaften erzielt.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Im Audio heißt es: 'Nach sieben Verhandlungsrunden bleiben Bahn und Gewerkschaft weiterhin uneinig; ein Abschluss ist bislang nicht in Sicht.' 'nicht in Sicht' bedeutet, dass kein Abschluss erzielt wurde. Die Aussage ist also falsch. B2-Trap: Das Verb 'verhandeln' suggeriert Ergebnis, aber der Hedging-Ausdruck 'weiterhin uneinig' zeigt den fehlenden Abschluss.",
+              "audioTimestamp": 118
+            },
+            {
+              "id": "B2_m01_L1_q5",
+              "type": "true_false",
+              "questionText": "Eine Studie der Hans-Böckler-Stiftung zeigt, dass der Anteil der Homeoffice-Beschäftigten in Deutschland weiter zunimmt.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Der Text stellt klar: 'Laut einer aktuellen Studie stagniert der Anteil der Beschäftigten im Homeoffice seit eineinhalb Jahren bei rund 24 Prozent.' 'stagniert' bedeutet bleibt gleich – weder Zunahme noch Abnahme. Die Behauptung 'nimmt zu' ist also falsch.",
+              "audioTimestamp": 155
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Sie hören ein Interview zum Thema Weiterbildung im Beruf. Entscheiden Sie, ob die folgenden zehn Aussagen richtig oder falsch sind. Sie hören das Interview nur einmal.",
+          "instructionsTranslation": "You will hear an interview about professional further education. Decide whether the following ten statements are correct or incorrect. You will hear the interview only once.",
+          "audioFile": "assets/audio/B2/mock01/listening_part2.mp3",
+          "playCount": 1,
+          "questions": [
+            {
+              "id": "B2_m01_L2_q1",
+              "type": "true_false",
+              "questionText": "Frau Dr. Richter leitet das Institut für Berufsbildungsforschung in Bonn.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Der Moderator stellt sie vor: 'Frau Dr. Sabine Richter, Leiterin des Instituts für Berufsbildungsforschung in Bonn.' Die Aussage wird wörtlich bestätigt.",
+              "audioTimestamp": 15
+            },
+            {
+              "id": "B2_m01_L2_q2",
+              "type": "true_false",
+              "questionText": "Laut Dr. Richter investieren deutsche Unternehmen inzwischen so viel in Weiterbildung wie Unternehmen in Skandinavien.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Dr. Richter sagt: 'Im internationalen Vergleich hinken deutsche Betriebe den skandinavischen Ländern nach wie vor deutlich hinterher.' 'nach wie vor hinterherhinken' bedeutet weiterhin weniger. B2-Falle: 'inzwischen' im Prompt deutet auf Veränderung hin, aber das Audio zeigt das Gegenteil.",
+              "audioTimestamp": 48
+            },
+            {
+              "id": "B2_m01_L2_q3",
+              "type": "true_false",
+              "questionText": "Dr. Richter ist der Meinung, dass kleine Betriebe Weiterbildung grundsätzlich ablehnen.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Die Expertin differenziert: 'Man hört oft, kleine Betriebe würden Weiterbildung ablehnen – das stimmt so pauschal nicht. Viele wollen, können aber ihre Mitarbeiter schlicht nicht freistellen.' Sie widerspricht also der Behauptung. Dies ist eine klassische B2-Hedging-Falle: 'Man hört oft' kennzeichnet eine fremde Meinung, die die Sprecherin gerade NICHT teilt.",
+              "audioTimestamp": 92
+            },
+            {
+              "id": "B2_m01_L2_q4",
+              "type": "true_false",
+              "questionText": "Der Moderator weist darauf hin, dass viele Beschäftigte ihren Weiterbildungsbedarf unterschätzen.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Der Moderator fragt: 'Studien zeigen, dass viele Beschäftigte ihren eigenen Qualifizierungsbedarf eher zu niedrig einschätzen. Wie kommt das?' 'zu niedrig einschätzen' = unterschätzen. Die Aussage ist also korrekt.",
+              "audioTimestamp": 138
+            },
+            {
+              "id": "B2_m01_L2_q5",
+              "type": "true_false",
+              "questionText": "Dr. Richter sieht in der Digitalisierung vor allem Chancen für Weiterbildung.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Die Expertin betont: 'Die Digitalisierung bringt zweifellos Belastungen mit sich, aber überwiegend sehe ich enorme Chancen – vor allem durch orts- und zeitflexible Lernformate.' Trotz Nennen der Belastungen ist ihre Position klar: 'überwiegend sehe ich enorme Chancen'.",
+              "audioTimestamp": 175
+            },
+            {
+              "id": "B2_m01_L2_q6",
+              "type": "true_false",
+              "questionText": "Die Expertin behauptet, dass reine Online-Kurse besser wirken als Präsenzformate.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Dr. Richter plädiert stattdessen für Mischformen: 'Blended Learning, also die Kombination aus Online- und Präsenzphasen, erzielt nachweislich die besten Lerneffekte – reine Online-Formate allein nicht.' Sie sagt also das Gegenteil: Mischung ist am besten, nicht reines Online.",
+              "audioTimestamp": 212
+            },
+            {
+              "id": "B2_m01_L2_q7",
+              "type": "true_false",
+              "questionText": "Dr. Richter empfiehlt Arbeitgebern, die Weiterbildungszeit als Arbeitszeit anzuerkennen.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Die Expertin sagt deutlich: 'Entscheidend ist, dass Weiterbildung als Arbeitszeit gilt und nicht in die Freizeit verlagert wird – sonst brechen gerade Beschäftigte mit Familie schnell ab.' Die Empfehlung ist klar.",
+              "audioTimestamp": 245
+            },
+            {
+              "id": "B2_m01_L2_q8",
+              "type": "true_false",
+              "questionText": "Laut Dr. Richter nehmen Frauen seltener an Weiterbildungen teil als Männer.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "richtig",
+              "explanation": "Dr. Richter räumt ein: 'Leider zeigen unsere Daten, dass Frauen, vor allem in der Familienphase, deutlich seltener an betrieblichen Weiterbildungen teilnehmen als ihre männlichen Kollegen.' Das bestätigt die Aussage.",
+              "audioTimestamp": 275
+            },
+            {
+              "id": "B2_m01_L2_q9",
+              "type": "true_false",
+              "questionText": "Dr. Richter findet, dass die neue staatliche Bildungsprämie sofort abgeschafft werden sollte.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Im Gegenteil: 'Die Bildungsprämie ist ein Schritt in die richtige Richtung, auch wenn sie noch zu niedrig angesetzt ist.' Sie begrüßt die Prämie, fordert nur deren Aufstockung. B2-Trap: Kritik am Umfang bedeutet nicht Ablehnung der Idee.",
+              "audioTimestamp": 305
+            },
+            {
+              "id": "B2_m01_L2_q10",
+              "type": "true_false",
+              "questionText": "Am Ende des Interviews wird auf eine kommende Fachkonferenz in Köln hingewiesen.",
+              "options": ["richtig", "falsch"],
+              "correctAnswer": "falsch",
+              "explanation": "Der Moderator verabschiedet mit: 'Mehr zu diesem Thema finden Sie auf unserer Website.' Eine Konferenz in Köln wird nicht erwähnt. B2-Trap: Die Erwartung einer abschließenden Veranstaltungsankündigung wird nicht erfüllt.",
+              "audioTimestamp": 345
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Sie hören fünf kurze Ansagen oder Nachrichten aus dem beruflichen Alltag. Was ist richtig? Kreuzen Sie an: a, b oder c. Sie hören jeden Text nur einmal.",
+          "instructionsTranslation": "You will hear five short announcements or messages from professional daily life. What is correct? Choose a, b, or c. You will hear each text only once.",
+          "audioFile": "assets/audio/B2/mock01/listening_part3.mp3",
+          "playCount": 1,
+          "questions": [
+            {
+              "id": "B2_m01_L3_q1",
+              "type": "mcq",
+              "questionText": "Warum hat Herr Weber seinen Kollegen angerufen?",
+              "options": [
+                "a) Er möchte das Vorstellungsgespräch auf einen anderen Tag verschieben.",
+                "b) Er bittet darum, Unterlagen zum Vorstellungsgespräch mitzubringen.",
+                "c) Er sagt sein Kommen zum Vorstellungsgespräch endgültig ab."
+              ],
+              "correctAnswer": "b",
+              "explanation": "Herr Weber sagt auf der Mailbox: 'Könntest du bitte die aktualisierte Projektliste und die Zeugniskopien mitbringen? Ohne die kann ich im Gespräch nicht sinnvoll argumentieren.' Er verschiebt also nicht und sagt auch nicht ab, sondern bittet um Unterlagen. Distraktor a) nutzt 'Vorstellungsgespräch' aus dem Audio, verdreht aber den Zweck.",
+              "audioTimestamp": 18
+            },
+            {
+              "id": "B2_m01_L3_q2",
+              "type": "mcq",
+              "questionText": "Was teilt die Personalabteilung den Mitarbeitenden mit?",
+              "options": [
+                "a) Der diesjährige Betriebsausflug wird komplett abgesagt.",
+                "b) Ab sofort gilt eine neue Regelung zur Homeoffice-Abrechnung.",
+                "c) Das interne Weiterbildungsportal wird auf eine neue Plattform umgestellt."
+              ],
+              "correctAnswer": "c",
+              "explanation": "Die Ansage informiert: 'Ab Montag, dem 12. Mai, finden Sie alle internen Schulungen auf unserer neuen Lernplattform Talento. Die bisherige Seite wird abgeschaltet.' Der Umzug der Weiterbildungsplattform ist der Kern. Distraktor a) und b) werden nicht erwähnt.",
+              "audioTimestamp": 58
+            },
+            {
+              "id": "B2_m01_L3_q3",
+              "type": "mcq",
+              "questionText": "Was empfiehlt die Karriereberaterin der Anruferin?",
+              "options": [
+                "a) sofort eine schriftliche Kündigung einzureichen",
+                "b) zunächst ein Gespräch mit der Vorgesetzten zu suchen",
+                "c) sich heimlich bei einer anderen Firma zu bewerben"
+              ],
+              "correctAnswer": "b",
+              "explanation": "Die Beraterin sagt: 'Bevor Sie über eine Kündigung nachdenken, würde ich Ihnen dringend raten, zunächst das offene Gespräch mit Ihrer Vorgesetzten zu suchen.' Sie empfiehlt also explizit das Gespräch. Die Kündigung wird nicht abgelehnt, aber nicht als erster Schritt empfohlen (a falsch). Heimliche Bewerbung wird gar nicht genannt (c falsch).",
+              "audioTimestamp": 108
+            },
+            {
+              "id": "B2_m01_L3_q4",
+              "type": "mcq",
+              "questionText": "Was ist das Hauptanliegen der Voicemail vom Kunden?",
+              "options": [
+                "a) Er möchte einen bereits vereinbarten Liefertermin bestätigen.",
+                "b) Er beschwert sich über fehlerhafte Ware und fordert Ersatz.",
+                "c) Er interessiert sich für ein zusätzliches Produktangebot."
+              ],
+              "correctAnswer": "b",
+              "explanation": "Der Kunde beschwert sich deutlich: 'Drei der gelieferten Geräte weisen erhebliche Mängel auf – ich erwarte bis Ende der Woche eine Ersatzlieferung oder eine vollständige Gutschrift.' Die Mängelrüge und Ersatzforderung sind zentral. Distraktor a) und c) passen nicht zum Inhalt.",
+              "audioTimestamp": 150
+            },
+            {
+              "id": "B2_m01_L3_q5",
+              "type": "mcq",
+              "questionText": "Worüber informiert die Ansage im Tagungshotel?",
+              "options": [
+                "a) Die Fachkonferenz beginnt wegen technischer Probleme 30 Minuten später.",
+                "b) Die Kaffeepause wurde auf den Wintergarten verlegt.",
+                "c) Die Abendveranstaltung fällt wegen Krankheit des Redners aus."
+              ],
+              "correctAnswer": "b",
+              "explanation": "Die Ansage sagt: 'Liebe Teilnehmerinnen und Teilnehmer, die Kaffeepause findet heute ausnahmsweise nicht im Foyer, sondern im Wintergarten im Erdgeschoss statt.' Distraktor a) und c) werden nicht erwähnt – eine Verspätung der Konferenz oder eine Absage des Abendprogramms wird nirgends angekündigt.",
+              "audioTimestamp": 195
+            }
+          ]
+        }
+      ]
+    },
+    "reading": {
+      "totalTimeMinutes": 90,
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Lesen Sie zuerst die fünf Kurztexte (1–5) und dann die zehn Überschriften (a–j). Welche Überschrift passt am besten zu welchem Text? Für jeden Text gibt es genau eine passende Überschrift. Fünf Überschriften bleiben übrig.",
+          "instructionsTranslation": "First read the five short texts (1–5) and then the ten headlines (a–j). Which headline best matches which text? For each text there is exactly one matching headline. Five headlines remain unused.",
+          "texts": [
+            { "id": "B2_m01_R1_head_a", "type": "notice", "content": "a) Flexible Arbeitszeiten steigern die Produktivität – neue Studie aus München" },
+            { "id": "B2_m01_R1_head_b", "type": "notice", "content": "b) Wenn der Chef zum Freund wird: Grenzen im modernen Büro" },
+            { "id": "B2_m01_R1_head_c", "type": "notice", "content": "c) Weiterbildung zahlt sich aus – Gehaltssprünge nach Qualifizierung" },
+            { "id": "B2_m01_R1_head_d", "type": "notice", "content": "d) Bewerben ohne Foto und Namen – Pilotprojekt in Hamburger Behörden" },
+            { "id": "B2_m01_R1_head_e", "type": "notice", "content": "e) Vier-Tage-Woche: erste deutsche Firmen ziehen Bilanz" },
+            { "id": "B2_m01_R1_head_f", "type": "notice", "content": "f) Fachkräftemangel: Handwerksbetriebe setzen auf ausländische Azubis" },
+            { "id": "B2_m01_R1_head_g", "type": "notice", "content": "g) Burnout im Lehrerzimmer: psychische Belastung steigt weiter" },
+            { "id": "B2_m01_R1_head_h", "type": "notice", "content": "h) Startups gegen Konzerne – wo Berufseinsteiger heute lieber anfangen" },
+            { "id": "B2_m01_R1_head_i", "type": "notice", "content": "i) Rückkehr ins Büro – Unternehmen kassieren Homeoffice-Rechte wieder ein" },
+            { "id": "B2_m01_R1_head_j", "type": "notice", "content": "j) Rente mit 63: Anträge erreichen Höchststand" }
+          ],
+          "questions": [
+            {
+              "id": "B2_m01_R1_q1",
+              "type": "matching",
+              "questionText": "Text 1: Mehrere mittelständische Firmen aus dem Raum Köln, die seit 2024 die Vier-Tage-Woche bei vollem Lohnausgleich eingeführt haben, haben nun erste Ergebnisse veröffentlicht. Die Unternehmensleitungen berichten übereinstimmend von einem Rückgang der Krankheitstage um knapp 20 Prozent und einer spürbar höheren Zufriedenheit unter den Beschäftigten. Überraschend zeigt sich, dass die Produktivität nicht gelitten hat, sondern im Schnitt sogar leicht gestiegen ist. Skeptisch bleiben allerdings einige Geschäftsführer, vor allem im Dienstleistungssektor: Dort sei der Kundenkontakt an fünf Tagen pro Woche schwer zu ersetzen. Die Studien werten den Modellversuch dennoch als Erfolg, der zumindest für bestimmte Branchen ein Umdenken rechtfertige.",
+              "matchingSources": [
+                { "id": "B2_m01_R1_head_a", "label": "a" },
+                { "id": "B2_m01_R1_head_b", "label": "b" },
+                { "id": "B2_m01_R1_head_c", "label": "c" },
+                { "id": "B2_m01_R1_head_d", "label": "d" },
+                { "id": "B2_m01_R1_head_e", "label": "e" },
+                { "id": "B2_m01_R1_head_f", "label": "f" },
+                { "id": "B2_m01_R1_head_g", "label": "g" },
+                { "id": "B2_m01_R1_head_h", "label": "h" },
+                { "id": "B2_m01_R1_head_i", "label": "i" },
+                { "id": "B2_m01_R1_head_j", "label": "j" }
+              ],
+              "correctAnswer": "e",
+              "explanation": "Der Text berichtet, wie deutsche Firmen nach der Einführung der Vier-Tage-Woche Bilanz ziehen – Krankheitstage, Produktivität, Skepsis im Dienstleistungssektor. Das entspricht exakt Überschrift e) 'Vier-Tage-Woche: erste deutsche Firmen ziehen Bilanz'. Distraktor a) 'flexible Arbeitszeiten' ist zu unspezifisch; der Text behandelt kein Gleitzeitmodell, sondern ein spezifisches Wochenmodell."
+            },
+            {
+              "id": "B2_m01_R1_q2",
+              "type": "matching",
+              "questionText": "Text 2: Die Stadt Hamburg testet seit diesem Frühjahr ein neues Verfahren im öffentlichen Dienst: Bewerbungsunterlagen werden vor der Sichtung anonymisiert. Name, Foto, Geburtsjahr und auch die Herkunft des Bewerbers werden durch die Personalabteilung entfernt, bevor die Fachabteilung über eine Einladung zum Gespräch entscheidet. Das Projekt läuft zunächst in drei Behörden, darunter das Sozialamt und die Schulverwaltung. Ziel ist es, unbewusste Vorurteile im Auswahlprozess zu reduzieren. Kritiker wenden ein, dass Namen und Fotos in persönlichen Gesprächen ohnehin bekannt würden; Befürworter verweisen auf ähnliche Programme in skandinavischen Städten, die messbare Effekte auf die Vielfalt der Belegschaft gehabt haben.",
+              "matchingSources": [
+                { "id": "B2_m01_R1_head_a", "label": "a" },
+                { "id": "B2_m01_R1_head_b", "label": "b" },
+                { "id": "B2_m01_R1_head_c", "label": "c" },
+                { "id": "B2_m01_R1_head_d", "label": "d" },
+                { "id": "B2_m01_R1_head_e", "label": "e" },
+                { "id": "B2_m01_R1_head_f", "label": "f" },
+                { "id": "B2_m01_R1_head_g", "label": "g" },
+                { "id": "B2_m01_R1_head_h", "label": "h" },
+                { "id": "B2_m01_R1_head_i", "label": "i" },
+                { "id": "B2_m01_R1_head_j", "label": "j" }
+              ],
+              "correctAnswer": "d",
+              "explanation": "Das Hamburger Pilotprojekt zu anonymisierten Bewerbungen ohne Foto und Name entspricht präzise Überschrift d). Distraktor f) (ausländische Azubis im Handwerk) berührt zwar das Thema Vielfalt, aber weder Azubis noch Handwerk werden im Text erwähnt."
+            },
+            {
+              "id": "B2_m01_R1_q3",
+              "type": "matching",
+              "questionText": "Text 3: Eine aktuelle Untersuchung des Instituts für Arbeitsmarktforschung Nürnberg zeigt: Beschäftigte, die im vergangenen Jahr an einer zertifizierten Weiterbildung teilgenommen haben, verdienten zwei Jahre später durchschnittlich acht Prozent mehr als vergleichbare Kolleginnen und Kollegen ohne diese Qualifizierung. Besonders ausgeprägt ist der Effekt in den Branchen IT, Gesundheit und Logistik, wo technische Zertifikate unmittelbar in Aufgabenerweiterungen münden. Der Effekt tritt allerdings nur ein, wenn die Weiterbildung branchenbezogen ist und mit einer anerkannten Prüfung abschließt. Kurse ohne Prüfung oder Zertifikat zeigen in der Studie keinen messbaren Einfluss auf das Gehalt.",
+              "matchingSources": [
+                { "id": "B2_m01_R1_head_a", "label": "a" },
+                { "id": "B2_m01_R1_head_b", "label": "b" },
+                { "id": "B2_m01_R1_head_c", "label": "c" },
+                { "id": "B2_m01_R1_head_d", "label": "d" },
+                { "id": "B2_m01_R1_head_e", "label": "e" },
+                { "id": "B2_m01_R1_head_f", "label": "f" },
+                { "id": "B2_m01_R1_head_g", "label": "g" },
+                { "id": "B2_m01_R1_head_h", "label": "h" },
+                { "id": "B2_m01_R1_head_i", "label": "i" },
+                { "id": "B2_m01_R1_head_j", "label": "j" }
+              ],
+              "correctAnswer": "c",
+              "explanation": "Der Text beschreibt messbare Gehaltssprünge nach zertifizierter Weiterbildung – exakt Überschrift c). Distraktor a) (flexible Arbeitszeiten) passt nicht, da der Text keine Arbeitszeitmodelle diskutiert."
+            },
+            {
+              "id": "B2_m01_R1_q4",
+              "type": "matching",
+              "questionText": "Text 4: Immer mehr Handwerksbetriebe in Süddeutschland entscheiden sich dafür, ihre Lehrlingsausbildung international zu öffnen. Die Handwerkskammer Stuttgart meldet für das laufende Ausbildungsjahr einen Zuwachs von 35 Prozent bei Bewerbern aus dem Ausland – vor allem aus Marokko, Vietnam und der Ukraine. Kleine und mittlere Betriebe reagieren damit auf den zunehmenden Mangel an Nachwuchs: In mehr als jedem zweiten Betrieb blieben im vergangenen Jahr Ausbildungsplätze unbesetzt. Die Kammer fordert zugleich mehr Unterstützung bei Sprachförderung und Anerkennungsverfahren, damit die neuen Azubis auch langfristig im Betrieb bleiben.",
+              "matchingSources": [
+                { "id": "B2_m01_R1_head_a", "label": "a" },
+                { "id": "B2_m01_R1_head_b", "label": "b" },
+                { "id": "B2_m01_R1_head_c", "label": "c" },
+                { "id": "B2_m01_R1_head_d", "label": "d" },
+                { "id": "B2_m01_R1_head_e", "label": "e" },
+                { "id": "B2_m01_R1_head_f", "label": "f" },
+                { "id": "B2_m01_R1_head_g", "label": "g" },
+                { "id": "B2_m01_R1_head_h", "label": "h" },
+                { "id": "B2_m01_R1_head_i", "label": "i" },
+                { "id": "B2_m01_R1_head_j", "label": "j" }
+              ],
+              "correctAnswer": "f",
+              "explanation": "Der Text behandelt konkret Handwerksbetriebe, die ausländische Auszubildende einstellen – deckungsgleich mit Überschrift f). Distraktor h) (Startups vs. Konzerne) passt nicht, weil Startups nicht erwähnt werden und es um Handwerk statt Büroberufe geht."
+            },
+            {
+              "id": "B2_m01_R1_q5",
+              "type": "matching",
+              "questionText": "Text 5: Nachdem die meisten großen Unternehmen in den Jahren seit der Pandemie großzügige Homeoffice-Regelungen eingeführt hatten, ruft eine wachsende Zahl von Konzernen ihre Beschäftigten zurück an den festen Arbeitsplatz. Mehrere DAX-Unternehmen haben zuletzt verkündet, dass Mitarbeitende künftig wieder mindestens drei Tage pro Woche im Büro präsent sein müssen. Die Begründungen reichen von 'schwacher Teamkultur' über 'sinkender Innovationskraft' bis zu 'Kontrollproblemen'. Gewerkschaften kritisieren den Schritt als einseitige Rücknahme erworbener Rechte. In Umfragen äußern zwei Drittel der Betroffenen, sie würden bei strikten Präsenzpflichten über einen Arbeitgeberwechsel nachdenken.",
+              "matchingSources": [
+                { "id": "B2_m01_R1_head_a", "label": "a" },
+                { "id": "B2_m01_R1_head_b", "label": "b" },
+                { "id": "B2_m01_R1_head_c", "label": "c" },
+                { "id": "B2_m01_R1_head_d", "label": "d" },
+                { "id": "B2_m01_R1_head_e", "label": "e" },
+                { "id": "B2_m01_R1_head_f", "label": "f" },
+                { "id": "B2_m01_R1_head_g", "label": "g" },
+                { "id": "B2_m01_R1_head_h", "label": "h" },
+                { "id": "B2_m01_R1_head_i", "label": "i" },
+                { "id": "B2_m01_R1_head_j", "label": "j" }
+              ],
+              "correctAnswer": "i",
+              "explanation": "Der Text beschreibt genau den Widerruf von Homeoffice-Rechten durch DAX-Konzerne – Überschrift i) 'Unternehmen kassieren Homeoffice-Rechte wieder ein' passt exakt. Die verbleibenden Distraktoren a, b, g, h, j beziehen sich auf andere Themenbereiche (Flexzeit, Hierarchie, Burnout, Startups, Rente)."
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Lesen Sie den folgenden Zeitungsartikel. Wählen Sie bei jeder Aufgabe die beste Antwort (a, b oder c) aufgrund der Informationen im Text.",
+          "instructionsTranslation": "Read the following newspaper article. For each task choose the best answer (a, b, or c) based on the information in the text.",
+          "texts": [
+            {
+              "id": "B2_m01_R2_article",
+              "type": "article",
+              "content": "Digital, aber nicht entmenschlicht – was die neue Arbeitswelt vom Büro übrig lässt\n\nFünf Jahre nach dem großen Homeoffice-Schub steht fest, dass sich die Arbeitswelt in deutschen Unternehmen grundlegend verändert hat. Was viele zu Beginn der 2020er Jahre als Übergangslösung betrachteten, ist inzwischen Alltag. Gut ein Viertel aller Beschäftigten arbeitet mindestens einen Tag pro Woche von zu Hause; in Wissensberufen sind es deutlich mehr. Gleichzeitig mehren sich die Stimmen, die vor einem vorschnellen Rückzug aus dem physischen Büro warnen. 'Unternehmen, die das Präsenzbüro ganz aufgeben, handeln oft kurzsichtig', sagt Arbeitssoziologin Dr. Mira Hoffmann vom Wissenschaftszentrum Berlin. 'Vieles, was ein Team zusammenhält, entsteht nicht in der Videokonferenz, sondern in der Kaffeeküche.'\n\nEine von ihr geleitete Studie hat über zwei Jahre hinweg 40 Unternehmen aus verschiedenen Branchen begleitet. Das Ergebnis fällt differenziert aus. Reine Homeoffice-Modelle führen nach zwölf bis achtzehn Monaten häufig zu einer schleichenden Entfremdung zwischen Kollegen. Neu eingestellte Mitarbeitende tun sich schwerer, in die Unternehmenskultur hineinzufinden. Gleichzeitig zeigt sich: Eine vollständige Rückkehr in das klassische Fünf-Tage-Büro ist weder gewünscht noch realistisch. In einer begleitenden Umfrage gaben über 70 Prozent der Beschäftigten an, sie würden bei einer strikten Präsenzpflicht den Arbeitgeber wechseln – bei Fachkräften im IT-Bereich waren es sogar 85 Prozent.\n\nWas funktioniert, sind hybride Modelle mit klaren Strukturen. 'Die Firmen, die bei uns am besten abschneiden, haben zwei oder drei feste Bürotage pro Woche – und nutzen diese Tage bewusst für Teamarbeit, nicht für einsame Konzentrationsphasen am eigenen Schreibtisch', so Hoffmann. Konzeptionsarbeit, kreative Sprints und der Austausch zwischen Abteilungen gehören ins Büro. Einzelne Aufgaben, die lange Phasen ungestörter Aufmerksamkeit erfordern, werden zu Hause besser erledigt. Viele Unternehmen hätten diese Logik allerdings noch nicht verstanden und planten ihre Büroräume wie vor zehn Jahren: als Arbeitsplätze statt als Begegnungsräume.\n\nEin weiteres Ergebnis überrascht: Der oft beschworene Produktivitätsverlust bei Homeoffice ist in der Studie nicht nachweisbar. Wo Beschäftigte ihre Aufgaben klar definiert haben und regelmäßig Rückmeldungen erhalten, arbeiten sie zu Hause genauso gut wie im Büro. Kritisch wird es allerdings bei Führungskräften, die ihre Teams aus der Ferne steuern. Fehlt der informelle Austausch, wachsen Missverständnisse und Unsicherheit bei den Beschäftigten. Hoffmann empfiehlt daher regelmäßige persönliche Gespräche – nicht zwingend im Büro, aber doch in einer Weise, die über Bildschirmkontakt hinausgeht.\n\nBlickt man in die Zukunft, so dürfte sich das Büro in den nächsten Jahren weiter wandeln. Bereits heute experimentieren erste Firmen mit geteilten Arbeitsplätzen, spezialisierten Projekträumen und kleineren, regionalen Büros statt großer Zentralen. Entscheidend wird nach Hoffmanns Einschätzung sein, ob Unternehmen bereit sind, nicht nur Arbeitsorte, sondern auch Führungskulturen neu zu denken. 'Wer nach wie vor auf Kontrolle statt auf Vertrauen setzt, wird es künftig schwer haben, die besten Köpfe zu halten.' Das Büro der Zukunft, das zeichnet sich ab, wird weniger sein – aber das, was es ist, muss umso bewusster gestaltet werden.",
+              "source": "Frankfurter Rundschau, Wirtschaftsbeilage März 2026"
+            }
+          ],
+          "questions": [
+            {
+              "id": "B2_m01_R2_q1",
+              "type": "mcq",
+              "questionText": "Was ist die zentrale These von Dr. Hoffmann im Text?",
+              "relatedTextId": "B2_m01_R2_article",
+              "options": [
+                "a) Unternehmen sollten zur klassischen Fünf-Tage-Bürowoche zurückkehren.",
+                "b) Das Büro bleibt wichtig, aber seine Funktion muss neu definiert werden.",
+                "c) Homeoffice ist grundsätzlich produktiver als Präsenzarbeit."
+              ],
+              "correctAnswer": "b",
+              "explanation": "Hoffmann sagt klar: 'Vieles, was ein Team zusammenhält, entsteht nicht in der Videokonferenz' und plädiert für hybride Modelle mit 'klaren Strukturen'. Sie fordert also keine Rückkehr zur alten Fünf-Tage-Woche (a widerspricht ihr explizit) und stellt Homeoffice nicht als grundsätzlich überlegen dar (c). Ihre These ist die Neudefinition der Bürofunktion – Option b. B2-Trap: Der Text erwähnt alle drei Varianten, aber nur b ist Hoffmanns Position."
+            },
+            {
+              "id": "B2_m01_R2_q2",
+              "type": "mcq",
+              "questionText": "Was sagt die Studie zu neu eingestellten Mitarbeitenden in reinen Homeoffice-Modellen?",
+              "relatedTextId": "B2_m01_R2_article",
+              "options": [
+                "a) Sie sind nach kurzer Zeit genauso integriert wie langjährige Beschäftigte.",
+                "b) Sie werden in den ersten Monaten produktiver als ältere Kollegen.",
+                "c) Sie haben mehr Schwierigkeiten, in die Unternehmenskultur hineinzufinden."
+              ],
+              "correctAnswer": "c",
+              "explanation": "Der Text stellt fest: 'Neu eingestellte Mitarbeitende tun sich schwerer, in die Unternehmenskultur hineinzufinden.' Das ist genau Option c. Option a widerspricht dem Text, Option b wird nicht behauptet – Produktivität wird separat behandelt und nicht als Vorteil junger Mitarbeiter dargestellt."
+            },
+            {
+              "id": "B2_m01_R2_q3",
+              "type": "mcq",
+              "questionText": "Wie würden laut Umfrage IT-Fachkräfte auf eine strikte Rückkehr ins Büro reagieren?",
+              "relatedTextId": "B2_m01_R2_article",
+              "options": [
+                "a) Die Mehrheit würde widerwillig zustimmen, aber bleiben.",
+                "b) Eine große Mehrheit würde den Arbeitgeber wechseln.",
+                "c) Sie würden eine Gehaltserhöhung als Ausgleich fordern."
+              ],
+              "correctAnswer": "b",
+              "explanation": "Der Text sagt: 'Bei Fachkräften im IT-Bereich waren es sogar 85 Prozent', die bei Präsenzpflicht wechseln würden. 85 % ist eine klare Mehrheit – Option b. Gehaltserhöhung (c) wird nicht erwähnt; widerwilliges Bleiben (a) widerspricht der 85-Prozent-Zahl."
+            },
+            {
+              "id": "B2_m01_R2_q4",
+              "type": "mcq",
+              "questionText": "Welche Nutzung der Bürotage empfiehlt Dr. Hoffmann?",
+              "relatedTextId": "B2_m01_R2_article",
+              "options": [
+                "a) Bürotage für individuelle Konzentrationsarbeit reservieren, die zu Hause schwer fällt.",
+                "b) Bürotage gezielt für Team- und Austauschaufgaben nutzen, nicht für Einzelarbeit.",
+                "c) Bürotage abwechselnd zwischen den Abteilungen rotieren, um Kosten zu sparen."
+              ],
+              "correctAnswer": "b",
+              "explanation": "Hoffmann sagt: 'Teams nutzen diese Tage bewusst für Teamarbeit, nicht für einsame Konzentrationsphasen.' Das entspricht Option b. Option a kehrt die Empfehlung um (einsames Konzentrieren sei gerade nicht der Zweck des Bürotags). Kostenrotation (c) wird nicht genannt. B2-Trap: Option a enthält alle richtigen Stichwörter (Bürotag, Konzentrationsarbeit, Zuhause), kehrt aber die Logik um."
+            },
+            {
+              "id": "B2_m01_R2_q5",
+              "type": "mcq",
+              "questionText": "Worin sieht Hoffmann die größte Herausforderung für die Zukunft?",
+              "relatedTextId": "B2_m01_R2_article",
+              "options": [
+                "a) der Wandel von Kontroll- hin zu Vertrauenskulturen in der Führung",
+                "b) die flächendeckende technische Ausstattung aller Beschäftigten",
+                "c) die rechtliche Absicherung des Homeoffice-Anspruchs"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Hoffmann betont: 'Wer nach wie vor auf Kontrolle statt auf Vertrauen setzt, wird es künftig schwer haben, die besten Köpfe zu halten.' Sie fordert, 'nicht nur Arbeitsorte, sondern auch Führungskulturen neu zu denken'. Option a fasst das präzise zusammen. Technik (b) und Rechtsanspruch (c) werden nicht thematisiert."
+            }
+          ]
+        },
+        {
+          "partNumber": 3,
+          "instructions": "Lesen Sie die zehn Situationen (1–10) und die zwölf Anzeigen (a–l). Welche Anzeige passt zu welcher Situation? Für jede Situation gibt es höchstens eine passende Anzeige. Zwei Anzeigen bleiben übrig. Wenn keine Anzeige passt, schreiben Sie 'x'.",
+          "instructionsTranslation": "Read the ten situations (1–10) and the twelve advertisements (a–l). Which advertisement matches which situation? For each situation there is at most one matching advertisement. Two advertisements remain unused. If no advertisement fits, write 'x'.",
+          "texts": [
+            { "id": "B2_m01_R3_ad_a", "type": "ad", "content": "a) KarriereKompass Berlin – Individuelle Laufbahnberatung für Fach- und Führungskräfte. 90-minütige Einzelgespräche, kostenfrei gefördert über den Bildungsgutschein der Agentur für Arbeit. Termine auch abends. www.karrierekompass-berlin.de" },
+            { "id": "B2_m01_R3_ad_b", "type": "ad", "content": "b) Seminar 'Gelingende Teamführung' – zweitägiger Präsenzworkshop für neue Führungskräfte. Schwerpunkte: Feedbackkultur, Delegation, Konfliktgespräche. Nächster Termin: 18.–19. Juni, Leipzig. 690 € inkl. Materialien. info@leadership-akademie.de" },
+            { "id": "B2_m01_R3_ad_c", "type": "ad", "content": "c) Bewerbungsunterlagen-Check – Eine erfahrene HR-Beraterin prüft Lebenslauf und Anschreiben innerhalb von 48 Stunden und liefert schriftliches Feedback. Pauschal 89 €. Ideal vor wichtigen Bewerbungen. kontakt@bewerbungsprofi.de" },
+            { "id": "B2_m01_R3_ad_d", "type": "ad", "content": "d) IHK-Fortbildung zum Geprüften Betriebswirt – berufsbegleitend, 18 Monate, abends und samstags. Abschluss auf Master-Niveau. Start: Oktober. Förderung über Aufstiegs-BAföG möglich. ihk-weiterbildung.de" },
+            { "id": "B2_m01_R3_ad_e", "type": "ad", "content": "e) Online-Kurs 'Englisch für den Beruf B2' – 12 Wochen, flexibel lernen, wöchentliche Live-Sessions mit Muttersprachlern. Zertifikat nach bestandener Prüfung. Monatlich 49 €. www.business-english-online.de" },
+            { "id": "B2_m01_R3_ad_f", "type": "ad", "content": "f) Rechtsberatung Arbeitsrecht – Erstgespräch kostenlos für Mitglieder der Gewerkschaft ver.di. Themen: Kündigungsschutz, Abfindung, Arbeitszeugnis. Online oder vor Ort in unseren Büros in allen Bundesländern. mitglieder.verdi.de" },
+            { "id": "B2_m01_R3_ad_g", "type": "ad", "content": "g) Programmier-Bootcamp 'Full-Stack-Entwicklung' – 14 Wochen Vollzeit, Präsenz Berlin oder remote. Jobgarantie: Bei Nichtvermittlung nach 6 Monaten volle Geldrückgabe. 9.900 €, vollständig über Bildungsgutschein abrechenbar. bootcamp.dev" },
+            { "id": "B2_m01_R3_ad_h", "type": "ad", "content": "h) Coaching für Wiedereinstieg nach Elternzeit – Zehn Gruppensitzungen, jeweils montags 10–12 Uhr. Themen: Selbstbewusstsein, Zeitmanagement, Verhandlungstechniken. Gefördert durch das Familienministerium. 120 € Eigenbeitrag. www.wiedereinstieg-coaching.de" },
+            { "id": "B2_m01_R3_ad_i", "type": "ad", "content": "i) Kongress 'Zukunft Arbeit 2026' – zwei Tage mit Vorträgen, Workshops und Networking. Themen: Digitalisierung, hybride Teams, Fachkräftesicherung. 08.–09. Mai, Köln. Frühbucher bis 15. März: 390 € statt 490 €. zukunft-arbeit-kongress.de" },
+            { "id": "B2_m01_R3_ad_j", "type": "ad", "content": "j) Sprachkurs Deutsch für den Beruf C1 – Vorbereitung auf telc Deutsch C1 Beruf. 60 Unterrichtseinheiten, dienstags und donnerstags, 19–21 Uhr. Volkshochschule München, 240 €. Einstiegstest erforderlich. www.vhs-muenchen.de" },
+            { "id": "B2_m01_R3_ad_k", "type": "ad", "content": "k) Praktikumsbörse für Studierende – Über 800 aktuelle Angebote aus Industrie, Medien und öffentlichem Dienst. Kostenlose Registrierung, Filter nach Fachrichtung und Ort. Persönliche Beratung jeden Mittwoch in der Jobcenter-Außenstelle. praktikum-finder.de" },
+            { "id": "B2_m01_R3_ad_l", "type": "ad", "content": "l) Fernstudium 'Bachelor Wirtschaftspsychologie' – Akkreditiert, berufsbegleitend in 7 Semestern. Keine Anwesenheitspflicht. Betreuung durch Online-Tutorien. 14.900 € gesamt, monatliche Raten möglich. www.fernhochschule-nord.de" }
+          ],
+          "questions": [
+            {
+              "id": "B2_m01_R3_q1",
+              "type": "matching",
+              "questionText": "1. Lena hat vor zwei Monaten eine Führungsposition in einem mittelständischen Unternehmen übernommen. Sie fühlt sich bei Konfliktgesprächen mit dem Team unsicher und sucht eine kompakte Weiterbildung im Präsenzformat.",
+              "matchingSources": [
+                { "id": "B2_m01_R3_ad_a", "label": "a" }, { "id": "B2_m01_R3_ad_b", "label": "b" },
+                { "id": "B2_m01_R3_ad_c", "label": "c" }, { "id": "B2_m01_R3_ad_d", "label": "d" },
+                { "id": "B2_m01_R3_ad_e", "label": "e" }, { "id": "B2_m01_R3_ad_f", "label": "f" },
+                { "id": "B2_m01_R3_ad_g", "label": "g" }, { "id": "B2_m01_R3_ad_h", "label": "h" },
+                { "id": "B2_m01_R3_ad_i", "label": "i" }, { "id": "B2_m01_R3_ad_j", "label": "j" },
+                { "id": "B2_m01_R3_ad_k", "label": "k" }, { "id": "B2_m01_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "b",
+              "explanation": "Anzeige b) 'Gelingende Teamführung' bietet genau die Themen, die Lena braucht (Feedbackkultur, Konfliktgespräche), im geforderten Präsenzformat und als zweitägiger Kompaktworkshop. Distraktor d) (Betriebswirt-Fortbildung) ist viel zu lang (18 Monate) und nicht auf Führung fokussiert."
+            },
+            {
+              "id": "B2_m01_R3_q2",
+              "type": "matching",
+              "questionText": "2. Herr Öztürk möchte nach zehn Jahren als Sachbearbeiter einen Karrieresprung machen und denkt an eine anerkannte Weiterbildung mit staatlicher Förderung, die er neben seinem Vollzeitjob absolvieren kann.",
+              "matchingSources": [
+                { "id": "B2_m01_R3_ad_a", "label": "a" }, { "id": "B2_m01_R3_ad_b", "label": "b" },
+                { "id": "B2_m01_R3_ad_c", "label": "c" }, { "id": "B2_m01_R3_ad_d", "label": "d" },
+                { "id": "B2_m01_R3_ad_e", "label": "e" }, { "id": "B2_m01_R3_ad_f", "label": "f" },
+                { "id": "B2_m01_R3_ad_g", "label": "g" }, { "id": "B2_m01_R3_ad_h", "label": "h" },
+                { "id": "B2_m01_R3_ad_i", "label": "i" }, { "id": "B2_m01_R3_ad_j", "label": "j" },
+                { "id": "B2_m01_R3_ad_k", "label": "k" }, { "id": "B2_m01_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "d",
+              "explanation": "Anzeige d) IHK-Fortbildung zum Geprüften Betriebswirt ist genau für berufsbegleitende Aufstiegsqualifizierung konzipiert, abends/samstags, mit Aufstiegs-BAföG-Förderung. Das passt zu Herrn Öztürks Wunsch nach Karrieresprung neben dem Vollzeitjob."
+            },
+            {
+              "id": "B2_m01_R3_q3",
+              "type": "matching",
+              "questionText": "3. Sarah hat nach der zweiten Elternzeit beschlossen, wieder Vollzeit zu arbeiten, fühlt sich aber nach drei Jahren Pause unsicher und sucht eine gezielte Unterstützung in einer Gruppe mit ähnlich betroffenen Frauen.",
+              "matchingSources": [
+                { "id": "B2_m01_R3_ad_a", "label": "a" }, { "id": "B2_m01_R3_ad_b", "label": "b" },
+                { "id": "B2_m01_R3_ad_c", "label": "c" }, { "id": "B2_m01_R3_ad_d", "label": "d" },
+                { "id": "B2_m01_R3_ad_e", "label": "e" }, { "id": "B2_m01_R3_ad_f", "label": "f" },
+                { "id": "B2_m01_R3_ad_g", "label": "g" }, { "id": "B2_m01_R3_ad_h", "label": "h" },
+                { "id": "B2_m01_R3_ad_i", "label": "i" }, { "id": "B2_m01_R3_ad_j", "label": "j" },
+                { "id": "B2_m01_R3_ad_k", "label": "k" }, { "id": "B2_m01_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "h",
+              "explanation": "Anzeige h) 'Coaching für Wiedereinstieg nach Elternzeit' ist genau auf Sarahs Situation zugeschnitten – Gruppenformat, Wiedereinstieg, Selbstbewusstsein und Verhandlungstechniken. Andere Anzeigen betreffen nicht speziell den Wiedereinstieg nach Elternzeit."
+            },
+            {
+              "id": "B2_m01_R3_q4",
+              "type": "matching",
+              "questionText": "4. Tobias ist Quereinsteiger und möchte innerhalb weniger Monate Programmierkenntnisse erwerben, um in die IT-Branche zu wechseln. Er benötigt möglichst hohe Erfolgsgarantien, da er dafür seine jetzige Stelle kündigen müsste.",
+              "matchingSources": [
+                { "id": "B2_m01_R3_ad_a", "label": "a" }, { "id": "B2_m01_R3_ad_b", "label": "b" },
+                { "id": "B2_m01_R3_ad_c", "label": "c" }, { "id": "B2_m01_R3_ad_d", "label": "d" },
+                { "id": "B2_m01_R3_ad_e", "label": "e" }, { "id": "B2_m01_R3_ad_f", "label": "f" },
+                { "id": "B2_m01_R3_ad_g", "label": "g" }, { "id": "B2_m01_R3_ad_h", "label": "h" },
+                { "id": "B2_m01_R3_ad_i", "label": "i" }, { "id": "B2_m01_R3_ad_j", "label": "j" },
+                { "id": "B2_m01_R3_ad_k", "label": "k" }, { "id": "B2_m01_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "g",
+              "explanation": "Anzeige g) Bootcamp 'Full-Stack-Entwicklung' bietet exakt das: 14 Wochen intensive Programmierausbildung und eine Jobgarantie (Geld zurück bei Nichtvermittlung). Das deckt Tobias' Sicherheitsbedürfnis beim Quereinstieg."
+            },
+            {
+              "id": "B2_m01_R3_q5",
+              "type": "matching",
+              "questionText": "5. Frau Sánchez hat eine Kündigung erhalten und möchte wissen, welche Ansprüche auf eine Abfindung sie hat. Als Gewerkschaftsmitglied sucht sie eine schnelle Erstberatung.",
+              "matchingSources": [
+                { "id": "B2_m01_R3_ad_a", "label": "a" }, { "id": "B2_m01_R3_ad_b", "label": "b" },
+                { "id": "B2_m01_R3_ad_c", "label": "c" }, { "id": "B2_m01_R3_ad_d", "label": "d" },
+                { "id": "B2_m01_R3_ad_e", "label": "e" }, { "id": "B2_m01_R3_ad_f", "label": "f" },
+                { "id": "B2_m01_R3_ad_g", "label": "g" }, { "id": "B2_m01_R3_ad_h", "label": "h" },
+                { "id": "B2_m01_R3_ad_i", "label": "i" }, { "id": "B2_m01_R3_ad_j", "label": "j" },
+                { "id": "B2_m01_R3_ad_k", "label": "k" }, { "id": "B2_m01_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "f",
+              "explanation": "Anzeige f) Rechtsberatung Arbeitsrecht bietet Erstgespräche speziell zum Thema Kündigungsschutz und Abfindung – kostenlos für Gewerkschaftsmitglieder. Passt exakt zu Frau Sánchez' Situation."
+            },
+            {
+              "id": "B2_m01_R3_q6",
+              "type": "matching",
+              "questionText": "6. Paul ist seit kurzem arbeitslos und möchte mit professioneller Hilfe eine neue Perspektive entwickeln. Ihm ist wichtig, dass die Beratung von der Arbeitsagentur finanziert wird.",
+              "matchingSources": [
+                { "id": "B2_m01_R3_ad_a", "label": "a" }, { "id": "B2_m01_R3_ad_b", "label": "b" },
+                { "id": "B2_m01_R3_ad_c", "label": "c" }, { "id": "B2_m01_R3_ad_d", "label": "d" },
+                { "id": "B2_m01_R3_ad_e", "label": "e" }, { "id": "B2_m01_R3_ad_f", "label": "f" },
+                { "id": "B2_m01_R3_ad_g", "label": "g" }, { "id": "B2_m01_R3_ad_h", "label": "h" },
+                { "id": "B2_m01_R3_ad_i", "label": "i" }, { "id": "B2_m01_R3_ad_j", "label": "j" },
+                { "id": "B2_m01_R3_ad_k", "label": "k" }, { "id": "B2_m01_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "a",
+              "explanation": "Anzeige a) KarriereKompass Berlin bietet genau diese individuelle Laufbahnberatung, die über den Bildungsgutschein der Agentur für Arbeit finanziert wird. Die Abendtermine passen ebenfalls zu Pauls Situation."
+            },
+            {
+              "id": "B2_m01_R3_q7",
+              "type": "matching",
+              "questionText": "7. Herr Bauer bewirbt sich nächste Woche auf eine Stelle als Projektleiter. Er ist unsicher, ob sein Anschreiben überzeugt, und möchte noch vor dem Abschicken eine professionelle Rückmeldung erhalten.",
+              "matchingSources": [
+                { "id": "B2_m01_R3_ad_a", "label": "a" }, { "id": "B2_m01_R3_ad_b", "label": "b" },
+                { "id": "B2_m01_R3_ad_c", "label": "c" }, { "id": "B2_m01_R3_ad_d", "label": "d" },
+                { "id": "B2_m01_R3_ad_e", "label": "e" }, { "id": "B2_m01_R3_ad_f", "label": "f" },
+                { "id": "B2_m01_R3_ad_g", "label": "g" }, { "id": "B2_m01_R3_ad_h", "label": "h" },
+                { "id": "B2_m01_R3_ad_i", "label": "i" }, { "id": "B2_m01_R3_ad_j", "label": "j" },
+                { "id": "B2_m01_R3_ad_k", "label": "k" }, { "id": "B2_m01_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "c",
+              "explanation": "Anzeige c) 'Bewerbungsunterlagen-Check' liefert innerhalb von 48 Stunden schriftliches Feedback zu Lebenslauf und Anschreiben – genau die schnelle professionelle Rückmeldung, die Herr Bauer vor dem Abschicken braucht."
+            },
+            {
+              "id": "B2_m01_R3_q8",
+              "type": "matching",
+              "questionText": "8. Frau Weber arbeitet in einem internationalen Unternehmen und braucht für eine bevorstehende Versetzung nach London gute Wirtschaftsenglisch-Kenntnisse, die sie flexibel neben dem Job erwerben kann.",
+              "matchingSources": [
+                { "id": "B2_m01_R3_ad_a", "label": "a" }, { "id": "B2_m01_R3_ad_b", "label": "b" },
+                { "id": "B2_m01_R3_ad_c", "label": "c" }, { "id": "B2_m01_R3_ad_d", "label": "d" },
+                { "id": "B2_m01_R3_ad_e", "label": "e" }, { "id": "B2_m01_R3_ad_f", "label": "f" },
+                { "id": "B2_m01_R3_ad_g", "label": "g" }, { "id": "B2_m01_R3_ad_h", "label": "h" },
+                { "id": "B2_m01_R3_ad_i", "label": "i" }, { "id": "B2_m01_R3_ad_j", "label": "j" },
+                { "id": "B2_m01_R3_ad_k", "label": "k" }, { "id": "B2_m01_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "e",
+              "explanation": "Anzeige e) 'Englisch für den Beruf B2' ist ein flexibler 12-Wochen-Online-Kurs mit wöchentlichen Live-Sessions – ideal neben dem Job. Das passt zu Frau Webers Bedarf an Business-Englisch vor der Versetzung."
+            },
+            {
+              "id": "B2_m01_R3_q9",
+              "type": "matching",
+              "questionText": "9. Marco studiert im vierten Semester Maschinenbau und sucht für die vorlesungsfreie Zeit ein Pflichtpraktikum in einem Industrieunternehmen in Nord- oder Westdeutschland.",
+              "matchingSources": [
+                { "id": "B2_m01_R3_ad_a", "label": "a" }, { "id": "B2_m01_R3_ad_b", "label": "b" },
+                { "id": "B2_m01_R3_ad_c", "label": "c" }, { "id": "B2_m01_R3_ad_d", "label": "d" },
+                { "id": "B2_m01_R3_ad_e", "label": "e" }, { "id": "B2_m01_R3_ad_f", "label": "f" },
+                { "id": "B2_m01_R3_ad_g", "label": "g" }, { "id": "B2_m01_R3_ad_h", "label": "h" },
+                { "id": "B2_m01_R3_ad_i", "label": "i" }, { "id": "B2_m01_R3_ad_j", "label": "j" },
+                { "id": "B2_m01_R3_ad_k", "label": "k" }, { "id": "B2_m01_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "k",
+              "explanation": "Anzeige k) Praktikumsbörse für Studierende listet über 800 aktuelle Praktikumsangebote aus Industrie und weiteren Bereichen, filterbar nach Fachrichtung und Ort – genau, was Marco für sein Pflichtpraktikum benötigt."
+            },
+            {
+              "id": "B2_m01_R3_q10",
+              "type": "matching",
+              "questionText": "10. Herr Nowak bereitet sich auf ein Assessment Center bei einer Unternehmensberatung vor und sucht eine mehrtägige Simulation mit realistischen Übungen und individuellem Feedback zu seinem Auftreten.",
+              "matchingSources": [
+                { "id": "B2_m01_R3_ad_a", "label": "a" }, { "id": "B2_m01_R3_ad_b", "label": "b" },
+                { "id": "B2_m01_R3_ad_c", "label": "c" }, { "id": "B2_m01_R3_ad_d", "label": "d" },
+                { "id": "B2_m01_R3_ad_e", "label": "e" }, { "id": "B2_m01_R3_ad_f", "label": "f" },
+                { "id": "B2_m01_R3_ad_g", "label": "g" }, { "id": "B2_m01_R3_ad_h", "label": "h" },
+                { "id": "B2_m01_R3_ad_i", "label": "i" }, { "id": "B2_m01_R3_ad_j", "label": "j" },
+                { "id": "B2_m01_R3_ad_k", "label": "k" }, { "id": "B2_m01_R3_ad_l", "label": "l" }
+              ],
+              "correctAnswer": "x",
+              "explanation": "Keine der zwölf Anzeigen bietet eine mehrtägige Assessment-Center-Simulation. Anzeige c) deckt nur schriftliches Feedback auf Unterlagen ab, nicht das Auftreten. Anzeige i) ist ein Fachkongress zur Zukunft der Arbeit, keine AC-Simulation. Anzeige a) ist eine 90-minütige Einzelberatung – kein mehrtägiges Assessment. Die Situation erfordert also die Antwort 'x' (kein passendes Angebot). Anzeigen j) (VHS-Deutschkurs C1) und l) (Fernstudium Wirtschaftspsychologie) bleiben als Distraktoren in der Anzeigenliste übrig, passen zu keiner der zehn Situationen."
+            }
+          ]
+        }
+      ]
+    },
+    "sprachbausteine": {
+      "parts": [
+        {
+          "partNumber": 1,
+          "instructions": "Lesen Sie den folgenden Text und entscheiden Sie, welches Wort (a, b, c oder d) in die Lücke passt. Es gibt jeweils nur eine richtige Lösung.",
+          "text": "Sehr geehrte Kolleginnen und Kollegen,\n\nhiermit möchte ich Sie über die geplanten Neuerungen bei unserem betrieblichen Weiterbildungsangebot informieren. Nach einer ausführlichen Bedarfsanalyse, die von der Personalabteilung __(1)__ worden ist, stehen nun die Eckpunkte für das kommende Jahr fest. Zum ersten Mal werden wir ein vollständig neues Qualifizierungsprogramm anbieten, __(2)__ sich sowohl an Führungskräfte als auch an Fachkräfte richtet.\n\nBesonderer Wert wird darauf gelegt, dass jeder Beschäftigte mindestens fünf bezahlte Weiterbildungstage pro Jahr __(3)__ kann. Sollte die Geschäftsleitung in Einzelfällen einem Antrag nicht zustimmen können, __(4)__ sie dies schriftlich begründen. __(5)__ der erheblichen Investitionen erwarten wir eine deutliche Steigerung der Qualifikation in allen Bereichen.\n\nDas Programm umfasst klassische Präsenzseminare, __(6)__ auch digitale Lernformate, die individuell genutzt werden können. Teilnehmende, die eine externe Zertifizierung __(7)__, erhalten die vollen Gebühren erstattet. __(8)__ ist die enge Abstimmung mit der jeweiligen Führungskraft, damit die Weiterbildung zu den Aufgaben im Team passt.\n\nDie von uns __(9)__ Maßnahme ist Teil einer umfassenderen Personalstrategie. Die Geschäftsleitung ist überzeugt, __(10)__ investierte Euro in Weiterbildung mehrfach zurückfließt – durch höhere Motivation, geringere Fluktuation und eine bessere Position am Markt.\n\nMit freundlichen Grüßen\nDr. Martina Klose, Leiterin Personalentwicklung",
+          "questions": [
+            {
+              "blankNumber": 1,
+              "type": "mcq",
+              "options": ["a) durchgeführt", "b) durchführte", "c) durchzuführen", "d) durchführend"],
+              "correctAnswer": "a",
+              "explanation": "Zustandspassiv/Passiv-Perfekt: 'die von der Personalabteilung durchgeführt worden ist' — Vorgangspassiv im Perfekt (wurde + Partizip II, hier mit 'ist worden' als Passiv-Perfekt). Das Partizip II 'durchgeführt' ist zwingend. Distraktoren: b) 'durchführte' wäre Aktiv-Präteritum (falsche Diathese), c) zu+Infinitiv passt grammatisch nicht zu 'ist worden', d) Partizip I signalisiert laufende Handlung und kombiniert nicht mit 'worden'. B2-Grammatik: Passiv-Perfekt."
+            },
+            {
+              "blankNumber": 2,
+              "type": "mcq",
+              "options": ["a) der", "b) das", "c) die", "d) was"],
+              "correctAnswer": "b",
+              "explanation": "Relativsatz: 'ein Qualifizierungsprogramm, das sich ... richtet.' Das Relativpronomen bezieht sich auf 'Programm' (Neutrum) im Nominativ: 'das'. Distraktoren: a) 'der' = Maskulin, c) 'die' = Feminin/Plural, d) 'was' nur nach unbestimmten Pronomen wie 'etwas, alles, nichts' oder nach neutralen Nominalisierungen wie 'das Beste'. Hier verlangt 'Programm' das Relativpronomen 'das'."
+            },
+            {
+              "blankNumber": 3,
+              "type": "mcq",
+              "options": ["a) in Anspruch nehmen", "b) in Anspruch genommen", "c) beanspruchen lassen", "d) sich beanspruchen"],
+              "correctAnswer": "a",
+              "explanation": "Funktionsverbgefüge (typisches B2-Konstrukt): 'etwas in Anspruch nehmen' = nutzen, beanspruchen. Nach Modalverb 'kann' folgt Infinitiv: 'in Anspruch nehmen'. Distraktoren: b) Partizip passt nicht zu 'kann' (Modalverb + Infinitiv, nicht + Partizip II ohne Hilfsverb), c) 'beanspruchen lassen' wäre reflexiv-kausativ und sinnverändernd, d) 'sich beanspruchen' ist kein idiomatisches Verb im Deutschen."
+            },
+            {
+              "blankNumber": 4,
+              "type": "mcq",
+              "options": ["a) muss", "b) soll", "c) müsste", "d) hätte"],
+              "correctAnswer": "a",
+              "explanation": "Inversion nach vorangestelltem Konditionalsatz ohne 'wenn': 'Sollte ... nicht zustimmen können, muss sie dies ... begründen.' Es geht um eine klare Verpflichtung in der formellen Geschäftskommunikation → Indikativ 'muss'. Distraktoren: b) 'soll' wäre schwächer (moralischer Auftrag, nicht verpflichtend), c) 'müsste' wäre Konjunktiv II und würde irrealen Ton geben, d) 'hätte' ist formal-grammatisch falsch (Hilfsverb, aber ohne Partizip II sinnlos)."
+            },
+            {
+              "blankNumber": 5,
+              "type": "mcq",
+              "options": ["a) Wegen", "b) Trotz", "c) Angesichts", "d) Außer"],
+              "correctAnswer": "c",
+              "explanation": "Genitiv-Präposition mit passender Semantik: 'Angesichts der erheblichen Investitionen' = 'in Anbetracht, im Hinblick auf' – betont, dass die Investitionen die Erwartung rechtfertigen. Distraktoren: a) 'Wegen' wäre semantisch möglich, aber im formellen B2-Register ist 'angesichts' präziser und gehobener, b) 'Trotz' widerspricht der Logik (Erwartung trotz Investitionen ergibt keinen Sinn), d) 'Außer' heißt 'mit Ausnahme von' – unsinnig. B2-Präposition mit Genitiv: 'angesichts' ist die erwartete Form."
+            },
+            {
+              "blankNumber": 6,
+              "type": "mcq",
+              "options": ["a) sondern", "b) aber auch", "c) dennoch", "d) zudem"],
+              "correctAnswer": "b",
+              "explanation": "Additiver Konnektor: 'Das Programm umfasst ... Präsenzseminare, aber auch digitale Lernformate.' Die Struktur fordert eine Hinzufügung mit leichtem Kontrast. Distraktoren: a) 'sondern' verlangt vorher Negation (hier fehlt 'nicht nur'), c) 'dennoch' drückt Gegensatz aus (passt inhaltlich nicht – die beiden Formate schließen sich nicht aus), d) 'zudem' wäre ein reines Additiv, aber würde wie ein eigener Satz wirken (Verb an Position 2). 'aber auch' passt hier im Aufzählungskontext."
+            },
+            {
+              "blankNumber": 7,
+              "type": "mcq",
+              "options": ["a) anstreben", "b) anzustreben", "c) anstrebten", "d) angestrebt"],
+              "correctAnswer": "a",
+              "explanation": "Relativsatz mit Präsens-Indikativ: 'Teilnehmende, die eine externe Zertifizierung anstreben, erhalten ...' Das Verb kongruiert mit Subjekt 'Teilnehmende' (Plural Präsens). Distraktoren: b) Infinitiv mit zu passt nicht in den Relativsatz, c) Präteritum bricht die Zeitebene (der gesamte Text ist im Präsens), d) Partizip II allein ohne Hilfsverb ist syntaktisch unmöglich im finiten Satz."
+            },
+            {
+              "blankNumber": 8,
+              "type": "mcq",
+              "options": ["a) Entscheidend", "b) Entscheidung", "c) Entscheidende", "d) Entschieden"],
+              "correctAnswer": "a",
+              "explanation": "Prädikatives Adjektiv: 'Entscheidend ist die enge Abstimmung ...' Die endungslose Form signalisiert, dass das Adjektiv als Prädikativum nach 'sein' steht (vgl. 'Wichtig ist ...'). Distraktoren: b) 'Entscheidung' ist Substantiv und würde 'Eine Entscheidung ist ...' verlangen, c) 'Entscheidende' mit Endung wäre substantivierte Form und passt nur mit Artikel ('Das Entscheidende ist ...'), d) 'Entschieden' wäre Partizip II (z.B. 'entschieden haben wir ...'), passt nicht als Satzanfang mit 'ist'. B2-Grammatik: Nominalisierung vs. Adjektiv."
+            },
+            {
+              "blankNumber": 9,
+              "type": "mcq",
+              "options": ["a) getroffene", "b) treffende", "c) zu treffende", "d) getroffen"],
+              "correctAnswer": "a",
+              "explanation": "Partizipialattribut als B2-Kernthema: 'Die von uns getroffene Maßnahme' = 'Die Maßnahme, die von uns getroffen wurde'. Partizip II 'getroffen' + Adjektivendung -e (Nom. Sg. Fem. schwache Deklination nach 'Die'). Distraktoren: b) 'treffende' (Partizip I) würde aktive, gleichzeitige Handlung anzeigen (passt nicht: die Maßnahme trifft nicht sich selbst), c) 'zu treffende' wäre Gerundivum (zukünftig/notwendig zu tun), d) 'getroffen' ohne Endung – unflektiert – bricht die Deklination im Attribut. Passivisches Partizipialattribut: getroffene."
+            },
+            {
+              "blankNumber": 10,
+              "type": "mcq",
+              "options": ["a) dass jeder", "b) dass jedem", "c) dass alle", "d) dass man"],
+              "correctAnswer": "a",
+              "explanation": "Subjekt des dass-Satzes im Nominativ: 'dass jeder investierte Euro ... zurückfließt'. 'jeder' (Nom. Sg. Mask.) als Subjekt zu 'zurückfließt' (Singular). Distraktoren: b) 'jedem' wäre Dativ, aber hier braucht es Subjekt, c) 'dass alle ... zurückfließt' würde Subjekt-Verb-Inkongruenz verursachen (Plural Subjekt + Singular Verb), d) 'man' ist zu unspezifisch und kollidiert mit 'investierte Euro' als gemeinter Referenz – grammatisch möglich, aber inhaltlich und stilistisch falsch, da das Substantiv 'Euro' das Subjekt sein muss."
+            }
+          ]
+        },
+        {
+          "partNumber": 2,
+          "instructions": "Lesen Sie den folgenden Text. Welches Wort aus der Liste a–o passt in die Lücken? Jedes Wort passt nur einmal. Fünf Wörter bleiben übrig.",
+          "text": "Wer sich heute um eine anspruchsvolle Stelle bewirbt, steht unter hohem Erwartungsdruck. Die Zahl der Bewerberinnen und Bewerber ist in vielen Branchen erheblich, und Personalabteilungen sichten täglich __(11)__ Lebensläufe. Ein sorgfältig gestaltetes Anschreiben kann in __(12)__ Fällen den Unterschied zwischen Einladung und Absage ausmachen.\n\nAllerdings reicht es nicht aus, lediglich frühere Aufgaben zu beschreiben. Moderne Bewerbungsberatungen empfehlen __(13)__, die eigene Motivation klar zu benennen und konkrete Bezüge zur ausgeschriebenen Stelle herzustellen. __(14)__ gelingt es oft, aus einer Bewerbung eine einprägsame Geschichte zu machen, die Personalverantwortliche auch nach Hunderten anderer Unterlagen noch im Kopf behalten.\n\nEin weiterer wichtiger Punkt __(15)__ die realistische Selbsteinschätzung. Wer Kompetenzen übertreibt, fliegt spätestens im Vorstellungsgespräch __(16)__. Umgekehrt führen unnötige Bescheidenheit und das Herunterspielen eigener Leistungen dazu, dass vorhandenes Potenzial gar nicht erst wahrgenommen wird. Ein ehrlicher, präziser Ton gilt deshalb als goldene __(17)__.\n\n__(18)__ der hohen Belastung im Auswahlprozess setzen viele Unternehmen inzwischen auf strukturierte Interviews und digitale Vorauswahl. Das nimmt Bewerbenden zwar Spielraum, erhöht aber die Vergleichbarkeit der Ergebnisse. Fachleute sehen __(19)__ eine faire Tendenz – sofern die eingesetzten Verfahren transparent bleiben.\n\nWer seine Bewerbung auf diese Weise __(20)__ plant, vergrößert seine Chancen erheblich. Eine Bewerbung ist keine Formalität, sondern die erste berufliche Leistung für den potenziellen neuen Arbeitgeber.",
+          "questions": [
+            {
+              "blankNumber": 11,
+              "type": "word_bank",
+              "options": [
+                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
+                "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
+              ],
+              "correctAnswer": "a",
+              "explanation": "'hunderte Lebensläufe' — indefinite Mengenangabe (Plural ohne Artikel). Distraktor o) 'wenigen' würde das Gegenteil bedeuten und widerspricht dem Kontext ('erheblich', 'täglich'). B2-Vokabular: 'hunderte' als großzügige Mengenangabe, typisch für Nachrichtensprache."
+            },
+            {
+              "blankNumber": 12,
+              "type": "word_bank",
+              "options": [
+                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
+                "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
+              ],
+              "correctAnswer": "b",
+              "explanation": "'in vielen Fällen' — feste Wendung für 'in a lot of cases'. 'vielen' (Dativ Plural, starke Deklination nach 'in'). Distraktoren: o) 'wenigen' kehrt die Aussage um (wäre semantisch zwar möglich, widerspricht aber dem Sinn 'den Unterschied ausmachen'), m) 'jeden' wäre Singular/Akkusativ."
+            },
+            {
+              "blankNumber": 13,
+              "type": "word_bank",
+              "options": [
+                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
+                "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
+              ],
+              "correctAnswer": "c",
+              "explanation": "Feste Kombination: 'raten zu etwas' → hier als Pronominaladverb: 'empfehlen dazu, ... zu benennen' (auf das Folgende verweisend). 'dazu' verweist auf den zu+Infinitiv-Nebensatz. Distraktor i) 'darin' verweist eher auf 'in etwas', hier folgt aber 'zu+Infinitiv'. Pronominaladverb-Kenntnisse gehören zu B2."
+            },
+            {
+              "blankNumber": 14,
+              "type": "word_bank",
+              "options": [
+                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
+                "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
+              ],
+              "correctAnswer": "d",
+              "explanation": "Satzanfang + kausaler Konnektor: 'Dadurch gelingt es oft, ...' = 'Mit diesem Vorgehen gelingt es ...'. Großschreibung signalisiert den Satzanfang. 'Dadurch' verbindet kausal-folgernd mit dem vorherigen Satz (Motivation klar benennen → dadurch eine Geschichte formen)."
+            },
+            {
+              "blankNumber": 15,
+              "type": "word_bank",
+              "options": [
+                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
+                "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
+              ],
+              "correctAnswer": "e",
+              "explanation": "Kopulaverb: 'Ein weiterer wichtiger Punkt ist die realistische Selbsteinschätzung.' 'ist' verbindet Subjekt mit prädikativem Nomen. Distraktor n) 'stellt' würde 'stellt ... dar' verlangen (zu 'ist' strukturell anders)."
+            },
+            {
+              "blankNumber": 16,
+              "type": "word_bank",
+              "options": [
+                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
+                "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
+              ],
+              "correctAnswer": "f",
+              "explanation": "Idiomatische Wendung: 'auffliegen' = entdeckt werden (jmds Lüge fliegt auf). Trennbares Verb: 'fliegt ... auf'. Die Präposition 'auf' ist Teil der trennbaren Verbpartikel. Alternative Lesart mit 'k) bei' wäre syntaktisch möglich ('fliegt bei ...'), aber 'auffliegen' als Idiom für Enttarnung verlangt 'auf'."
+            },
+            {
+              "blankNumber": 17,
+              "type": "word_bank",
+              "options": [
+                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
+                "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
+              ],
+              "correctAnswer": "g",
+              "explanation": "Feste Kollokation: 'goldene Regel' = allgemein anerkannte Grundregel. Substantiv nach Adjektiv 'goldene'. Distraktoren: l) 'entscheidend' wäre Adjektiv und passt nicht nach 'goldene' (doppelte Attribution 'goldene entscheidend' wäre ungrammatisch)."
+            },
+            {
+              "blankNumber": 18,
+              "type": "word_bank",
+              "options": [
+                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
+                "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
+              ],
+              "correctAnswer": "h",
+              "explanation": "Genitiv-Präposition 'Angesichts der hohen Belastung' (Satzanfang, großgeschrieben). Passt zur nachfolgenden Schlussfolgerung ('setzen viele Unternehmen ... auf strukturierte Verfahren'). Distraktor b) 'vielen' ist Pronomen und schon verbraucht. B2-Präposition."
+            },
+            {
+              "blankNumber": 19,
+              "type": "word_bank",
+              "options": [
+                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
+                "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
+              ],
+              "correctAnswer": "i",
+              "explanation": "Pronominaladverb: 'sehen darin eine faire Tendenz' = 'sehen in diesem Vorgehen ...'. 'darin' verweist auf das zuvor beschriebene Verfahren (strukturierte Interviews, digitale Vorauswahl). Das Verb 'sehen in etwas' ist die feste Kollokation."
+            },
+            {
+              "blankNumber": 20,
+              "type": "word_bank",
+              "options": [
+                "a) hunderte", "b) vielen", "c) dazu", "d) Dadurch", "e) ist",
+                "f) auf", "g) Regel", "h) Angesichts", "i) darin", "j) über",
+                "k) bei", "l) entscheidend", "m) jeden", "n) stellt", "o) wenigen"
+              ],
+              "correctAnswer": "l",
+              "explanation": "Adverbiale Funktion: 'entscheidend plant' = in einer entscheidenden Weise. 'entscheidend' als unflektiertes Adverb verstärkt das Verb 'plant' und fasst die zentrale Aussage des Textes zusammen (alle vorher genannten Punkte sind entscheidend für den Erfolg). Distraktoren: j) 'über' wäre Präposition ohne passenden Kontext (kein Objekt), k) 'bei' ebenso, m) 'jeden' wäre Determiner ohne nachfolgendes Substantiv, n) 'stellt' würde Verbdopplung erzeugen (neben 'plant'), o) 'wenigen' kehrt die positive Aussage unsinnig um. Die verbleibenden fünf Distraktoren (j, k, m, n, o) passen zu keiner Lücke im Text."
+            }
+          ]
+        }
+      ]
+    },
+    "writing": {
+      "totalTimeMinutes": 30,
+      "tasks": [
+        {
+          "taskNumber": 1,
+          "type": "letter",
+          "instructions": "Wählen Sie EINE der beiden folgenden Aufgaben (A oder B) und bearbeiten Sie diese. Beachten Sie die Leitpunkte und schreiben Sie mindestens 150 Wörter (Richtwert: 200 Wörter). Kennzeichnen Sie am Anfang Ihres Textes deutlich, welche Aufgabe Sie gewählt haben.",
+          "instructionsTranslation": "Choose ONE of the two tasks (A or B) below and complete it. Address the guiding points and write at least 150 words (target: around 200 words). Clearly mark at the top of your text which task you have chosen.",
+          "prompt": "AUFGABE A (Beschwerdebrief):\n\nSituation: Vor drei Wochen haben Sie an einem viertägigen Weiterbildungsseminar zum Thema 'Projektmanagement im digitalen Zeitalter' bei der Weiterbildungsakademie BusinessPro in Frankfurt teilgenommen. Sie hatten sich viel davon versprochen, waren aber sehr enttäuscht: Der Dozent war mehrfach nicht anwesend, die angekündigten Fallstudien wurden durch allgemeine Vorträge ersetzt, und die versprochenen Lernunterlagen haben Sie bis heute nicht erhalten. Die Kursgebühr von 890 € wurde bereits komplett abgebucht.\n\nSchreiben Sie eine formelle Beschwerde an die Geschäftsleitung (Frau Dr. Andrea Hoffmann) der BusinessPro Weiterbildungsakademie. Gehen Sie auf die folgenden drei Leitpunkte ein:\n\n• Beschreiben Sie die konkreten Mängel während des Seminars.\n• Erläutern Sie, welche Folgen diese Mängel für Ihre beruflichen Ziele haben.\n• Formulieren Sie eine klare Forderung (z. B. Teilerstattung, kostenfreie Nachholveranstaltung) und setzen Sie eine Frist.\n\nBeachten Sie Anrede, Einleitung und Grußformel. Schreiben Sie mindestens 150 Wörter.\n\n— ODER —\n\nAUFGABE B (Stellungnahme):\n\nSituation: In der überregionalen Wochenzeitung 'Zeit & Gesellschaft' ist ein Leitartikel unter dem Titel 'Homeoffice macht Karrieren unsichtbar' erschienen. Die Autorin behauptet darin, Beschäftigte, die überwiegend von zu Hause arbeiten, würden seltener befördert, bekämen weniger Sichtbarkeit und riskierten langfristig ihre Karrierechancen. Sie wollen auf diesen Artikel mit einem Leserbrief antworten.\n\nSchreiben Sie einen Leserbrief an die Redaktion (Herrn Bernhard Lutz, Redaktion 'Zeit & Gesellschaft'). Gehen Sie auf die folgenden drei Leitpunkte ein:\n\n• Nehmen Sie Stellung zu der zentralen These des Artikels – stimmen Sie zu oder widersprechen Sie?\n• Nennen Sie mindestens zwei konkrete Argumente oder Beispiele aus Ihrer eigenen Erfahrung oder Beobachtung.\n• Machen Sie einen konstruktiven Vorschlag, wie Unternehmen beide Arbeitsformen fair gestalten könnten.\n\nBeachten Sie eine passende semi-formelle Anrede und eine sachliche Argumentation. Schreiben Sie mindestens 150 Wörter.",
+          "promptTranslation": "TASK A (Complaint letter):\n\nSituation: Three weeks ago you attended a four-day further-education seminar on 'Project Management in the Digital Age' at BusinessPro Academy in Frankfurt. You had high expectations but were deeply disappointed: the trainer was absent several times, the announced case studies were replaced with generic lectures, and the promised learning materials have not arrived. The fee of 890 € was already charged.\n\nWrite a formal complaint to the director (Dr. Andrea Hoffmann), BusinessPro Academy. Address these three guiding points:\n\n• Describe the concrete shortcomings during the seminar.\n• Explain what consequences these have for your professional goals.\n• Formulate a clear demand (e.g. partial refund, free replacement course) and set a deadline.\n\nInclude greeting, opening, and closing. Write at least 150 words.\n\n— OR —\n\nTASK B (Opinion piece):\n\nSituation: A national weekly newspaper has published an article titled 'Home office makes careers invisible'. The author claims that employees who work mostly from home get promoted less often, have less visibility, and risk their long-term career. You want to respond with a letter to the editor.\n\nWrite a letter to the editor (Mr. Bernhard Lutz). Address these three guiding points:\n\n• State your position on the main thesis – agree or disagree.\n• Give at least two concrete arguments or examples from your own experience or observation.\n• Suggest constructively how companies could make both work forms fair.\n\nUse an appropriate semi-formal salutation and factual reasoning. Write at least 150 words.",
+          "requiredPoints": [
+            "Aufgabe A: konkrete Mängel, Folgen für berufliche Ziele, klare Forderung + Frist",
+            "Aufgabe B: Positionsbezug zur These, zwei eigene Argumente/Beispiele, konstruktiver Vorschlag"
+          ],
+          "wordCountMin": 150,
+          "wordCountMax": 230,
+          "sampleAnswer": "[AUFGABE A — Beispielantwort]\n\nSehr geehrte Frau Dr. Hoffmann,\n\nvor drei Wochen nahm ich an dem viertägigen Seminar 'Projektmanagement im digitalen Zeitalter' in Ihrem Hause teil. Leider sehe ich mich gezwungen, auf erhebliche Mängel hinzuweisen.\n\nZunächst war der angekündigte Dozent an zwei von vier Tagen nicht anwesend, sondern wurde durch eine fachfremde Vertretung ersetzt. Die im Programm versprochenen Fallstudien aus realen Unternehmen wurden vollständig gestrichen und durch allgemeine Vorträge ersetzt. Darüber hinaus habe ich die angekündigten digitalen Lernunterlagen bis heute nicht erhalten, obwohl mir zu Beginn des Seminars zugesichert wurde, sie innerhalb einer Woche zu erhalten.\n\nDiese Mängel haben konkrete berufliche Folgen für mich. Ich hatte das Seminar gezielt gebucht, um eine interne Bewerbung auf eine Projektleitungsstelle zu unterstützen. Ohne die angekündigten Inhalte und Materialien ist meine Vorbereitung unvollständig, und die Kursgebühr von 890 € entspricht in keiner Weise der erbrachten Leistung.\n\nIch fordere Sie daher auf, mir entweder 50 Prozent der Kursgebühr zu erstatten oder eine kostenfreie Nachholveranstaltung mit dem ursprünglich angekündigten Dozenten anzubieten. Bis spätestens zum 30. April erwarte ich eine verbindliche schriftliche Rückmeldung.\n\nMit freundlichen Grüßen\nAlexander Keller",
+          "scoringCriteria": [
+            {
+              "criterion": "I. Berücksichtigung der Leitpunkte",
+              "maxPoints": 15,
+              "description": "Alle drei Leitpunkte der gewählten Aufgabe (A oder B) werden inhaltlich mit B2-typischer Tiefe behandelt – nicht nur erwähnt, sondern mit Begründung und konkreten Details ausgeführt. A: A++ (15 Pkt) / B: B+ (10 Pkt) / C: C (5 Pkt) / D: unbehandelt (0 Pkt). Wird diese Kategorie mit D bewertet, erhält die gesamte Aufgabe 0 Punkte."
+            },
+            {
+              "criterion": "II. Kommunikative Gestaltung",
+              "maxPoints": 15,
+              "description": "Formelle/semi-formelle Anrede, logischer Textaufbau (Einleitung – Hauptteil – Schluss), konsistenter Sie-Register, B2-typische Diskursmarker (allerdings, darüber hinaus, im Übrigen, folglich, angesichts, hinsichtlich), passende Grußformel. Register-Sprünge (z.B. 'Hallo' in Beschwerde) werden abgewertet."
+            },
+            {
+              "criterion": "III. Formale Richtigkeit",
+              "maxPoints": 15,
+              "description": "B2-Grammatik korrekt eingesetzt: Passiv, Konjunktiv II für höfliche Forderungen ('Ich möchte Sie darum bitten', 'Ich erwarte, dass ...'), Nominalisierung, komplexe Nebensätze, Genitiv-Präpositionen. Rechtschreibung und Zeichensetzung. Fehler, die das Verständnis blockieren, führen zu D und damit zu 0 Punkten gesamt."
+            }
+          ]
+        }
+      ]
+    },
+    "speaking": {
+      "totalTimeMinutes": 15,
+      "prepTimeMinutes": 20,
+      "parts": [
+        {
+          "partNumber": 1,
+          "type": "presentation",
+          "instructions": "Teil 1 — Präsentation (ca. 3 Minuten pro Kandidat:in). Jede:r Kandidat:in erhält eine Themenkarte und hält eine kurze, strukturierte Präsentation (Einstieg, Hauptteil, Schluss). Anschließend stellt die Partnerin/der Partner 1–2 Nachfragen.",
+          "instructionsTranslation": "Part 1 — Presentation (approx. 3 minutes per candidate). Each candidate receives a topic card and gives a short, structured presentation (intro, main body, conclusion). Afterwards the partner asks 1–2 follow-up questions.",
+          "prompt": "KANDIDAT:IN A — Thema: 'Die Bedeutung von Weiterbildung im Beruf'\n\nHalten Sie eine kurze Präsentation (ca. 3 Minuten) zu diesem Thema. Strukturieren Sie Ihren Vortrag so:\n\n• Einstieg: Warum ist Weiterbildung heute wichtiger als früher? Nennen Sie ein konkretes Beispiel aus Ihrem Umfeld.\n• Hauptteil: Welche Vorteile bringt lebenslanges Lernen – für Beschäftigte und für Unternehmen? Welche Herausforderungen gibt es (Zeit, Kosten, Motivation)?\n• Schluss: Wie könnte Weiterbildung in der Zukunft gefördert werden? Ihre persönliche Einschätzung.\n\n—\n\nKANDIDAT:IN B — Thema: 'Vorteile und Nachteile von Homeoffice'\n\nHalten Sie eine kurze Präsentation (ca. 3 Minuten) zu diesem Thema. Strukturieren Sie Ihren Vortrag so:\n\n• Einstieg: Wie verbreitet ist Homeoffice heute in Deutschland und in Ihrem Umfeld? Ein konkretes Beispiel.\n• Hauptteil: Welche Vorteile bietet Homeoffice (für Beschäftigte, Unternehmen, Umwelt)? Welche Nachteile beobachten Sie (soziale Isolation, unklare Grenzen, Ausstattung)?\n• Schluss: Welche Bedingungen sollten erfüllt sein, damit Homeoffice funktioniert? Ihre Einschätzung.",
+          "sampleResponse": "[Kandidat:in A — Weiterbildung im Beruf]\n\nMeine Damen und Herren, ich möchte heute über die Bedeutung von Weiterbildung im Beruf sprechen. In kaum einem anderen Bereich hat sich so viel verändert wie in der Arbeitswelt. Eine gute Freundin von mir arbeitet als Krankenpflegerin und muss sich jedes Jahr verpflichtend digital fortbilden, weil die Software ständig weiterentwickelt wird. An diesem Beispiel zeigt sich: Berufliches Wissen hat heute eine kürzere Haltbarkeit als früher.\n\nIm Hauptteil möchte ich kurz auf Vorteile und Herausforderungen eingehen. Für Beschäftigte eröffnet lebenslanges Lernen neue Karrierewege, stärkt das Selbstbewusstsein und reduziert die Angst vor Veränderungen. Für Unternehmen wiederum bedeutet es motivierte Mitarbeitende, geringere Fluktuation und eine bessere Position am Markt. Allerdings darf man die Herausforderungen nicht unterschätzen. Weiterbildung kostet Zeit, Geld und innere Motivation. Gerade Eltern kleiner Kinder kommen oft an ihre Grenzen, wenn Kurse in die Freizeit verlegt werden.\n\nAbschließend bin ich überzeugt, dass Weiterbildung in Zukunft stärker gefördert werden muss – durch bezahlte Lerntage, staatliche Zuschüsse und flexible Online-Angebote. Nur so kann man den Übergang in eine digitale Arbeitswelt fair gestalten. Vielen Dank – was denken Sie dazu?\n\n[Beispielhafte Nachfrage der Partnerin/des Partners: 'Welche Art von Weiterbildung hat dir persönlich am meisten gebracht?']",
+          "evaluationTips": [
+            "Strukturieren Sie die Präsentation klar: Einstieg – Hauptteil – Schluss",
+            "Verwenden Sie B2-Diskursmarker: 'Zunächst', 'Darüber hinaus', 'Allerdings', 'Abschließend'",
+            "Nennen Sie EIN konkretes Beispiel (aus Umfeld/Beruf/Erfahrung), keine rein abstrakten Aussagen",
+            "Balance aus Vorteilen UND Herausforderungen zeigen – B2 verlangt Differenzierung",
+            "Konjunktiv II für Einschätzungen: 'Ich könnte mir vorstellen, dass ...', 'Sinnvoll wäre ...'",
+            "Direkter Schluss mit persönlicher Einschätzung + Übergabe an Partner",
+            "Zeitlimit (~3 Min) beachten – nicht länger, nicht kürzer"
+          ],
+          "keyPhrases": [
+            "Ich möchte heute über ... sprechen.",
+            "Ein konkretes Beispiel dafür ist ...",
+            "Einerseits ..., andererseits ...",
+            "Besonders hervorheben möchte ich ...",
+            "Allerdings darf man nicht übersehen, dass ...",
+            "Meiner Ansicht nach ...",
+            "Abschließend lässt sich festhalten ...",
+            "Was denken Sie / was denkst du dazu?"
+          ]
+        },
+        {
+          "partNumber": 2,
+          "type": "discussion",
+          "instructions": "Teil 2 — Diskussion (ca. 5 Minuten gemeinsam). Beide Kandidat:innen erhalten denselben provokanten Satz und diskutieren ihn. Ziel: eigene Position vertreten, auf die Argumente der Partnerin/des Partners eingehen, widersprechen oder weiterentwickeln.",
+          "instructionsTranslation": "Part 2 — Discussion (approx. 5 minutes together). Both candidates receive the same provocative statement and discuss it. Goal: defend your own position, engage with the partner's arguments, disagree or build on them.",
+          "prompt": "Thema für beide Kandidat:innen:\n\n'Bewerbungen sollten grundsätzlich anonym sein. Foto, Name, Alter und Geschlecht gehören nicht in einen Lebenslauf.'\n\n— Leitfragen für die Diskussion —\n\n• Stimmen Sie dieser These zu oder widersprechen Sie?\n• Welche Vorteile hätten anonyme Bewerbungen? Für wen?\n• Welche Nachteile oder praktischen Probleme sehen Sie?\n• Wären Sie selbst bereit, sich anonym zu bewerben? Warum (nicht)?\n\nReagieren Sie auf die Argumente Ihrer Partnerin/Ihres Partners, widersprechen Sie höflich, wo nötig, und versuchen Sie am Ende, Ihre Positionen zusammenzuführen oder respektvoll unterschiedlich stehen zu lassen.",
+          "sampleResponse": "KANDIDAT:IN A: 'Also, grundsätzlich finde ich die Idee spannend. Studien zeigen, dass Namen, Fotos und Alter unbewusst in die Vorauswahl einfließen – das ist einfach nicht fair. Ich würde deshalb eher zustimmen: Die erste Sichtung sollte anonym sein.'\n\nKANDIDAT:IN B: 'Da möchte ich teilweise widersprechen. Ich sehe zwar das Fairness-Argument, aber in manchen Branchen – zum Beispiel im Vertrieb – spielt die Persönlichkeit eine entscheidende Rolle. Ohne irgendwelche persönlichen Informationen wird die Vorauswahl nach meiner Einschätzung zu technisch.'\n\nKANDIDAT:IN A: 'Das ist ein interessanter Einwand. Allerdings geht es ja nur um die erste Sichtung. Im Vorstellungsgespräch trifft man sich dann doch persönlich, und da kommt die Persönlichkeit voll zum Tragen. Meinst du nicht, dass genau diese Trennung sinnvoll wäre?'\n\nKANDIDAT:IN B: 'Guter Punkt – wenn man es so staffelt, sehe ich das tatsächlich anders. Dann bleibt allerdings die Frage, ob die Verwaltungskosten für eine solche Anonymisierung angemessen sind, besonders für kleinere Betriebe.'\n\nKANDIDAT:IN A: 'Da stimme ich dir zu. Kleine Firmen haben nicht die Kapazitäten. Vielleicht wäre ein Pilotprojekt im öffentlichen Dienst ein guter Einstieg – dort ist die Verwaltung sowieso vorhanden.'\n\nKANDIDAT:IN B: 'Ja, das könnte ein realistischer Kompromiss sein. Insgesamt sehe ich die Idee anonymer Bewerbungen positiv, aber mit klaren Grenzen.'",
+          "evaluationTips": [
+            "Klare Position beziehen – 'Ich stimme zu / Ich widerspreche'",
+            "Auf das Gesagte des Partners konkret eingehen – nicht nur die eigene Position wiederholen",
+            "Widerspruch höflich: 'Da möchte ich teilweise widersprechen ...', 'Das sehe ich anders, weil ...'",
+            "Konjunktiv II für hypothetische Argumentation: 'Wäre ...', 'Würde ...', 'Könnte ...'",
+            "Konkrete Beispiele oder Branchen nennen, keine rein theoretischen Argumente",
+            "Versuch der Synthese am Ende: 'Wenn man es so staffelt, ...', 'Ein möglicher Kompromiss wäre ...'",
+            "Diskursmarker der Argumentation: 'allerdings', 'andererseits', 'demgegenüber', 'darüber hinaus'"
+          ],
+          "keyPhrases": [
+            "Meiner Meinung nach ...",
+            "Ich kann dem nur teilweise zustimmen.",
+            "Das sehe ich anders, weil ...",
+            "Ein starkes Argument dafür/dagegen ist ...",
+            "Darf ich kurz darauf eingehen?",
+            "Ich verstehe deinen Punkt, allerdings ...",
+            "Wenn man es so betrachtet, ...",
+            "Ein Kompromiss könnte sein, dass ...",
+            "Da sind wir uns wohl einig."
+          ]
+        },
+        {
+          "partNumber": 3,
+          "type": "planning",
+          "instructions": "Teil 3 — Gemeinsam Planen (ca. 5 Minuten). Beide Kandidat:innen erhalten denselben Planungsauftrag und müssen gemeinsam zu einer konkreten Lösung kommen: Vorschläge machen, abwägen, verhandeln, Entscheidung treffen.",
+          "instructionsTranslation": "Part 3 — Collaborative Planning (approx. 5 minutes). Both candidates receive the same planning task and must reach a concrete joint solution: make proposals, weigh options, negotiate, decide.",
+          "prompt": "Planungsauftrag für beide Kandidat:innen:\n\nIn Ihrer Abteilung beginnt kommende Woche eine neue Kollegin, Frau Daria Kowalski (aus Polen, zwei Jahre Berufserfahrung in einer ähnlichen Position). Ihre Vorgesetzte hat Sie beide gebeten, gemeinsam einen 'Willkommenstag' für sie zu organisieren.\n\nBesprechen Sie folgende Punkte und treffen Sie konkrete Entscheidungen:\n\n• Zeitpunkt: Wann genau soll der Willkommenstag stattfinden? An welchem Tag der Arbeitswoche? Morgens, nachmittags, ganztägig?\n• Ort: Welche Räume werden benötigt? Soll etwas außerhalb des Büros stattfinden (Mittagessen, kurze Stadtführung, Teambuilding-Aktivität)?\n• Budget: Wie viel sind Sie bereit auszugeben? Wie teilen Sie die Ausgaben auf?\n• Aktivitäten: Welche inhaltlichen Punkte sollen enthalten sein (Begrüßung, Vorstellungsrunde, technische Einrichtung, Einführung in Arbeitsabläufe, gemeinsames Essen)?\n• Aufgabenverteilung: Wer übernimmt welche konkrete Vorbereitung bis zum Starttag?\n\nEinigen Sie sich am Ende auf einen klaren Plan.",
+          "sampleResponse": "KANDIDAT:IN A: 'Fangen wir mit dem Zeitpunkt an. Ich würde vorschlagen, den Willkommenstag gleich am Montag zu machen, an dem Daria anfängt – ganztägig, damit sie einen strukturierten Start hat. Was hältst du davon?'\n\nKANDIDAT:IN B: 'Ganztägig finde ich etwas zu viel für den ersten Tag. Wie wäre es, wenn wir vormittags die offiziellen Sachen machen – Begrüßung, IT, Einweisung – und nachmittags mit einem Mittagessen und einem kleinen Teamrundgang ausklingen lassen?'\n\nKANDIDAT:IN A: 'Okay, das klingt sinnvoller – nicht zu überfordern. Zum Ort: den kleinen Konferenzraum für die offizielle Begrüßung, und fürs Essen könnten wir ins italienische Restaurant nebenan gehen, das kennen alle im Team.'\n\nKANDIDAT:IN B: 'Einverstanden. Zum Budget: Sollten wir 150 Euro einplanen? Das reicht für ein gemeinsames Mittagessen und ein kleines Willkommensgeschenk, zum Beispiel einen Gutschein für eine lokale Buchhandlung. Die Firma übernimmt bei Willkommenstagen normalerweise die Hälfte.'\n\nKANDIDAT:IN A: 'Gute Idee mit dem Gutschein. Und zum Inhalt: Ich würde vorschlagen, dass wir eine kurze Vorstellungsrunde im Team machen, gefolgt von einer Einführung in unsere Projektplattform. Der IT-Kollege kann die technische Einrichtung ab 10 Uhr übernehmen – den spreche ich an.'\n\nKANDIDAT:IN B: 'Prima, dann übernehme ich die Restaurantreservierung und bereite eine kurze Übersicht unserer aktuellen Projekte vor, damit Daria direkt einen Überblick hat. Können wir uns Freitag nochmal kurz abstimmen?'\n\nKANDIDAT:IN A: 'Perfekt. Also zusammengefasst: Montag, vormittags offiziell, nachmittags Essen im Italiener, 150 Euro Budget, du machst Reservierung und Projektübersicht, ich klär IT-Kollegen und Gutschein. Abgemacht!'",
+          "evaluationTips": [
+            "Konkrete Vorschläge statt vager Ideen: Tag, Uhrzeit, Ort, Betrag nennen",
+            "Aktiv zuhören – reagieren Sie spezifisch auf die Vorschläge des Partners",
+            "Konjunktiv II für Vorschläge: 'Ich würde vorschlagen ...', 'Wir könnten ...', 'Wie wäre es mit ...?'",
+            "Kompromisse zeigen: 'Ganztägig ist mir zu viel – wie wäre halbtags?'",
+            "Am Ende zusammenfassen: 'Also zusammengefasst: ...'",
+            "Aufgabenverteilung explizit machen: 'Du übernimmst ..., ich übernehme ...'",
+            "Höfliche Zustimmung/Widerspruch: 'Einverstanden', 'Abgemacht', 'Das sehe ich anders'",
+            "Budget und Aufgabenverteilung müssen beide konkret benannt werden"
+          ],
+          "keyPhrases": [
+            "Ich würde vorschlagen, dass ...",
+            "Wie wäre es, wenn wir ...?",
+            "Das klingt sinnvoll, aber ...",
+            "Können wir uns darauf einigen, dass ...?",
+            "Wer übernimmt ...?",
+            "Ich kümmere mich um ..., du übernimmst bitte ...",
+            "Einverstanden / Abgemacht.",
+            "Also zusammengefasst: ...",
+            "Sollen wir das so festhalten?"
+          ]
+        }
+      ]
+    }
   }
 }

--- a/packages/content/src/catalog.ts
+++ b/packages/content/src/catalog.ts
@@ -22,8 +22,8 @@ function generateEntries(level: Level, count: number): MockExamEntry[] {
       'Gesellschaft', 'Kultur', 'Gesundheit', 'Reisen', 'Konsum',
     ],
     B2: [
-      'Wissenschaft', 'Beruf', 'Bildung', 'Medien', 'Umwelt',
-      'Gesellschaft', 'Kultur', 'Wirtschaft', 'Politik', 'Technologie',
+      'Beruf & Arbeitswelt', 'Mobilität', 'Gesellschaft', 'Digitales', 'Bildung',
+      'Work-Life-Balance', 'Integration', 'Konsum', 'Fachkräfte', 'Medienkompetenz',
     ],
     C1: [
       'Wissenschaft', 'Forschung', 'Bildung', 'Medien', 'Umwelt',

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,27 @@
+# Specs Index
+
+> **Last updated:** 2026-04-20
+
+## Content Format
+
+| Spec | Source | Summary |
+|------|--------|---------|
+| [`content-format/mock-exam-schema.md`](content-format/mock-exam-schema.md) | `packages/types/src/exam.ts` | TypeScript interfaces for all mock exam JSON files; edge cases for stubs, missing audio, word bank rendering |
+| [`content-format/b2-mock-content-conventions.md`](content-format/b2-mock-content-conventions.md) | `apps/mobile/assets/content/B2/mock_01.json`, B2 SSML files | B2 structural rules, item counts, SSML conventions, calibration rules for mocks 02–10 |
+
+## Services
+
+| Spec | Source | Summary |
+|------|--------|---------|
+| [`services/content-catalog.md`](services/content-catalog.md) | `packages/content/src/catalog.ts` | Mock exam metadata catalog; title generation logic; known catalog/JSON title mismatch for B2 mock_01 |
+
+## Coverage Gaps
+
+The following source areas have no spec yet (bootstrap not yet run):
+
+- `src/app/**/*.tsx` — screens (dashboard, practice, exam simulator, score report, resources, settings)
+- `src/components/**/*.tsx` — all UI and exam components
+- `src/services/database.ts` — SQLite schema and migrations
+- `packages/core/src/scoring.ts` — telc scoring logic
+- `packages/core/src/spaced-repetition.ts` — SM-2 algorithm
+- `packages/core/src/timer.ts` — section time limits

--- a/specs/content-format/b2-mock-content-conventions.md
+++ b/specs/content-format/b2-mock-content-conventions.md
@@ -1,0 +1,144 @@
+# B2 Mock Exam Content Conventions
+
+> **Last synced:** 2026-04-20 | **Source:** `apps/mobile/assets/content/B2/mock_01.json`, `.planning/audio-prompts/B2_mock01_listening_part{1,2,3}.ssml`, `.planning/research/B2-exam-format.md`
+
+## Purpose
+
+Documents the structural rules, item counts, and authoring conventions that apply to all B2 mocks. `mock_01.json` is the worked example — mocks 02–10 must follow these conventions exactly. Deviations require an explicit note here.
+
+## Exam Structure
+
+| Section | Parts | Items | Max Points | Time |
+|---------|-------|-------|------------|------|
+| Hören | 3 | 20 | 75 | 20 min |
+| Lesen | 3 | 20 | 75 | 90 min |
+| Sprachbausteine | 2 | 20 | 30 | included in reading time |
+| Schreiben | 1 (2 prompts) | 2 tasks | 45 | 30 min |
+| Sprechen | 3 | 3 | 75 | 15 min + 20 min prep |
+
+Pass threshold: 60% in both written sections (Hören+Lesen+Schreiben+Sprachbausteine) and oral (Sprechen).
+
+## Hören (Listening)
+
+### Part breakdown
+
+| Part | Format | Items | Play rule |
+|------|--------|-------|-----------|
+| Teil 1 | 5 short news bulletins, true/false | 5 | `playCount: 1` |
+| Teil 2 | Expert interview, true/false | 10 | `playCount: 1` |
+| Teil 3 | 5 short professional announcements, 3-option MCQ | 5 | `playCount: 1` |
+
+**`playCount: 1` is mandatory on all three parts.** This is the B2 single-play rule — no item in the listening section may be heard twice. This intentionally mirrors real telc B2 exam conditions and tests authentic comprehension, not memory on second pass. Authors must never set `playCount: 2` on any B2 listening part.
+
+### Trap design conventions
+- Teil 1: Each bulletin contains at least one lexical hedge or quantitative mismatch that creates a plausible false positive. The `explanation` field must identify the specific trap word or phrase.
+- Teil 2: Interview questions are designed around B2 hedging patterns — `"Man hört oft ... aber"`, `"überwiegend"`, `"nach wie vor"`. The trap must be named explicitly in `explanation`.
+- Teil 3: MCQ distractors must reuse vocabulary from the audio to create false familiarity. Correct answers require inference, not surface matching.
+
+### Question ID pattern
+`B2_m{NN}_L{PartNum}_q{ItemNum}` — e.g. `B2_m01_L2_q7`
+
+### `audioTimestamp` field
+Required on all listening questions. Value is seconds from audio start to the moment the answer evidence is spoken. Used for post-exam review to jump the player to the relevant passage.
+
+## Lesen (Reading)
+
+### Part breakdown
+
+| Part | Format | Items |
+|------|--------|-------|
+| Teil 1 | 10 headings → 5 texts (5 distractor headings) | 10 |
+| Teil 2 | Long article (~500+ words), 5 inference-only MCQ | 5 |
+| Teil 3 | 10 situations → 12 ads (includes ≥1 `"x"` no-match) | 10 |
+
+**Lesen Teil 3 must include at least one `"x"` no-match situation per mock.** This calibration rule (from `.planning/research/B2-exam-format.md`) ensures candidates practice the no-match option rather than assuming every situation maps to an ad.
+
+### Lesen Teil 2 text length
+Feature article must exceed 500 words. MCQs must test inference — no answer should be directly quotable from a single sentence. If a candidate can find the answer by scanning for a keyword, the question is too easy for B2.
+
+## Sprachbausteine
+
+### Part breakdown
+
+| Part | Type | Items | Option count |
+|------|------|-------|-------------|
+| Teil 1 | Close text, 4-option MCQ | 10 | **4 (a/b/c/d)** |
+| Teil 2 | Close text, word bank | 10 | **15 (a–o), 5 unused** |
+
+**Teil 1 uses 4 options — this is the primary structural difference from B1 Teil 1 (which uses 3).** Rendering components must not assume 3 options for `mcq` type Sprachbausteine questions. The correct option can land at any position (a, b, c, or d) and answers must be distributed across positions to avoid pattern bias.
+
+### B2 grammar features tested in Teil 1
+Each Sprachbausteine Teil 1 item must test a named B2 grammar feature. The `explanation` field must state the feature name. Features established in mock_01 as the canonical set:
+
+- Passiv-Perfekt (`wurde ... gemacht` / `ist ... worden`)
+- Relativpronomen (gender + case agreement)
+- Funktionsverbgefüge (`in Anspruch nehmen`, `in Betracht ziehen`, etc.)
+- Modalverb + Konjunktiv vs. Indikativ contrast
+- Genitiv-Präpositionen (`angesichts`, `trotz`, `wegen`, `aufgrund`)
+- Koordinierende Konnektoren with structural constraints (`sondern` requires negation, `aber auch` does not)
+- Partizipialattribute (Partizip I vs. II vs. Gerundivum `zu+Partizip`)
+- Nominalisierung vs. Adjektiv (prädikativ vs. attributiv, endungslos vs. flektiert)
+- Deklination in Relativsätzen and dass-Sätzen
+- Inversion after conditional `Sollte...`
+
+### Teil 2 word bank
+15 options must cover different word classes. The 5 unused words should be plausible distractors for multiple blanks, not obviously wrong. Authors must verify no unused word could unambiguously fit any blank.
+
+## Schreiben (Writing)
+
+Candidates choose between two prompts:
+- **Option A:** Formal complaint letter (Beschwerdebrief) — professional register, specific factual demands
+- **Option B:** Stellungnahme / argumentative essay — must argue a position, not merely describe
+
+Both prompts must be provided in every B2 mock. The task is stored as a single `WritingTask` entry with both options described in the `prompt` field. `sampleAnswer` covers one option only — note which option is answered.
+
+**B2 scoring note:** A D (lowest grade) in either criterion I (Inhalt) or III (Sprachliche Angemessenheit) results in 0 points for the entire writing task. The `scoringCriteria` array in the JSON captures this via `description` fields; the exam runner does not automatically apply this rule — it is for human scoring reference only.
+
+## Sprechen (Speaking)
+
+| Part | Type | Duration | Notes |
+|------|------|----------|-------|
+| Teil 1 | `presentation` | ~3 min/candidate | **Candidate A and B receive different topic cards** |
+| Teil 2 | `discussion` | ~5 min shared | Both see the same provocative statement |
+| Teil 3 | `planning` | ~5 min shared | Both see the same task; must reach a joint decision |
+
+`prepTimeMinutes: 20` on the `SpeakingSection`. This applies to B2 (and B1). A1, A2, C1 have `prepTimeMinutes: 0`.
+
+Speaking parts are not scored automatically. The `evaluationTips` and `keyPhrases` arrays are displayed post-practice for self-assessment.
+
+## Audio Pipeline (SSML Conventions)
+
+SSML scripts live at `.planning/audio-prompts/{LEVEL}_mock{NN}_listening_part{N}.ssml`. These are source scripts for TTS generation; the compiled MP3s go to `assets/audio/{LEVEL}/mock{NN}/listening_part{N}.mp3`.
+
+### B2-specific SSML rules (differ from B1)
+
+| Parameter | B1 | B2 |
+|-----------|----|----|
+| `prosody rate` | `"slow"` (narrator/content) | `"1.0"` everywhere — natural speed, no slowing |
+| Initial pause after instructions | 3s | **10s** — candidates need time to read all 5 statements before audio starts |
+| Pause between Teil 1/3 items | 2s | **5s** — longer gaps for note-taking at B2 |
+| Teil 2 item-level pauses | Individual breaks | None — interview flows continuously; no breaks between questions |
+| Narrator voice | `de-DE-Wavenet-C` (female) | `de-DE-Wavenet-C` (female) — same |
+| Content voices Teil 1 | B/C (2 voices) | **B/A/D** (3 voices rotating for news variety) |
+| Content voices Teil 2 | single speaker or pairs | Named characters: `de-DE-Wavenet-E` (Moderator), `de-DE-Wavenet-F` (Dr. Richter) |
+| Content voices Teil 3 | varied | B/A/D/F/E — one voice per announcement |
+
+### Rationale for 10s pause after instructions
+At B2, Teil 1 instructions ask candidates to pre-read all 5 true/false statements before the first audio clip plays. A 3s pause (B1 convention) is too short to read 5 full German sentences. 10s matches the telc exam administration guidance.
+
+### Rationale for no item-level pauses in Teil 2
+The Teil 2 interview is presented as a continuous uninterrupted recording. Inserting pauses between questions would break the naturalistic register and give candidates artificial processing time that doesn't exist in the real exam. This is a deliberate difficulty calibration.
+
+## Content Theme
+
+mock_01 theme: **Beruf & Arbeitswelt** (Bewerbung, Weiterbildung, Homeoffice, Work-Life-Balance). Vocabulary throughout is consistently professional/workplace register. All proper nouns (institutions, names) are fictional but realistic.
+
+## Calibration Rules for mocks 02–10
+
+1. Keep `playCount: 1` on all listening parts — non-negotiable
+2. Always use 4 options in Sprachbausteine Teil 1
+3. Always include ≥1 `"x"` no-match in Lesen Teil 3
+4. Provide two writing prompts (A and B) per mock
+5. Speaking Teil 1 must give different topic cards to candidate A and B
+6. Every `explanation` must name the B2 grammar feature being tested (Sprachbausteine) or the specific trap (Listening)
+7. Gloss every above-B2 word inside the `explanation` field where it appears

--- a/specs/content-format/mock-exam-schema.md
+++ b/specs/content-format/mock-exam-schema.md
@@ -1,0 +1,80 @@
+# Mock Exam Schema
+
+> **Last synced:** 2026-04-20 | **Source:** `packages/types/src/exam.ts`
+
+## Purpose
+
+Canonical TypeScript interfaces for all mock exam JSON files. Every `mock_XX.json` under `apps/mobile/assets/content/{level}/` is expected to conform to `MockExam`. The schema is shared across the mobile and web apps via `@fastrack/types`.
+
+## Interface
+
+### Top-level `MockExam`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | yes | `{LEVEL}_mock_{NN}` — e.g. `B2_mock_01` |
+| `level` | `Level` | yes | `A1 \| A2 \| B1 \| B2 \| C1` |
+| `title` | `string` | yes | Display title, e.g. `"B2 Übungstest 1: Beruf & Arbeitswelt"` |
+| `version` | `number` | yes | Content version; increment on breaking changes |
+| `sections.listening` | `ListeningSection` | yes | |
+| `sections.reading` | `ReadingSection` | yes | |
+| `sections.writing` | `WritingSection` | yes | |
+| `sections.sprachbausteine` | `SprachbausteineSection` | no | B1+ only |
+| `sections.speaking` | `SpeakingSection` | yes | |
+
+### `ListeningPart`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `audioFile` | `string` | Relative path from app root, e.g. `assets/audio/B2/mock01/listening_part1.mp3` |
+| `playCount` | `number` | Enforced by the exam runner. **B2 rule: always 1.** A1/A2: 2, B1: 1. |
+| `questions[].audioTimestamp` | `number?` | Seconds into the audio where the answer evidence occurs. Used for post-exam review navigation. |
+
+### `SprachbausteineQuestion`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `type` | `'mcq' \| 'word_bank'` | Teil 1 = `mcq`, Teil 2 = `word_bank` |
+| `options` | `string[]` | **B2 Teil 1: exactly 4 options** (`a/b/c/d`). **B1 Teil 1: 3 options** (`a/b/c`). Teil 2 (all levels): 15 options (`a–o`), 5 unused per text. |
+
+### `WritingTask`
+
+`type` field valid values: `'form_fill' | 'short_message' | 'letter' | 'essay'`. B2 writing uses `'letter'` (Beschwerdebrief/formeller Brief) and `'essay'` (Stellungnahme). The B2 task presents **two prompts (A and B)** — the candidate selects one. [TODO: verify with user — schema has a single `WritingTask`, but B2 mock_01 wraps both prompts inside one task; confirm whether future mocks should use two separate `WritingTask` entries or keep both prompts in one task's `prompt` field.]
+
+### `SpeakingSection`
+
+| Field | Notes |
+|-------|-------|
+| `prepTimeMinutes` | B1 and B2: 20 min. A1, A2, C1: 0. |
+| `parts[].type` | B2 uses `'presentation'`, `'discussion'`, `'planning'`. A1/A2 use `'introduce'`, `'picture_cards'`, `'und_du'`. |
+
+## Key Behaviors
+
+### Level-gated `sprachbausteine`
+The field is `optional` on `MockExam.sections`. A1 and A2 mocks omit it entirely. B1+ mocks must include it. The exam runner should guard against absent `sprachbausteine` rather than assuming presence.
+
+### `playCount` enforcement
+The `playCount` value in each `ListeningPart` is the single source of truth for how many times the audio may play during the exam. The exam runner is expected to read this field and disable replay once the count is reached. Content authors must not override the level rule in JSON — B2 mocks must always carry `playCount: 1`.
+
+### Question IDs
+IDs follow the pattern `{LEVEL}_m{NN}_{SectionCode}{PartNum}_q{ItemNum}` — e.g. `B2_m01_L1_q3`. The section codes are `L` (Listening), `R` (Reading), `SB` (Sprachbausteine), `W` (Writing), `SP` (Speaking). IDs must be unique within a mock and stable across versions unless the question changes materially.
+
+### `explanation` field (all question types)
+Mandatory on every question. Serves two purposes: (1) post-attempt review in the app, (2) makes the mock function as a teaching artefact. At B2, explanations are expected to name the specific grammar feature tested (e.g. "Passiv-Perfekt", "Partizipialattribut", "Funktionsverbgefüge") and gloss any above-B2 vocabulary inline.
+
+## Edge Cases
+
+- **Stub files:** A `_stub: true` key at the top level indicates placeholder content. The exam runner (and validator) must reject stubs and not expose them as playable mocks. Stub files have no `sections` key.
+- **Missing audio:** If the MP3 referenced by `audioFile` does not exist, the exam runner must surface a clear error rather than silently failing. The listening section cannot proceed without audio. [TODO: verify with user — confirm how the web app handles missing audio vs mobile.]
+- **Word bank distractors:** Teil 2 `word_bank` questions all share the same 15-option list even though only 10 blanks exist. The 5 unused words are intentional distractors. Renderers must display the full 15-option list once per part, not per question.
+
+## Dependencies
+
+- `@fastrack/types` — this file IS the types package; consumed by both apps and `@fastrack/core`
+- `packages/content/src/catalog.ts` — uses `Level` from this file
+- `apps/mobile/src/services/database.ts` — persists `ExamAttempt` which mirrors section score fields from this schema
+
+## Notes
+
+- B2 Sprachbausteine Teil 1 uses **4 options (a/b/c/d)**, not 3. This is the primary structural difference from B1 Teil 1 (3 options). Rendering components must not hardcode option count.
+- `ReadingText.type` enum (`'email' | 'ad' | 'notice' | 'article' | 'letter'`) does not currently include a `'heading'` type. Lesen Teil 1 at B2 involves matching 10 headings to 5 texts with 5 distractors — the headings are stored as question `questionText` fields, not as `ReadingText` entries. [TODO: verify with user — this works for content storage but may need a dedicated heading type for renderer clarity.]

--- a/specs/services/content-catalog.md
+++ b/specs/services/content-catalog.md
@@ -1,0 +1,67 @@
+# Content Catalog
+
+> **Last synced:** 2026-04-20 | **Source:** `packages/content/src/catalog.ts`
+
+## Purpose
+
+Provides a flat list of all mock exam metadata entries — one per mock across all five levels. Used by the UI to populate level screens and by the content loader to map level+mockNumber to a file path. Does not load or validate JSON content; that is the content loader's job.
+
+## Interface
+
+### `MockExamEntry`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | `{LEVEL}_mock_{NN}` — matches the `id` field inside `mock_NN.json` |
+| `level` | `Level` | One of `A1 \| A2 \| B1 \| B2 \| C1` |
+| `mockNumber` | `number` | 1-based index |
+| `title` | `string` | Generated as `"{LEVEL} Übungstest {N}: {theme}"` |
+
+### Key functions
+
+```ts
+getMocksForLevel(level: Level): MockExamEntry[]
+getAvailableLevels(): Level[]
+```
+
+`MOCK_EXAM_CATALOG` is the pre-built flat array — 50 entries (10 per level × 5 levels).
+
+## Key Behaviors
+
+### Title generation
+Titles are generated programmatically by `generateEntries()`. A hardcoded `titles` map provides the theme suffix per level. The theme is positional — index 0 = mock_01 theme, index 9 = mock_10 theme.
+
+**Current B2 title map (index order):**
+```
+0: Wissenschaft       mock_01
+1: Beruf              mock_02
+2: Bildung            mock_03
+3: Medien             mock_04
+4: Umwelt             mock_05
+5: Gesellschaft       mock_06
+6: Kultur             mock_07
+7: Wirtschaft         mock_08
+8: Politik            mock_09
+9: Technologie        mock_10
+```
+
+**Note:** `mock_01.json` sets its own `title` to `"B2 Übungstest 1: Beruf & Arbeitswelt"` in the JSON file itself, but the catalog generates `"B2 Übungstest 1: Wissenschaft"`. These are out of sync. The catalog title is what the UI renders on the level screen; the JSON title is what the exam runner displays during the exam. If these should match, the B2 titles map index 0 needs updating from `"Wissenschaft"` to `"Beruf & Arbeitswelt"`. [TODO: verify with user — confirm whether catalog titles should match JSON titles, and if so update index 0 of the B2 array.]
+
+## State / Data Flow
+
+The catalog is a static in-memory array — no async loading, no DB. It is imported directly at build time by any component that needs to list available mocks. Entry count and theme strings change only when catalog.ts is edited.
+
+## Edge Cases
+
+- **Stub mocks:** The catalog always lists all 50 entries regardless of whether the underlying JSON exists or is a stub. The UI layer is responsible for checking stub status before launching an exam.
+- **Level not found:** `getMocksForLevel` returns an empty array for any `Level` value that has no entries — currently impossible given the static data, but safe for future partial catalogs.
+- **Title/JSON mismatch:** See note above. The catalog title and the JSON `title` field are independently maintained. They can diverge silently.
+
+## Dependencies
+
+- `@fastrack/types` — imports `Level` type
+- Used by the exam list screen (mobile) and level selection screen (web)
+
+## Notes
+
+- The catalog currently has no `isAvailable` or `isStub` flag. Distinguishing playable from stub mocks requires reading the JSON file. [TODO: verify with user — consider adding an `available: boolean` field to `MockExamEntry` driven by a build-time manifest, rather than requiring runtime file access to check stub status.]


### PR DESCRIPTION
## Summary

Authors **B2 mock_01** — the first real B2 mock exam. This is the **worked example** that the remaining 9 B2 mocks will follow. Theme: **Beruf & Arbeitswelt** (Bewerbung, Weiterbildung, Homeoffice, Work-Life-Balance).

Replaces the 372-byte `_stub: true` placeholder at `apps/mobile/assets/content/B2/mock_01.json` with ~94 KB of authored content that matches the full telc B2 exam format spec in `.planning/research/B2-exam-format.md`.

Closes #60.

## What's inside

| Section | Parts | Items | Pts | B2-specific features |
|---------|-------|-------|-----|----------------------|
| Hören | 3 | 20 | 75 | `playCount=1` everywhere (B2 single-play rule); hedging trap in Teil 2 interview; news-style formal register in Teil 1 |
| Lesen | 3 | 20 | 75 | 10 headings / 5 texts (5 distractors); 500+ word feature article with inference-only MCQ; 10 situations / 12 ads with 1 `"x"` no-match situation |
| Sprachbausteine | 2 | 20 | 30 | **Teil 1 uses 4 options a/b/c/d** (KEY diff from B1); tests Passiv+Perfekt, Partizipialattribute, Nominalisierung, Genitiv-Präpositionen, Funktionsverbgefüge; Teil 2 word bank of 15 options |
| Schreiben | 1 | 2 prompts | 45 | Candidate chooses A (Beschwerdebrief — Weiterbildungsseminar) or B (Stellungnahme — Homeoffice-Leitartikel); full sample answer; B2 rubric note (D in I or III → 0 pts) |
| Sprechen | 3 | 3 | 75 | Teil 1 Präsentation with dual A/B candidate cards; Teil 2 Diskussion (anonyme Bewerbungen); Teil 3 gemeinsam planen (Willkommenstag); 20 min Vorbereitung |

Audio is wired via `assets/audio/B2/mock01/listening_part{1,2,3}.mp3` paths (MP3s not generated yet — separate issue). SSML scripts written under `.planning/audio-prompts/B2_mock01_listening_part{1,2,3}.ssml` following the B1 mock_01 convention (rate=`1.0` for B2 natural speed, multi-voice assignments, 10s initial pause for reading statements).

## Quality Gates

| Gate | Status | Notes |
|------|--------|-------|
| Typecheck | PASS | `pnpm typecheck` clean across all 6 workspace packages |
| Tests (web) | PASS | 210/210 tests pass via `pnpm --filter @fastrack/web test` |
| Tests (mobile) | n/a | Pre-existing Jest/expo-modules-core config failure on main — unrelated |
| Structural validation | PASS | All counts correct (5/10/5 listening; 5/5/10 reading; 10/10 sprachbausteine; 1 writing task; 3 speaking parts); 40 unique question IDs; every question has `explanation` |
| Schema (`MockExam`) | PASS | Validates via `validateMockExam`; `sprachbausteine` key present; `_stub` removed |
| Sprachbausteine format | PASS | Teil 1: 10/10 items have exactly 4 options; Teil 2: 10/10 items have exactly 15 options |
| Timing | PASS | Listening 20 min, Reading 90 min, Writing 30 min, Speaking 15 min + 20 min prep (matches B2 spec) |
| language-checker | Requested | To be run post-PR-open on `content-only, level=B2` |
| exam-tester layers A+B | Requested | Structure pass already done manually; full tester run requested |
| pedagogy-director 6-dim review | Requested | **Hard gate — to be posted on this PR before merge** |
| compliance-guardian | n/a | Content-only PR, no auth/PII touched |
| spec-tracker | Requested | `mode=sync` for the changed content file |

## Test plan

- [ ] `pnpm typecheck` — all packages clean
- [ ] `pnpm --filter @fastrack/web test` — all 210 tests pass
- [ ] Structural validator script — all counts + unique IDs + explanations verified
- [ ] Manual read-through — every MCQ answer defensible, every Sprachbausteine gap has exactly one correct answer, every distractor text-derived
- [ ] language-checker quality pass (B2 content-only)
- [ ] exam-tester layer A (structure) + layer B (code tests)
- [ ] pedagogy-director full 6-dimension review — **review comment must appear on this PR**
- [ ] spec-tracker `mode=sync` run

## Pedagogy review verdict

Pending — pedagogy-director has not yet posted. This is the hard gate; do not merge until verdict is APPROVE.

## Calibration notes for B2 mocks 02–10

- Stick to 4 options (a/b/c/d) in Sprachbausteine Teil 1 at all times — this is the primary B2 difference from B1 and must be consistent
- Keep `playCount: 1` on all three listening parts; this is non-negotiable B2 spec
- Include at least 1 `"x"` no-match situation in Lesen Teil 3 per mock (per research doc calibration rule 7)
- Writing task needs TWO prompts (A and B), not one, and the candidate selects
- Speaking Teil 1 should provide DIFFERENT topic cards for candidates A and B (see pattern in this mock)
- Sprachbausteine explanations should explicitly call out the B2 grammar feature being tested (Passiv-Perfekt, Partizipialattribut, Funktionsverbgefüge, etc.) — this makes the mock function as a teaching artefact
- Every above-B2 word must be glossed inside the `explanation` field — no exceptions

## Files changed

- `apps/mobile/assets/content/B2/mock_01.json` — stub → ~94 KB full content
- `packages/content/src/catalog.ts` — B2 titles array updated to real mock themes (mock_01 = "Beruf & Arbeitswelt")
- `.planning/audio-prompts/B2_mock01_listening_part1.ssml` — new (Teil 1 news bulletins, 5 voices rotating)
- `.planning/audio-prompts/B2_mock01_listening_part2.ssml` — new (interview, Moderator + Dr. Richter)
- `.planning/audio-prompts/B2_mock01_listening_part3.ssml` — new (5 workplace announcements, varied voices)