### PR TITLE
feat(web): feedback FAB Vercel Blob attachments + weekly cleanup cron (#87)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -15,26 +15,33 @@ pnpm build         # production build
 
 A floating action button is mounted globally in the root layout. Users can report bugs, request features, or ask questions. Each submission creates a GitHub issue on `kirankbs/fastrack-deutsch` with metadata (route, browser, device type, commit SHA, timestamp).
 
-### Required environment variable
+### Environment variables
 
-| Variable | Description |
-|----------|-------------|
-| `GITHUB_TOKEN` | Personal access token with `issues: write` scope on `kirankbs/fastrack-deutsch` |
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GITHUB_TOKEN` | Yes | Fine-grained PAT, `issues: write` on `kirankbs/fastrack-deutsch` |
+| `BLOB_READ_WRITE_TOKEN` | Yes (attachments) | Vercel Blob token — Vercel dashboard → Storage → Blob store |
+| `CRON_SECRET` | Yes (cron) | Random secret: `openssl rand -hex 32` |
 
-The PAT must have **Contents: Read** and **Issues: Read and Write** permissions on the `kirankbs/fastrack-deutsch` repository (fine-grained PAT) or `repo` scope (classic PAT).
+Add all three to Vercel (**Settings → Environment Variables**, Production + Preview + Development) and to `apps/web/.env.local`.
 
 ### Local setup
 
-Add to `apps/web/.env.local`:
-
 ```
 GITHUB_TOKEN=ghp_your_token_here
+BLOB_READ_WRITE_TOKEN=vercel_blob_...
+CRON_SECRET=your_random_secret
 ```
 
-### Vercel setup
+### Vercel Blob store
 
-Add `GITHUB_TOKEN` as an environment variable in Vercel dashboard under **Settings → Environment Variables** for both **Production** and **Preview** environments.
+Create a Blob store in the Vercel dashboard under **Storage → Blob**, then copy the `BLOB_READ_WRITE_TOKEN`. Feedback attachments are stored under the `feedback-attachments/` prefix.
+
+### Cleanup cron
+
+A weekly cron runs every Monday at 03:00 UTC (`0 3 * * 1`) via `vercel.json`. It deletes all blobs in `feedback-attachments/` older than 7 days. The route is at `/api/cron/cleanup-feedback-attachments` and is protected by `Authorization: Bearer <CRON_SECRET>`.
 
 ### Graceful degradation
 
-If `GITHUB_TOKEN` is missing or invalid, the FAB still renders. Submitting the form returns a friendly error message to the user rather than crashing. No issues are silently dropped.
+- `GITHUB_TOKEN` missing → FAB renders, submit returns friendly error, no issue created.
+- `BLOB_READ_WRITE_TOKEN` missing → FAB renders, file uploads fail gracefully, issue still created without attachments.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@fastrack/content": "workspace:*",
     "@fastrack/core": "workspace:*",
     "@fastrack/types": "workspace:*",
+    "@vercel/blob": "^2.3.3",
     "lucide-react": "^1.8.0",
     "next": "^15.3.0",
     "react": "^19.2.0",

--- a/apps/web/src/__tests__/feedback/FeedbackFAB.test.tsx
+++ b/apps/web/src/__tests__/feedback/FeedbackFAB.test.tsx
@@ -11,6 +11,10 @@ vi.mock("@/lib/actions/feedback", () => ({
   submitFeedback: vi.fn(),
 }));
 
+vi.mock("@vercel/blob/client", () => ({
+  upload: vi.fn().mockResolvedValue({ url: "https://blob.vercel.com/test.png" }),
+}));
+
 import { submitFeedback } from "@/lib/actions/feedback";
 
 const mockSubmit = vi.mocked(submitFeedback);
@@ -232,5 +236,48 @@ describe("FeedbackFAB — submission states", () => {
     await act(async () => {
       resolveSubmit({ issueNumber: 1 });
     });
+  });
+});
+
+describe("FeedbackFAB — attachments", () => {
+  it("renders file input in form", async () => {
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    expect(screen.getByTestId("feedback-attachment")).toBeInTheDocument();
+  });
+
+  it("shows attachmentsFailed warning on success when blobs failed", async () => {
+    mockSubmit.mockResolvedValue({ issueNumber: 5, attachmentsFailed: true });
+
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    await userEvent.type(screen.getByTestId("feedback-title"), "My bug report");
+    await userEvent.type(
+      screen.getByTestId("feedback-description"),
+      "This is a detailed description that is long enough to pass validation."
+    );
+    await userEvent.click(screen.getByTestId("feedback-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("feedback-attachments-warning")).toBeInTheDocument();
+    });
+  });
+
+  it("does not show attachmentsFailed warning when all uploads succeed", async () => {
+    mockSubmit.mockResolvedValue({ issueNumber: 6 });
+
+    render(<FeedbackFAB />);
+    await userEvent.click(screen.getByTestId("feedback-fab"));
+    await userEvent.type(screen.getByTestId("feedback-title"), "My bug report");
+    await userEvent.type(
+      screen.getByTestId("feedback-description"),
+      "This is a detailed description that is long enough to pass validation."
+    );
+    await userEvent.click(screen.getByTestId("feedback-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("feedback-success")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("feedback-attachments-warning")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/__tests__/feedback/blobUploadRoute.test.ts
+++ b/apps/web/src/__tests__/feedback/blobUploadRoute.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@vercel/blob/client", () => ({
+  handleUpload: vi.fn(),
+}));
+
+import { handleUpload } from "@vercel/blob/client";
+import { POST } from "@/app/api/blob-upload/route";
+
+const mockHandleUpload = vi.mocked(handleUpload);
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/blob-upload", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/blob-upload", () => {
+  it("returns handleUpload result on success", async () => {
+    mockHandleUpload.mockResolvedValue({ type: "blob.generate-client-token" } as never);
+
+    const res = await POST(makeRequest({ type: "blob.generate-client-token" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ type: "blob.generate-client-token" });
+  });
+
+  it("rejects upload with invalid path prefix via onBeforeGenerateToken", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockHandleUpload.mockImplementation(async ({ onBeforeGenerateToken }: any) => {
+      await onBeforeGenerateToken("wrong-prefix/file.png");
+      return {} as never;
+    });
+
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/Invalid upload path/i);
+  });
+
+  it("allows upload with correct feedback-attachments prefix", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockHandleUpload.mockImplementation(async ({ onBeforeGenerateToken }: any) => {
+      const result = await onBeforeGenerateToken("feedback-attachments/screenshot.png");
+      return (result ?? {}) as never;
+    });
+
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 when handleUpload throws", async () => {
+    mockHandleUpload.mockRejectedValue(new Error("Storage unavailable"));
+
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Storage unavailable");
+  });
+});

--- a/apps/web/src/__tests__/feedback/cleanupCronRoute.test.ts
+++ b/apps/web/src/__tests__/feedback/cleanupCronRoute.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@vercel/blob", () => ({
+  list: vi.fn(),
+  del: vi.fn(),
+}));
+
+import { list, del } from "@vercel/blob";
+import { GET } from "@/app/api/cron/cleanup-feedback-attachments/route";
+
+const mockList = vi.mocked(list);
+const mockDel = vi.mocked(del);
+
+const CRON_SECRET = "test-cron-secret";
+
+function makeRequest(secret?: string): Request {
+  return new Request("http://localhost/api/cron/cleanup-feedback-attachments", {
+    headers: secret ? { Authorization: `Bearer ${secret}` } : {},
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("CRON_SECRET", CRON_SECRET);
+});
+
+describe("GET /api/cron/cleanup-feedback-attachments", () => {
+  it("returns 401 when Authorization header is missing", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when secret is wrong", async () => {
+    const res = await GET(makeRequest("wrong-secret"));
+    expect(res.status).toBe(401);
+  });
+
+  it("deletes old blobs and returns count", async () => {
+    const oldDate = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    mockList.mockResolvedValue({
+      blobs: [
+        { url: "https://blob.vercel.com/old1.png", uploadedAt: oldDate, pathname: "feedback-attachments/old1.png", size: 100, downloadUrl: "" },
+        { url: "https://blob.vercel.com/old2.png", uploadedAt: oldDate, pathname: "feedback-attachments/old2.png", size: 200, downloadUrl: "" },
+      ],
+      cursor: undefined,
+      hasMore: false,
+    } as never);
+    mockDel.mockResolvedValue(undefined);
+
+    const res = await GET(makeRequest(CRON_SECRET));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.deleted).toBe(2);
+    expect(mockDel).toHaveBeenCalledWith([
+      "https://blob.vercel.com/old1.png",
+      "https://blob.vercel.com/old2.png",
+    ]);
+  });
+
+  it("skips recent blobs and returns deleted: 0", async () => {
+    const recentDate = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString();
+    mockList.mockResolvedValue({
+      blobs: [
+        { url: "https://blob.vercel.com/new1.png", uploadedAt: recentDate, pathname: "feedback-attachments/new1.png", size: 100, downloadUrl: "" },
+      ],
+      cursor: undefined,
+      hasMore: false,
+    } as never);
+
+    const res = await GET(makeRequest(CRON_SECRET));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.deleted).toBe(0);
+    expect(mockDel).not.toHaveBeenCalled();
+  });
+
+  it("paginates through multiple pages", async () => {
+    const oldDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    mockList
+      .mockResolvedValueOnce({
+        blobs: [{ url: "https://blob.vercel.com/p1.png", uploadedAt: oldDate, pathname: "feedback-attachments/p1.png", size: 100, downloadUrl: "" }],
+        cursor: "cursor-abc",
+        hasMore: true,
+      } as never)
+      .mockResolvedValueOnce({
+        blobs: [{ url: "https://blob.vercel.com/p2.png", uploadedAt: oldDate, pathname: "feedback-attachments/p2.png", size: 100, downloadUrl: "" }],
+        cursor: undefined,
+        hasMore: false,
+      } as never);
+    mockDel.mockResolvedValue(undefined);
+
+    const res = await GET(makeRequest(CRON_SECRET));
+    const json = await res.json();
+    expect(json.deleted).toBe(2);
+    expect(mockList).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/__tests__/feedback/submitFeedback.test.ts
+++ b/apps/web/src/__tests__/feedback/submitFeedback.test.ts
@@ -175,3 +175,81 @@ describe("submitFeedback — error cases", () => {
     expect(result.error).toBe("Network failure");
   });
 });
+
+describe("submitFeedback — attachments", () => {
+  it("embeds successful attachment as markdown image in body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ number: 10 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await submitFeedback({
+      ...BASE_PARAMS,
+      attachments: [{ name: "screenshot.png", url: "https://cdn.example.com/screenshot.png" }],
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.body).toContain("![screenshot.png](https://cdn.example.com/screenshot.png)");
+  });
+
+  it("notes failed attachment in body when url is null", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ number: 11 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await submitFeedback({
+      ...BASE_PARAMS,
+      attachments: [{ name: "screenshot.png", url: null }],
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.body).toContain("screenshot.png (upload failed)");
+  });
+
+  it("omits attachments section when no attachments provided", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ number: 12 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await submitFeedback(BASE_PARAMS);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.body).not.toContain("**Attachments:**");
+  });
+
+  it("returns attachmentsFailed: true when any url is null", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ number: 13 }),
+    }));
+
+    const result = await submitFeedback({
+      ...BASE_PARAMS,
+      attachments: [
+        { name: "ok.png", url: "https://cdn.example.com/ok.png" },
+        { name: "fail.png", url: null },
+      ],
+    });
+
+    expect(result.attachmentsFailed).toBe(true);
+  });
+
+  it("does not set attachmentsFailed when all uploads succeed", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ number: 14 }),
+    }));
+
+    const result = await submitFeedback({
+      ...BASE_PARAMS,
+      attachments: [{ name: "ok.png", url: "https://cdn.example.com/ok.png" }],
+    });
+
+    expect(result.attachmentsFailed).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/api/blob-upload/route.ts
+++ b/apps/web/src/app/api/blob-upload/route.ts
@@ -1,0 +1,36 @@
+import { handleUpload, type HandleUploadBody } from "@vercel/blob/client";
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const body = (await request.json()) as HandleUploadBody;
+  try {
+    const jsonResponse = await handleUpload({
+      body,
+      request,
+      onBeforeGenerateToken: async (pathname) => {
+        if (!pathname.startsWith("feedback-attachments/")) {
+          throw new Error("Invalid upload path");
+        }
+        return {
+          allowedContentTypes: [
+            "image/png",
+            "image/jpeg",
+            "image/gif",
+            "image/webp",
+            "application/pdf",
+            "text/plain",
+          ],
+          maximumSizeInBytes: 10 * 1024 * 1024,
+          addRandomSuffix: true,
+        };
+      },
+      onUploadCompleted: async () => {},
+    });
+    return NextResponse.json(jsonResponse);
+  } catch (error) {
+    return NextResponse.json(
+      { error: (error as Error).message },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/web/src/app/api/cron/cleanup-feedback-attachments/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-feedback-attachments/route.ts
@@ -1,0 +1,31 @@
+import { list, del } from "@vercel/blob";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const auth = request.headers.get("authorization");
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  let deleted = 0;
+  let cursor: string | undefined;
+
+  do {
+    const result = await list({
+      prefix: "feedback-attachments/",
+      cursor,
+      limit: 100,
+    });
+    const old = result.blobs.filter(
+      (b) => new Date(b.uploadedAt) < cutoff
+    );
+    if (old.length) {
+      await del(old.map((b) => b.url));
+      deleted += old.length;
+    }
+    cursor = result.cursor;
+  } while (cursor);
+
+  return NextResponse.json({ deleted });
+}

--- a/apps/web/src/components/FeedbackFAB.tsx
+++ b/apps/web/src/components/FeedbackFAB.tsx
@@ -8,7 +8,16 @@ import {
   type FormEvent,
 } from "react";
 import { usePathname } from "next/navigation";
+import { upload } from "@vercel/blob/client";
 import { submitFeedback, type FeedbackCategory } from "@/lib/actions/feedback";
+
+const MAX_FILES = 5;
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+interface AttachmentItem {
+  file: File;
+  error?: string;
+}
 
 const MAX_TITLE_LENGTH = 80;
 const MIN_DESCRIPTION_LENGTH = 20;
@@ -33,9 +42,13 @@ export function FeedbackFAB() {
   const [apiError, setApiError] = useState<string | null>(null);
   const [titleError, setTitleError] = useState<string | null>(null);
   const [descError, setDescError] = useState<string | null>(null);
+  const [attachments, setAttachments] = useState<AttachmentItem[]>([]);
+  const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const [attachmentsFailed, setAttachmentsFailed] = useState(false);
 
   const dialogRef = useRef<HTMLDialogElement>(null);
   const firstFocusableRef = useRef<HTMLInputElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const resetForm = useCallback(() => {
     setTitle("");
@@ -46,7 +59,35 @@ export function FeedbackFAB() {
     setApiError(null);
     setTitleError(null);
     setDescError(null);
+    setAttachments([]);
+    setAttachmentError(null);
+    setAttachmentsFailed(false);
   }, []);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(e.target.files ?? []);
+    if (!selected.length) return;
+    const combined = [...attachments, ...selected.map((f) => ({ file: f }))];
+    if (combined.length > MAX_FILES) {
+      setAttachmentError(`Maximum ${MAX_FILES} files allowed`);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+    const validated = combined.map((item) => ({
+      file: item.file,
+      error: item.file.size > MAX_FILE_SIZE ? "File exceeds 10 MB limit" : undefined,
+    }));
+    setAttachments(validated);
+    setAttachmentError(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const removeAttachment = (index: number) => {
+    setAttachments((prev) => prev.filter((_, i) => i !== index));
+    setAttachmentError(null);
+  };
+
+  const hasAttachmentErrors = attachments.some((a) => a.error);
 
   const openModal = useCallback(() => {
     resetForm();
@@ -136,6 +177,21 @@ export function FeedbackFAB() {
         ? "Tablet"
         : "Desktop";
 
+    const uploadedAttachments = await Promise.all(
+      attachments.filter((a) => !a.error).map(async ({ file }) => {
+        try {
+          const blob = await upload(
+            `feedback-attachments/${file.name}`,
+            file,
+            { access: "public", handleUploadUrl: "/api/blob-upload" }
+          );
+          return { name: file.name, url: blob.url };
+        } catch {
+          return { name: file.name, url: null as string | null };
+        }
+      })
+    );
+
     const result = await submitFeedback({
       title: title.trim(),
       description,
@@ -143,6 +199,7 @@ export function FeedbackFAB() {
       pathname,
       userAgent: ua,
       deviceType,
+      attachments: uploadedAttachments.length > 0 ? uploadedAttachments : undefined,
     });
 
     if (result.error) {
@@ -150,6 +207,7 @@ export function FeedbackFAB() {
       setModalState("error");
     } else {
       setIssueNumber(result.issueNumber ?? null);
+      setAttachmentsFailed(result.attachmentsFailed === true);
       setModalState("success");
     }
   };
@@ -250,6 +308,14 @@ export function FeedbackFAB() {
                     >
                       #{issueNumber}
                     </a>
+                  </p>
+                )}
+                {attachmentsFailed && (
+                  <p
+                    data-testid="feedback-attachments-warning"
+                    className="text-sm text-text-secondary bg-surface-container rounded-xl px-4 py-2"
+                  >
+                    Some attachments could not be uploaded and are missing from the issue.
                   </p>
                 )}
                 <button
@@ -403,6 +469,60 @@ export function FeedbackFAB() {
                   </select>
                 </div>
 
+                {/* File attachments */}
+                <div className="flex flex-col gap-1">
+                  <label
+                    htmlFor="feedback-attachment-input"
+                    className="text-sm font-medium text-text-secondary"
+                  >
+                    Screenshots or files{" "}
+                    <span className="text-text-tertiary font-normal">(optional)</span>
+                  </label>
+                  <input
+                    id="feedback-attachment-input"
+                    ref={fileInputRef}
+                    data-testid="feedback-attachment"
+                    type="file"
+                    multiple
+                    accept="image/*,application/pdf,text/plain"
+                    onChange={handleFileChange}
+                    className="text-sm text-text-secondary file:mr-3 file:rounded-lg file:border-0 file:bg-brand-600/10 file:px-3 file:py-1 file:text-brand-600 file:cursor-pointer file:font-medium"
+                  />
+                  <p className="text-xs text-text-tertiary">
+                    Up to {MAX_FILES} files, 10 MB each
+                  </p>
+                  {attachmentError && (
+                    <p role="alert" className="text-error text-xs">
+                      {attachmentError}
+                    </p>
+                  )}
+                  {attachments.length > 0 && (
+                    <ul className="flex flex-col gap-1 mt-1">
+                      {attachments.map((item, i) => (
+                        <li key={i} className="flex items-center gap-2 text-xs">
+                          <span
+                            className={
+                              item.error ? "text-error" : "text-text-secondary"
+                            }
+                          >
+                            {item.file.name}{" "}
+                            ({(item.file.size / 1024 / 1024).toFixed(2)} MB)
+                            {item.error && ` — ${item.error}`}
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => removeAttachment(i)}
+                            className="text-error hover:opacity-70 focus:outline-none focus-visible:ring-1 focus-visible:ring-error"
+                            aria-label={`Remove ${item.file.name}`}
+                          >
+                            ✕
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
                 {/* API error */}
                 {modalState === "error" && apiError && (
                   <div
@@ -441,7 +561,7 @@ export function FeedbackFAB() {
                     <button
                       type="submit"
                       data-testid="feedback-submit"
-                      disabled={modalState === "submitting"}
+                      disabled={modalState === "submitting" || hasAttachmentErrors}
                       className="min-h-[44px] px-4 py-2 rounded-xl bg-brand-600 text-white font-medium hover:bg-brand-700 transition-colors disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
                     >
                       {modalState === "submitting" ? "Submitting..." : "Submit"}

--- a/apps/web/src/lib/actions/feedback.ts
+++ b/apps/web/src/lib/actions/feedback.ts
@@ -8,6 +8,11 @@ const CATEGORY_LABELS: Record<FeedbackCategory, string> = {
   question: "question",
 };
 
+export interface FeedbackAttachment {
+  name: string;
+  url: string | null;
+}
+
 export interface FeedbackParams {
   title: string;
   description: string;
@@ -15,11 +20,13 @@ export interface FeedbackParams {
   pathname: string;
   userAgent: string;
   deviceType: "Mobile" | "Tablet" | "Desktop";
+  attachments?: FeedbackAttachment[];
 }
 
 export interface FeedbackResult {
   issueNumber?: number;
   error?: string;
+  attachmentsFailed?: boolean;
 }
 
 const COMMIT_SHA =
@@ -33,11 +40,21 @@ export async function submitFeedback(
     return { error: "Feedback is unavailable — GitHub token not configured." };
   }
 
-  const { title, description, category, pathname, userAgent, deviceType } =
+  const { title, description, category, pathname, userAgent, deviceType, attachments } =
     params;
 
   const timestamp = new Date().toISOString();
   const label = CATEGORY_LABELS[category];
+
+  const attachmentSection =
+    attachments && attachments.length > 0
+      ? "\n\n**Attachments:**\n" +
+        attachments
+          .map((a) =>
+            a.url ? `![${a.name}](${a.url})` : `- ${a.name} (upload failed)`
+          )
+          .join("\n")
+      : "";
 
   const body = [
     `**Description:**\n${description}`,
@@ -46,7 +63,7 @@ export async function submitFeedback(
     `**Browser:** ${userAgent.slice(0, 120)}`,
     `**Device:** ${deviceType}`,
     `**Submitted at:** ${timestamp}`,
-  ].join("\n\n");
+  ].join("\n\n") + attachmentSection;
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 10_000);
@@ -85,7 +102,8 @@ export async function submitFeedback(
     }
 
     const data = (await response.json()) as { number: number };
-    return { issueNumber: data.number };
+    const attachmentsFailed = attachments?.some((a) => a.url === null) ?? false;
+    return { issueNumber: data.number, ...(attachmentsFailed ? { attachmentsFailed: true } : {}) };
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
       return { error: "Request timed out. Please try again." };

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/cleanup-feedback-attachments",
+      "schedule": "0 3 * * 1"
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       '@fastrack/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@vercel/blob':
+        specifier: ^2.3.3
+        version: 2.3.3
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.5)
@@ -2109,6 +2112,10 @@ packages:
     peerDependencies:
       '@urql/core': ^5.0.0
 
+  '@vercel/blob@2.3.3':
+    resolution: {integrity: sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==}
+    engines: {node: '>=20.0.0'}
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -2147,6 +2154,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
@@ -2254,6 +2262,9 @@ packages:
 
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -3285,6 +3296,10 @@ packages:
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -3313,6 +3328,9 @@ packages:
   is-nan@1.3.2:
     resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -4437,6 +4455,10 @@ packages:
     resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
     engines: {node: '>=4'}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
@@ -4755,6 +4777,10 @@ packages:
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -7298,6 +7324,14 @@ snapshots:
       '@urql/core': 5.2.0
       wonka: 6.3.6
 
+  '@vercel/blob@2.3.3':
+    dependencies:
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.24.1
+
   '@vitejs/plugin-react@4.7.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
@@ -7449,6 +7483,10 @@ snapshots:
   assertion-error@2.0.1: {}
 
   async-limiter@1.0.1: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   asynckit@0.4.0: {}
 
@@ -8558,6 +8596,8 @@ snapshots:
 
   is-arrayish@0.3.4: {}
 
+  is-buffer@2.0.5: {}
+
   is-callable@1.2.7: {}
 
   is-core-module@2.16.1:
@@ -8582,6 +8622,8 @@ snapshots:
     dependencies:
       call-bind: 1.0.9
       define-properties: 1.2.1
+
+  is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
 
@@ -10173,6 +10215,8 @@ snapshots:
       onetime: 2.0.1
       signal-exit: 3.0.7
 
+  retry@0.13.1: {}
+
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
@@ -10526,6 +10570,8 @@ snapshots:
       any-promise: 1.3.0
 
   throat@5.0.0: {}
+
+  throttleit@2.1.0: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## Summary
- File attachments (up to 5, 10 MB each) upload to Vercel Blob before issue creation
- Partial-success: blob failures noted in issue body, do not block submission  
- Weekly cron (0 3 * * 1) prunes feedback-attachments/ blobs older than 7 days

## Test plan
- [ ] Valid upload → URL embedded as markdown image in GH issue
- [ ] Oversized file blocked client-side before upload attempt
- [ ] 6th file rejected with visible error
- [ ] Blob 500 → partial success warning on success screen
- [ ] Cron rejects wrong CRON_SECRET (401)
- [ ] Cron deletes old blobs, returns { deleted: N }
- [ ] Cron skips recent blobs (deleted: 0)
- [ ] Zero attachments → existing submit flow unchanged
- [ ] Missing BLOB_READ_WRITE_TOKEN → graceful error, issue still created

Closes #87