### PR TITLE
fix(web): feedback FAB no longer freezes on server action throw

### DIFF
--- a/apps/web/src/components/FeedbackFAB.tsx
+++ b/apps/web/src/components/FeedbackFAB.tsx
@@ -177,38 +177,49 @@ export function FeedbackFAB() {
         ? "Tablet"
         : "Desktop";
 
-    const uploadedAttachments = await Promise.all(
-      attachments.filter((a) => !a.error).map(async ({ file }) => {
-        try {
-          const blob = await upload(
-            `feedback-attachments/${file.name}`,
-            file,
-            { access: "public", handleUploadUrl: "/api/blob-upload" }
-          );
-          return { name: file.name, url: blob.url };
-        } catch {
-          return { name: file.name, url: null as string | null };
-        }
-      })
-    );
+    try {
+      const uploadedAttachments = await Promise.all(
+        attachments.filter((a) => !a.error).map(async ({ file }) => {
+          try {
+            const blob = await upload(
+              `feedback-attachments/${file.name}`,
+              file,
+              { access: "public", handleUploadUrl: "/api/blob-upload" }
+            );
+            return { name: file.name, url: blob.url };
+          } catch (err) {
+            console.error(`Blob upload failed for ${file.name}:`, err);
+            return { name: file.name, url: null as string | null };
+          }
+        })
+      );
 
-    const result = await submitFeedback({
-      title: title.trim(),
-      description,
-      category,
-      pathname,
-      userAgent: ua,
-      deviceType,
-      attachments: uploadedAttachments.length > 0 ? uploadedAttachments : undefined,
-    });
+      const result = await submitFeedback({
+        title: title.trim(),
+        description,
+        category,
+        pathname,
+        userAgent: ua,
+        deviceType,
+        attachments: uploadedAttachments.length > 0 ? uploadedAttachments : undefined,
+      });
 
-    if (result.error) {
-      setApiError(result.error);
+      if (result.error) {
+        setApiError(result.error);
+        setModalState("error");
+      } else {
+        setIssueNumber(result.issueNumber ?? null);
+        setAttachmentsFailed(result.attachmentsFailed === true);
+        setModalState("success");
+      }
+    } catch (err) {
+      console.error("Feedback submit failed:", err);
+      setApiError(
+        err instanceof Error
+          ? err.message
+          : "Something went wrong. Please try again."
+      );
       setModalState("error");
-    } else {
-      setIssueNumber(result.issueNumber ?? null);
-      setAttachmentsFailed(result.attachmentsFailed === true);
-      setModalState("success");
     }
   };
 


### PR DESCRIPTION
## Problem

Reported by user: submitting feedback with an attachment leaves the modal stuck on "Submitting..." forever. Logs show blob upload succeeds (`/api/blob-upload` → 200) but no follow-up request. No GitHub issue created.

## Root cause

`handleSubmit` in `FeedbackFAB.tsx` had no top-level try/catch. If either the blob `upload()` client call rejects with an uncaught error, or the `submitFeedback` server action throws (e.g. server boundary failure), the modal state never transitions out of `submitting`.

## Fix

Wrap the full submit flow (upload + server action + state transitions) in try/catch. On any unhandled throw: log to console, surface the message in the API error banner, and set modal state to `error` so the user can Retry or Cancel.

## Test plan

- [ ] Submit text-only feedback → issue created, success state shown
- [ ] Submit with image attachment → issue created with embedded image, success state shown
- [ ] Server action throws → modal transitions to error state (no hang)
- [ ] Blob upload throws for one file → URL null, issue created with "(upload failed)" note