### PR TITLE
fix(web): server-side blob upload — unfreezes FAB on mobile + attaches images

### DIFF
--- a/apps/web/src/__tests__/feedback/FeedbackFAB.test.tsx
+++ b/apps/web/src/__tests__/feedback/FeedbackFAB.test.tsx
@@ -11,16 +11,19 @@ vi.mock("@/lib/actions/feedback", () => ({
   submitFeedback: vi.fn(),
 }));
 
-vi.mock("@vercel/blob/client", () => ({
-  upload: vi.fn().mockResolvedValue({ url: "https://blob.vercel.com/test.png" }),
-}));
-
 import { submitFeedback } from "@/lib/actions/feedback";
 
 const mockSubmit = vi.mocked(submitFeedback);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: "https://blob.vercel.com/test.png", name: "test.png" }),
+    })
+  );
 });
 
 describe("FeedbackFAB — open/close", () => {

--- a/apps/web/src/__tests__/feedback/blobUploadRoute.test.ts
+++ b/apps/web/src/__tests__/feedback/blobUploadRoute.test.ts
@@ -1,20 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock("@vercel/blob/client", () => ({
-  handleUpload: vi.fn(),
+vi.mock("@vercel/blob", () => ({
+  put: vi.fn(),
 }));
 
-import { handleUpload } from "@vercel/blob/client";
+import { put } from "@vercel/blob";
 import { POST } from "@/app/api/blob-upload/route";
 
-const mockHandleUpload = vi.mocked(handleUpload);
+const mockPut = vi.mocked(put);
 
-function makeRequest(body: unknown): Request {
-  return new Request("http://localhost/api/blob-upload", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+type MockRequest = {
+  formData: () => Promise<{ get(name: string): File | string | null }>;
+};
+
+function makeRequest(file: File | null): MockRequest {
+  return {
+    formData: async () => ({
+      get: (name: string) => (name === "file" ? file : null),
+    }),
+  };
 }
 
 beforeEach(() => {
@@ -22,44 +26,58 @@ beforeEach(() => {
 });
 
 describe("POST /api/blob-upload", () => {
-  it("returns handleUpload result on success", async () => {
-    mockHandleUpload.mockResolvedValue({ type: "blob.generate-client-token" } as never);
+  it("returns URL on successful upload", async () => {
+    mockPut.mockResolvedValue({
+      url: "https://blob.vercel.com/feedback-attachments/test.png",
+      pathname: "feedback-attachments/test.png",
+      contentDisposition: "inline",
+      contentType: "image/png",
+      downloadUrl: "",
+    } as never);
 
-    const res = await POST(makeRequest({ type: "blob.generate-client-token" }));
+    const file = new File(["hello"], "test.png", { type: "image/png" });
+    const res = await POST(makeRequest(file) as never);
+
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json).toEqual({ type: "blob.generate-client-token" });
+    expect(json.url).toContain("test.png");
+    expect(json.name).toBe("test.png");
   });
 
-  it("rejects upload with invalid path prefix via onBeforeGenerateToken", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mockHandleUpload.mockImplementation(async ({ onBeforeGenerateToken }: any) => {
-      await onBeforeGenerateToken("wrong-prefix/file.png");
-      return {} as never;
-    });
-
-    const res = await POST(makeRequest({}));
+  it("returns 400 when no file is provided", async () => {
+    const res = await POST(makeRequest(null) as never);
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toMatch(/Invalid upload path/i);
+    expect(json.error).toMatch(/no file/i);
   });
 
-  it("allows upload with correct feedback-attachments prefix", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mockHandleUpload.mockImplementation(async ({ onBeforeGenerateToken }: any) => {
-      const result = await onBeforeGenerateToken("feedback-attachments/screenshot.png");
-      return (result ?? {}) as never;
-    });
-
-    const res = await POST(makeRequest({}));
-    expect(res.status).toBe(200);
-  });
-
-  it("returns 400 when handleUpload throws", async () => {
-    mockHandleUpload.mockRejectedValue(new Error("Storage unavailable"));
-
-    const res = await POST(makeRequest({}));
+  it("returns 400 when file exceeds 10 MB", async () => {
+    const big = new File(
+      [new Uint8Array(11 * 1024 * 1024)],
+      "big.png",
+      { type: "image/png" }
+    );
+    const res = await POST(makeRequest(big) as never);
     expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/10 MB/i);
+  });
+
+  it("returns 400 for unsupported content type", async () => {
+    const file = new File(["x"], "bad.exe", {
+      type: "application/x-msdownload",
+    });
+    const res = await POST(makeRequest(file) as never);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/unsupported/i);
+  });
+
+  it("returns 500 when put throws", async () => {
+    mockPut.mockRejectedValue(new Error("Storage unavailable"));
+    const file = new File(["x"], "test.png", { type: "image/png" });
+    const res = await POST(makeRequest(file) as never);
+    expect(res.status).toBe(500);
     const json = await res.json();
     expect(json.error).toBe("Storage unavailable");
   });

--- a/apps/web/src/app/api/blob-upload/route.ts
+++ b/apps/web/src/app/api/blob-upload/route.ts
@@ -1,36 +1,53 @@
-import { handleUpload, type HandleUploadBody } from "@vercel/blob/client";
-import { NextResponse } from "next/server";
+import { put } from "@vercel/blob";
+import { NextResponse, type NextRequest } from "next/server";
 
-export async function POST(request: Request): Promise<NextResponse> {
-  const body = (await request.json()) as HandleUploadBody;
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const ALLOWED_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/gif",
+  "image/webp",
+  "image/heic",
+  "application/pdf",
+  "text/plain",
+];
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
-    const jsonResponse = await handleUpload({
-      body,
-      request,
-      onBeforeGenerateToken: async (pathname) => {
-        if (!pathname.startsWith("feedback-attachments/")) {
-          throw new Error("Invalid upload path");
-        }
-        return {
-          allowedContentTypes: [
-            "image/png",
-            "image/jpeg",
-            "image/gif",
-            "image/webp",
-            "application/pdf",
-            "text/plain",
-          ],
-          maximumSizeInBytes: 10 * 1024 * 1024,
-          addRandomSuffix: true,
-        };
-      },
-      onUploadCompleted: async () => {},
+    const formData = (await request.formData()) as unknown as {
+      get(name: string): File | string | null;
+    };
+    const file = formData.get("file");
+
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: "No file provided" }, { status: 400 });
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json(
+        { error: "File exceeds 10 MB limit" },
+        { status: 400 }
+      );
+    }
+
+    if (file.type && !ALLOWED_TYPES.includes(file.type)) {
+      return NextResponse.json(
+        { error: `Unsupported content type: ${file.type}` },
+        { status: 400 }
+      );
+    }
+
+    const blob = await put(`feedback-attachments/${file.name}`, file, {
+      access: "public",
+      addRandomSuffix: true,
     });
-    return NextResponse.json(jsonResponse);
+
+    return NextResponse.json({ url: blob.url, name: file.name });
   } catch (error) {
     return NextResponse.json(
       { error: (error as Error).message },
-      { status: 400 }
+      { status: 500 }
     );
   }
 }

--- a/apps/web/src/components/FeedbackFAB.tsx
+++ b/apps/web/src/components/FeedbackFAB.tsx
@@ -8,8 +8,36 @@ import {
   type FormEvent,
 } from "react";
 import { usePathname } from "next/navigation";
-import { upload } from "@vercel/blob/client";
 import { submitFeedback, type FeedbackCategory } from "@/lib/actions/feedback";
+
+const UPLOAD_TIMEOUT_MS = 30_000;
+
+async function uploadFile(
+  file: File
+): Promise<{ name: string; url: string | null }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), UPLOAD_TIMEOUT_MS);
+  try {
+    const formData = new FormData();
+    formData.append("file", file);
+    const response = await fetch("/api/blob-upload", {
+      method: "POST",
+      body: formData,
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      console.error(`Blob upload HTTP ${response.status} for ${file.name}`);
+      return { name: file.name, url: null };
+    }
+    const data = (await response.json()) as { url?: string };
+    return { name: file.name, url: data.url ?? null };
+  } catch (err) {
+    console.error(`Blob upload failed for ${file.name}:`, err);
+    return { name: file.name, url: null };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
 
 const MAX_FILES = 5;
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
@@ -179,19 +207,7 @@ export function FeedbackFAB() {
 
     try {
       const uploadedAttachments = await Promise.all(
-        attachments.filter((a) => !a.error).map(async ({ file }) => {
-          try {
-            const blob = await upload(
-              `feedback-attachments/${file.name}`,
-              file,
-              { access: "public", handleUploadUrl: "/api/blob-upload" }
-            );
-            return { name: file.name, url: blob.url };
-          } catch (err) {
-            console.error(`Blob upload failed for ${file.name}:`, err);
-            return { name: file.name, url: null as string | null };
-          }
-        })
+        attachments.filter((a) => !a.error).map(({ file }) => uploadFile(file))
       );
 
       const result = await submitFeedback({


### PR DESCRIPTION
## Problem

Reported by user: on mobile Chrome, submitting feedback with an image attachment leaves the modal stuck on "Submitting...". The GitHub issue eventually gets created (after a long delay) but without the image embedded. Desktop works.

## Root cause

`@vercel/blob/client`'s `upload()` uses a 3-step flow: (1) fetch client token from our handler, (2) direct browser→Vercel Blob storage PUT, (3) completion webhook. Step 2 hangs on some mobile networks — the `upload()` promise doesn't reject fast, so `handleSubmit` stays in `submitting` state until the browser gives up.

## Fix

Switch to server-side upload — no client SDK, no direct-to-storage PUT, no webhooks.

- Client sends the file as `FormData` to `/api/blob-upload`
- Route uses `put()` from `@vercel/blob` to store the file
- Route returns `{ url, name }`
- Client adds 30s `AbortController` timeout as a safety net — if the server-side upload fails or is slow, attachment falls through to `url: null` (issue still created with "(upload failed)" note), modal never freezes

Trade-off: file now goes through our server (2× bandwidth). Negligible for 10 MB max. Also lets us validate content-type and size server-side (now includes `image/heic` for iPhone screenshots).

## Test plan

- [x] Unit tests updated (5 route tests, component tests mock `fetch` instead of `upload`)
- [ ] Submit feedback with image on mobile Chrome → issue created + image embedded, modal shows success
- [ ] Submit feedback on desktop Chrome → same as above
- [ ] Submit with a >10 MB file → blocked client-side before upload
- [ ] Submit with a .heic from iPhone → uploads, embedded as markdown image

Closes user-reported bug.