### PR TITLE
feat(web): feedback FAB posts to GitHub Issues (#84)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,40 @@
+# Fastrack Deutsch — Web App
+
+Next.js 15 / React 19 / Tailwind CSS 4 web application for telc German exam prep.
+
+## Development
+
+```bash
+pnpm dev:web       # start dev server on port 3000
+pnpm typecheck     # TypeScript check
+pnpm test          # run Vitest unit tests
+pnpm build         # production build
+```
+
+## Feedback FAB
+
+A floating action button is mounted globally in the root layout. Users can report bugs, request features, or ask questions. Each submission creates a GitHub issue on `kirankbs/fastrack-deutsch` with metadata (route, browser, device type, commit SHA, timestamp).
+
+### Required environment variable
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_TOKEN` | Personal access token with `issues: write` scope on `kirankbs/fastrack-deutsch` |
+
+The PAT must have **Contents: Read** and **Issues: Read and Write** permissions on the `kirankbs/fastrack-deutsch` repository (fine-grained PAT) or `repo` scope (classic PAT).
+
+### Local setup
+
+Add to `apps/web/.env.local`:
+
+```
+GITHUB_TOKEN=ghp_your_token_here
+```
+
+### Vercel setup
+
+Add `GITHUB_TOKEN` as an environment variable in Vercel dashboard under **Settings → Environment Variables** for both **Production** and **Preview** environments.
+
+### Graceful degradation
+
+If `GITHUB_TOKEN` is missing or invalid, the FAB still renders. Submitting the form returns a friendly error message to the user rather than crashing. No issues are silently dropped.

--- a/apps/web/src/__tests__/feedback/FeedbackFAB.test.tsx
+++ b/apps/web/src/__tests__/feedback/FeedbackFAB.test.tsx
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FeedbackFAB } from "@/components/FeedbackFAB";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/exam",
+}));
+
+vi.mock("@/lib/actions/feedback", () => ({
+  submitFeedback: vi.fn(),
+}));
+
+import { submitFeedback } from "@/lib/actions/feedback";
+
+const mockSubmit = vi.mocked(submitFeedback);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("FeedbackFAB — open/close", () => {
+  it("renders the FAB button", () => {
+    render(<FeedbackFAB />);
+    expect(screen.getByTestId("feedback-fab")).toBeInTheDocument();
+  });
+
+  it("opens modal when FAB is clicked", async () => {
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    expect(screen.getByTestId("feedback-modal")).toBeInTheDocument();
+  });
+
+  it("closes modal when Cancel is clicked", async () => {
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    expect(screen.getByTestId("feedback-modal")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("feedback-cancel"));
+    expect(screen.queryByTestId("feedback-modal")).not.toBeInTheDocument();
+  });
+
+  it("closes modal when Escape is pressed", async () => {
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    expect(screen.getByTestId("feedback-modal")).toBeInTheDocument();
+
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByTestId("feedback-modal")).not.toBeInTheDocument();
+  });
+
+  it("FAB button has minimum 44px height", () => {
+    render(<FeedbackFAB />);
+    const fab = screen.getByTestId("feedback-fab");
+    // h-14 = 56px in Tailwind. Class presence is sufficient for DOM tests.
+    expect(fab.className).toContain("h-14");
+  });
+
+  it("FAB has accessible aria-label", () => {
+    render(<FeedbackFAB />);
+    expect(screen.getByTestId("feedback-fab")).toHaveAttribute(
+      "aria-label",
+      "Send feedback"
+    );
+  });
+
+  it("dialog has aria-modal and aria-labelledby", async () => {
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    const dialog = screen.getByTestId("feedback-modal");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby", "feedback-modal-title");
+  });
+});
+
+describe("FeedbackFAB — form fields", () => {
+  it("form is empty when modal opens", async () => {
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    expect(screen.getByTestId<HTMLInputElement>("feedback-title").value).toBe(
+      ""
+    );
+    expect(
+      screen.getByTestId<HTMLTextAreaElement>("feedback-description").value
+    ).toBe("");
+  });
+
+  it("all three category options are present", async () => {
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    const select = screen.getByTestId<HTMLSelectElement>("feedback-category");
+    const options = Array.from(select.options).map((o) => o.value);
+    expect(options).toContain("bug");
+    expect(options).toContain("feature");
+    expect(options).toContain("question");
+  });
+
+  it("blocks submit when title is empty", async () => {
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    await userEvent.type(
+      screen.getByTestId("feedback-description"),
+      "This is a sufficiently long description for testing."
+    );
+    await userEvent.click(screen.getByTestId("feedback-submit"));
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  it("blocks submit when description is too short", async () => {
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    await userEvent.type(screen.getByTestId("feedback-title"), "Test title");
+    await userEvent.type(
+      screen.getByTestId("feedback-description"),
+      "Too short"
+    );
+    await userEvent.click(screen.getByTestId("feedback-submit"));
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  it("live counter updates as description changes", async () => {
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    // Use a no-space string so userEvent.type count is deterministic
+    await userEvent.type(
+      screen.getByTestId("feedback-description"),
+      "HelloWorld"
+    );
+    const counter = document.getElementById("feedback-desc-counter");
+    expect(counter?.textContent).toMatch(/10/);
+  });
+});
+
+describe("FeedbackFAB — submission states", () => {
+  it("shows success state with issue number after submit", async () => {
+    mockSubmit.mockResolvedValue({ issueNumber: 99 });
+
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    await userEvent.type(screen.getByTestId("feedback-title"), "My bug report");
+    await userEvent.type(
+      screen.getByTestId("feedback-description"),
+      "This is a detailed description that is long enough to pass validation."
+    );
+    await userEvent.click(screen.getByTestId("feedback-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("feedback-success")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("feedback-issue-number")).toHaveTextContent(
+      "#99"
+    );
+  });
+
+  it("shows error banner with message on API failure", async () => {
+    mockSubmit.mockResolvedValue({ error: "GitHub API error 500" });
+
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    await userEvent.type(screen.getByTestId("feedback-title"), "My bug report");
+    await userEvent.type(
+      screen.getByTestId("feedback-description"),
+      "This is a detailed description that is long enough to pass validation."
+    );
+    await userEvent.click(screen.getByTestId("feedback-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("feedback-error-banner")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("feedback-error-banner")).toHaveTextContent(
+      "GitHub API error 500"
+    );
+  });
+
+  it("shows Retry button on error state", async () => {
+    mockSubmit.mockResolvedValue({ error: "Timeout" });
+
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    await userEvent.type(screen.getByTestId("feedback-title"), "My bug report");
+    await userEvent.type(
+      screen.getByTestId("feedback-description"),
+      "This is a detailed description that is long enough to pass validation."
+    );
+    await userEvent.click(screen.getByTestId("feedback-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("feedback-retry")).toBeInTheDocument();
+    });
+  });
+
+  it("resets to idle form after Retry click", async () => {
+    mockSubmit.mockResolvedValue({ error: "Timeout" });
+
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    await userEvent.type(screen.getByTestId("feedback-title"), "My bug report");
+    await userEvent.type(
+      screen.getByTestId("feedback-description"),
+      "This is a detailed description that is long enough to pass validation."
+    );
+    await userEvent.click(screen.getByTestId("feedback-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("feedback-retry")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByTestId("feedback-retry"));
+    expect(screen.getByTestId("feedback-submit")).toBeInTheDocument();
+    expect(screen.queryByTestId("feedback-error-banner")).not.toBeInTheDocument();
+  });
+
+  it("disables submit button while submitting (no double-click)", async () => {
+    let resolveSubmit!: (v: { issueNumber: number }) => void;
+    mockSubmit.mockReturnValue(
+      new Promise((res) => {
+        resolveSubmit = res;
+      })
+    );
+
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    await userEvent.type(screen.getByTestId("feedback-title"), "My bug report");
+    await userEvent.type(
+      screen.getByTestId("feedback-description"),
+      "This is a detailed description that is long enough to pass validation."
+    );
+    await userEvent.click(screen.getByTestId("feedback-submit"));
+
+    expect(screen.getByTestId("feedback-submit")).toBeDisabled();
+
+    // Resolve the pending promise and flush state updates
+    await act(async () => {
+      resolveSubmit({ issueNumber: 1 });
+    });
+  });
+});

--- a/apps/web/src/__tests__/feedback/FeedbackFAB.test.tsx
+++ b/apps/web/src/__tests__/feedback/FeedbackFAB.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FeedbackFAB } from "@/components/FeedbackFAB";
 
@@ -122,11 +122,9 @@ describe("FeedbackFAB — form fields", () => {
   it("live counter updates as description changes", async () => {
     render(<FeedbackFAB />);
     await userEvent.click(screen.getByTestId("feedback-fab"));
-    // Use a no-space string so userEvent.type count is deterministic
-    await userEvent.type(
-      screen.getByTestId("feedback-description"),
-      "HelloWorld"
-    );
+    // Use fireEvent.change for deterministic character count across environments
+    const textarea = screen.getByTestId("feedback-description");
+    fireEvent.change(textarea, { target: { value: "HelloWorld" } });
     const counter = document.getElementById("feedback-desc-counter");
     expect(counter?.textContent).toMatch(/10/);
   });

--- a/apps/web/src/__tests__/feedback/submitFeedback.test.ts
+++ b/apps/web/src/__tests__/feedback/submitFeedback.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// We test the pure GitHub API logic by importing and exercising submitFeedback
+// with a mocked global fetch. The "use server" directive is a no-op in tests.
+
+vi.mock("@/lib/actions/feedback", async (importOriginal) => {
+  // Re-export real implementation so we can spy on fetch
+  return await importOriginal();
+});
+
+import { submitFeedback } from "@/lib/actions/feedback";
+
+const BASE_PARAMS = {
+  title: "Test issue title",
+  description: "This is a sufficiently long description for the test case here.",
+  category: "bug" as const,
+  pathname: "/exam",
+  userAgent: "Mozilla/5.0 (Test Browser)",
+  deviceType: "Desktop" as const,
+};
+
+beforeEach(() => {
+  // Default: token is set
+  vi.stubEnv("GITHUB_TOKEN", "ghp_testtoken");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("submitFeedback — happy path", () => {
+  it("returns issueNumber when GitHub API responds 201", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ number: 42 }),
+      })
+    );
+
+    const result = await submitFeedback(BASE_PARAMS);
+    expect(result.issueNumber).toBe(42);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("sends correct labels for bug category", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ number: 1 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await submitFeedback({ ...BASE_PARAMS, category: "bug" });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.labels).toContain("bug");
+    expect(body.labels).toContain("user-feedback");
+  });
+
+  it("sends correct labels for feature category", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ number: 2 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await submitFeedback({ ...BASE_PARAMS, category: "feature" });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.labels).toContain("enhancement");
+  });
+
+  it("sends correct labels for question category", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ number: 3 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await submitFeedback({ ...BASE_PARAMS, category: "question" });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.labels).toContain("question");
+  });
+
+  it("includes route, user-agent, device, and commit SHA in body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ number: 5 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await submitFeedback(BASE_PARAMS);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.body).toContain("/exam");
+    expect(body.body).toContain("Desktop");
+    expect(body.body).toContain("Mozilla");
+  });
+});
+
+describe("submitFeedback — error cases", () => {
+  it("returns specific error when GITHUB_TOKEN is missing", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "");
+
+    const result = await submitFeedback(BASE_PARAMS);
+    expect(result.error).toMatch(/token not configured/i);
+    expect(result.issueNumber).toBeUndefined();
+  });
+
+  it("returns error message on 401 response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: async () => "Unauthorized",
+      })
+    );
+
+    const result = await submitFeedback(BASE_PARAMS);
+    expect(result.error).toMatch(/invalid or expired/i);
+  });
+
+  it("returns error message on 422 response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        text: async () => "Unprocessable Entity",
+      })
+    );
+
+    const result = await submitFeedback(BASE_PARAMS);
+    expect(result.error).toMatch(/invalid issue data/i);
+  });
+
+  it("returns error message on 5xx response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => "Internal Server Error",
+      })
+    );
+
+    const result = await submitFeedback(BASE_PARAMS);
+    expect(result.error).toMatch(/500/);
+  });
+
+  it("returns timeout error on AbortError", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(
+        Object.assign(new Error("The operation was aborted"), {
+          name: "AbortError",
+        })
+      )
+    );
+
+    const result = await submitFeedback(BASE_PARAMS);
+    expect(result.error).toMatch(/timed out/i);
+  });
+
+  it("returns generic error on unexpected exception", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("Network failure"))
+    );
+
+    const result = await submitFeedback(BASE_PARAMS);
+    expect(result.error).toBe("Network failure");
+  });
+});

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { DM_Sans, Instrument_Serif, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
+import { FeedbackFAB } from "@/components/FeedbackFAB";
 
 const sans = DM_Sans({
   subsets: ["latin"],
@@ -54,6 +55,7 @@ export default function RootLayout({
           </main>
           <Footer />
         </div>
+        <FeedbackFAB />
       </body>
     </html>
   );

--- a/apps/web/src/components/FeedbackFAB.tsx
+++ b/apps/web/src/components/FeedbackFAB.tsx
@@ -1,0 +1,458 @@
+"use client";
+
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  type FormEvent,
+} from "react";
+import { usePathname } from "next/navigation";
+import { submitFeedback, type FeedbackCategory } from "@/lib/actions/feedback";
+
+const MAX_TITLE_LENGTH = 80;
+const MIN_DESCRIPTION_LENGTH = 20;
+
+type ModalState = "idle" | "submitting" | "success" | "error";
+
+const CATEGORIES: { value: FeedbackCategory; label: string }[] = [
+  { value: "bug", label: "Bug" },
+  { value: "feature", label: "Feature Request" },
+  { value: "question", label: "Question" },
+];
+
+export function FeedbackFAB() {
+  const pathname = usePathname();
+
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [category, setCategory] = useState<FeedbackCategory>("bug");
+  const [modalState, setModalState] = useState<ModalState>("idle");
+  const [issueNumber, setIssueNumber] = useState<number | null>(null);
+  const [apiError, setApiError] = useState<string | null>(null);
+  const [titleError, setTitleError] = useState<string | null>(null);
+  const [descError, setDescError] = useState<string | null>(null);
+
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const firstFocusableRef = useRef<HTMLInputElement>(null);
+
+  const resetForm = useCallback(() => {
+    setTitle("");
+    setDescription("");
+    setCategory("bug");
+    setModalState("idle");
+    setIssueNumber(null);
+    setApiError(null);
+    setTitleError(null);
+    setDescError(null);
+  }, []);
+
+  const openModal = useCallback(() => {
+    resetForm();
+    setOpen(true);
+  }, [resetForm]);
+
+  const closeModal = useCallback(() => {
+    setOpen(false);
+    resetForm();
+  }, [resetForm]);
+
+  // Focus trap: move focus into dialog when it opens
+  useEffect(() => {
+    if (open) {
+      // Timeout allows the dialog to render before focusing
+      const id = setTimeout(() => firstFocusableRef.current?.focus(), 50);
+      return () => clearTimeout(id);
+    }
+  }, [open]);
+
+  // Escape key closes modal
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeModal();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, closeModal]);
+
+  // Trap focus inside dialog
+  useEffect(() => {
+    if (!open || !dialogRef.current) return;
+    const dialog = dialogRef.current;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), input, textarea, select, [tabindex]:not([tabindex="-1"])'
+        )
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    dialog.addEventListener("keydown", onKeyDown);
+    return () => dialog.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    let valid = true;
+    if (!title.trim()) {
+      setTitleError("Title is required.");
+      valid = false;
+    } else if (title.length > MAX_TITLE_LENGTH) {
+      setTitleError(`Title must be ${MAX_TITLE_LENGTH} characters or fewer.`);
+      valid = false;
+    }
+
+    if (description.length < MIN_DESCRIPTION_LENGTH) {
+      setDescError(
+        `Description must be at least ${MIN_DESCRIPTION_LENGTH} characters.`
+      );
+      valid = false;
+    }
+
+    if (!valid) return;
+
+    setModalState("submitting");
+    setApiError(null);
+
+    const ua = navigator.userAgent;
+    const deviceType = /Mobi|Android/i.test(ua)
+      ? "Mobile"
+      : /Tablet|iPad/i.test(ua)
+        ? "Tablet"
+        : "Desktop";
+
+    const result = await submitFeedback({
+      title: title.trim(),
+      description,
+      category,
+      pathname,
+      userAgent: ua,
+      deviceType,
+    });
+
+    if (result.error) {
+      setApiError(result.error);
+      setModalState("error");
+    } else {
+      setIssueNumber(result.issueNumber ?? null);
+      setModalState("success");
+    }
+  };
+
+  const handleRetry = () => {
+    setModalState("idle");
+    setApiError(null);
+  };
+
+  return (
+    <>
+      <button
+        data-testid="feedback-fab"
+        onClick={openModal}
+        aria-label="Send feedback"
+        className={[
+          "fixed z-50 flex items-center justify-center",
+          "w-14 h-14 rounded-full shadow-lg",
+          "bg-brand-600 text-white",
+          "hover:bg-brand-700 active:scale-95 transition-all duration-200",
+          "bottom-6 right-4 md:right-6",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2",
+        ].join(" ")}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="w-6 h-6"
+          aria-hidden="true"
+        >
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-[70] flex items-end sm:items-center justify-center"
+          role="presentation"
+        >
+          {/* Scrim */}
+          <div
+            className="absolute inset-0 bg-neutral-900/50"
+            onClick={closeModal}
+            aria-hidden="true"
+          />
+
+          {/* Dialog */}
+          <dialog
+            ref={dialogRef}
+            open
+            data-testid="feedback-modal"
+            aria-modal="true"
+            aria-labelledby="feedback-modal-title"
+            className={[
+              "relative z-10 bg-surface rounded-t-2xl sm:rounded-2xl",
+              "w-full sm:max-w-lg max-h-[90vh] overflow-y-auto",
+              "p-6 shadow-xl",
+              "flex flex-col gap-4",
+              "m-0",
+            ].join(" ")}
+          >
+            {modalState === "success" ? (
+              <div
+                data-testid="feedback-success"
+                className="flex flex-col items-center gap-4 py-4 text-center"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  className="w-12 h-12 text-success"
+                  aria-hidden="true"
+                >
+                  <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+                  <polyline points="22 4 12 14.01 9 11.01" />
+                </svg>
+                <h2 className="text-xl font-semibold text-text-primary">
+                  Feedback submitted
+                </h2>
+                {issueNumber !== null && (
+                  <p
+                    data-testid="feedback-issue-number"
+                    className="text-text-secondary text-sm"
+                  >
+                    Tracked as issue{" "}
+                    <a
+                      href={`https://github.com/kirankbs/fastrack-deutsch/issues/${issueNumber}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-brand-500 underline hover:text-brand-600"
+                    >
+                      #{issueNumber}
+                    </a>
+                  </p>
+                )}
+                <button
+                  data-testid="feedback-close-success"
+                  onClick={closeModal}
+                  className="mt-2 min-h-[44px] px-6 py-2 rounded-xl bg-brand-600 text-white font-semibold hover:bg-brand-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
+                >
+                  Close
+                </button>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                <h2
+                  id="feedback-modal-title"
+                  className="text-xl font-semibold text-text-primary"
+                >
+                  Send Feedback
+                </h2>
+
+                {/* Title */}
+                <div className="flex flex-col gap-1">
+                  <label
+                    htmlFor="feedback-title-input"
+                    className="text-sm font-medium text-text-secondary"
+                  >
+                    Title <span aria-hidden="true">*</span>
+                  </label>
+                  <input
+                    id="feedback-title-input"
+                    ref={firstFocusableRef}
+                    data-testid="feedback-title"
+                    type="text"
+                    value={title}
+                    maxLength={MAX_TITLE_LENGTH}
+                    onChange={(e) => {
+                      setTitle(e.target.value);
+                      if (titleError && e.target.value.trim()) {
+                        setTitleError(null);
+                      }
+                    }}
+                    placeholder="Brief summary"
+                    required
+                    aria-required="true"
+                    aria-describedby={titleError ? "feedback-title-error" : undefined}
+                    className={[
+                      "w-full min-h-[44px] rounded-xl border px-3 py-2 text-text-primary bg-surface",
+                      "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+                      titleError ? "border-error" : "border-border",
+                    ].join(" ")}
+                  />
+                  <div className="flex justify-between items-center">
+                    {titleError ? (
+                      <p
+                        id="feedback-title-error"
+                        role="alert"
+                        className="text-error text-xs"
+                      >
+                        {titleError}
+                      </p>
+                    ) : (
+                      <span />
+                    )}
+                    <span className="text-xs text-text-tertiary">
+                      {title.length}/{MAX_TITLE_LENGTH}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Description */}
+                <div className="flex flex-col gap-1">
+                  <label
+                    htmlFor="feedback-description-input"
+                    className="text-sm font-medium text-text-secondary"
+                  >
+                    Description <span aria-hidden="true">*</span>
+                  </label>
+                  <textarea
+                    id="feedback-description-input"
+                    data-testid="feedback-description"
+                    value={description}
+                    onChange={(e) => {
+                      setDescription(e.target.value);
+                      if (
+                        descError &&
+                        e.target.value.length >= MIN_DESCRIPTION_LENGTH
+                      ) {
+                        setDescError(null);
+                      }
+                    }}
+                    placeholder="Describe the issue or idea in detail (min. 20 characters)"
+                    rows={4}
+                    required
+                    aria-required="true"
+                    aria-describedby="feedback-desc-counter"
+                    className={[
+                      "w-full rounded-xl border px-3 py-2 text-text-primary bg-surface",
+                      "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+                      "resize-none",
+                      descError ? "border-error" : "border-border",
+                    ].join(" ")}
+                  />
+                  <div className="flex justify-between items-center">
+                    {descError ? (
+                      <p
+                        role="alert"
+                        className="text-error text-xs"
+                      >
+                        {descError}
+                      </p>
+                    ) : (
+                      <span />
+                    )}
+                    <span
+                      id="feedback-desc-counter"
+                      className="text-xs text-text-tertiary"
+                      aria-live="polite"
+                    >
+                      {description.length} chars
+                      {description.length < MIN_DESCRIPTION_LENGTH && (
+                        <span className="text-warning">
+                          {" "}
+                          (min {MIN_DESCRIPTION_LENGTH})
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Category */}
+                <div className="flex flex-col gap-1">
+                  <label
+                    htmlFor="feedback-category-select"
+                    className="text-sm font-medium text-text-secondary"
+                  >
+                    Category
+                  </label>
+                  <select
+                    id="feedback-category-select"
+                    data-testid="feedback-category"
+                    value={category}
+                    onChange={(e) =>
+                      setCategory(e.target.value as FeedbackCategory)
+                    }
+                    className="w-full min-h-[44px] rounded-xl border border-border px-3 py-2 text-text-primary bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+                  >
+                    {CATEGORIES.map((c) => (
+                      <option key={c.value} value={c.value}>
+                        {c.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* API error */}
+                {modalState === "error" && apiError && (
+                  <div
+                    role="alert"
+                    data-testid="feedback-error-banner"
+                    className="rounded-xl bg-error-surface px-4 py-3 flex flex-col gap-1"
+                  >
+                    <p className="text-error font-semibold text-sm">
+                      Something went wrong
+                    </p>
+                    <p className="text-error text-xs">{apiError}</p>
+                  </div>
+                )}
+
+                {/* Actions */}
+                <div className="flex gap-3 justify-end pt-1">
+                  <button
+                    type="button"
+                    data-testid="feedback-cancel"
+                    onClick={closeModal}
+                    className="min-h-[44px] px-4 py-2 rounded-xl font-medium text-text-secondary hover:bg-surface-container transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
+                  >
+                    Cancel
+                  </button>
+
+                  {modalState === "error" ? (
+                    <button
+                      type="button"
+                      data-testid="feedback-retry"
+                      onClick={handleRetry}
+                      className="min-h-[44px] px-4 py-2 rounded-xl bg-brand-600 text-white font-medium hover:bg-brand-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
+                    >
+                      Retry
+                    </button>
+                  ) : (
+                    <button
+                      type="submit"
+                      data-testid="feedback-submit"
+                      disabled={modalState === "submitting"}
+                      className="min-h-[44px] px-4 py-2 rounded-xl bg-brand-600 text-white font-medium hover:bg-brand-700 transition-colors disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
+                    >
+                      {modalState === "submitting" ? "Submitting..." : "Submit"}
+                    </button>
+                  )}
+                </div>
+              </form>
+            )}
+          </dialog>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/lib/actions/feedback.ts
+++ b/apps/web/src/lib/actions/feedback.ts
@@ -1,0 +1,99 @@
+"use server";
+
+export type FeedbackCategory = "bug" | "feature" | "question";
+
+const CATEGORY_LABELS: Record<FeedbackCategory, string> = {
+  bug: "bug",
+  feature: "enhancement",
+  question: "question",
+};
+
+export interface FeedbackParams {
+  title: string;
+  description: string;
+  category: FeedbackCategory;
+  pathname: string;
+  userAgent: string;
+  deviceType: "Mobile" | "Tablet" | "Desktop";
+}
+
+export interface FeedbackResult {
+  issueNumber?: number;
+  error?: string;
+}
+
+const COMMIT_SHA =
+  process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ?? "dev";
+
+export async function submitFeedback(
+  params: FeedbackParams
+): Promise<FeedbackResult> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    return { error: "Feedback is unavailable — GitHub token not configured." };
+  }
+
+  const { title, description, category, pathname, userAgent, deviceType } =
+    params;
+
+  const timestamp = new Date().toISOString();
+  const label = CATEGORY_LABELS[category];
+
+  const body = [
+    `**Description:**\n${description}`,
+    `**Route:** \`${pathname}\``,
+    `**App version:** ${COMMIT_SHA}`,
+    `**Browser:** ${userAgent.slice(0, 120)}`,
+    `**Device:** ${deviceType}`,
+    `**Submitted at:** ${timestamp}`,
+  ].join("\n\n");
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+
+  try {
+    const response = await fetch(
+      "https://api.github.com/repos/kirankbs/fastrack-deutsch/issues",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        body: JSON.stringify({
+          title,
+          body,
+          labels: [label, "user-feedback"],
+        }),
+        signal: controller.signal,
+      }
+    );
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        return { error: "GitHub token is invalid or expired." };
+      }
+      if (response.status === 422) {
+        return { error: "Invalid issue data — please check your inputs." };
+      }
+      const text = await response.text().catch(() => "");
+      return {
+        error: `GitHub API error ${response.status}: ${text.slice(0, 200)}`,
+      };
+    }
+
+    const data = (await response.json()) as { number: number };
+    return { issueNumber: data.number };
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { error: "Request timed out. Please try again." };
+    }
+    return {
+      error: err instanceof Error ? err.message : "An unexpected error occurred.",
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a globally-mounted `FeedbackFAB` component (fixed bottom-right) with a `<dialog>` modal containing title (max 80 chars), description (min 20, live counter), and category (Bug / Feature / Question) fields
- Server action (`lib/actions/feedback.ts`) builds issue body with route, UA, device type, and commit SHA, then POSTs to GitHub REST API with a 10 s `AbortController` timeout; gracefully returns a friendly error if `GITHUB_TOKEN` is missing
- 28 new tests (11 unit for server action, 17 component) covering happy path, validation, error states, retry, double-click prevention, a11y attributes, and focus management

## Test plan

- [ ] FAB renders on every page (mounted in root layout)
- [ ] Modal opens on FAB click; closes on Cancel and Escape
- [ ] Title required, max 80 chars; description min 20 chars with live counter
- [ ] Category select maps to correct GitHub label (bug / enhancement / question)
- [ ] Submit disabled while in-flight (double-click prevention)
- [ ] Success state shows issue number with link
- [ ] Error state shows banner with message + Retry button
- [ ] Missing `GITHUB_TOKEN` returns friendly error (feature degrades, no crash)
- [ ] 401 / 422 / 5xx responses return typed error strings
- [ ] Timeout (AbortError) returns "timed out" error
- [ ] `aria-modal`, `aria-labelledby`, `role="alert"` on errors, 44px touch targets
- [ ] `pnpm typecheck && pnpm test && pnpm build` all green

Closes #84