### PR TITLE
fix(web): diagnostic logging on blob-upload 500 + explicit token

### DIFF
--- a/apps/web/src/__tests__/feedback/blobUploadRoute.test.ts
+++ b/apps/web/src/__tests__/feedback/blobUploadRoute.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@vercel/blob", () => ({
   put: vi.fn(),
@@ -23,6 +23,11 @@ function makeRequest(file: File | null): MockRequest {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.stubEnv("BLOB_READ_WRITE_TOKEN", "vercel_blob_test_token");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 describe("POST /api/blob-upload", () => {
@@ -79,6 +84,16 @@ describe("POST /api/blob-upload", () => {
     const res = await POST(makeRequest(file) as never);
     expect(res.status).toBe(500);
     const json = await res.json();
-    expect(json.error).toBe("Storage unavailable");
+    expect(json.error).toMatch(/Storage unavailable/);
+    expect(json.stage).toBe("put");
+  });
+
+  it("returns 500 when BLOB_READ_WRITE_TOKEN is missing", async () => {
+    vi.stubEnv("BLOB_READ_WRITE_TOKEN", "");
+    const file = new File(["x"], "test.png", { type: "image/png" });
+    const res = await POST(makeRequest(file) as never);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/not configured/i);
   });
 });

--- a/apps/web/src/app/api/blob-upload/route.ts
+++ b/apps/web/src/app/api/blob-upload/route.ts
@@ -13,40 +13,73 @@ const ALLOWED_TYPES = [
   "text/plain",
 ];
 
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!token) {
+    console.error("[blob-upload] BLOB_READ_WRITE_TOKEN is not set");
+    return NextResponse.json(
+      { error: "Blob storage not configured (missing token)" },
+      { status: 500 }
+    );
+  }
+
+  let file: File | null = null;
   try {
     const formData = (await request.formData()) as unknown as {
       get(name: string): File | string | null;
     };
-    const file = formData.get("file");
+    const entry = formData.get("file");
+    if (entry instanceof File) file = entry;
+  } catch (error) {
+    console.error("[blob-upload] formData parse failed:", error);
+    return NextResponse.json(
+      {
+        error: `Failed to parse upload: ${(error as Error).message}`,
+        stage: "formData",
+      },
+      { status: 500 }
+    );
+  }
 
-    if (!(file instanceof File)) {
-      return NextResponse.json({ error: "No file provided" }, { status: 400 });
-    }
+  if (!file) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  }
 
-    if (file.size > MAX_FILE_SIZE) {
-      return NextResponse.json(
-        { error: "File exceeds 10 MB limit" },
-        { status: 400 }
-      );
-    }
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json(
+      { error: "File exceeds 10 MB limit" },
+      { status: 400 }
+    );
+  }
 
-    if (file.type && !ALLOWED_TYPES.includes(file.type)) {
-      return NextResponse.json(
-        { error: `Unsupported content type: ${file.type}` },
-        { status: 400 }
-      );
-    }
+  if (file.type && !ALLOWED_TYPES.includes(file.type)) {
+    return NextResponse.json(
+      { error: `Unsupported content type: ${file.type}` },
+      { status: 400 }
+    );
+  }
 
+  try {
+    console.log(
+      `[blob-upload] put ${file.name} size=${file.size} type=${file.type}`
+    );
     const blob = await put(`feedback-attachments/${file.name}`, file, {
       access: "public",
       addRandomSuffix: true,
+      token,
     });
-
+    console.log(`[blob-upload] success url=${blob.url}`);
     return NextResponse.json({ url: blob.url, name: file.name });
   } catch (error) {
+    console.error("[blob-upload] put() failed:", error);
     return NextResponse.json(
-      { error: (error as Error).message },
+      {
+        error: `Blob upload failed: ${(error as Error).message}`,
+        stage: "put",
+      },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Context

Blob upload returns 500 on mobile production. Vercel log shows function ran for 450ms with zero outgoing API calls — meaning `put()` threw (or something before it) without reaching Vercel Blob. Current catch block swallows the error without logging, so we can't see what failed.

## Changes

- `console.error` / `console.log` at every failure/success point so errors surface in Vercel function logs
- Up-front check for `BLOB_READ_WRITE_TOKEN` presence
- Pass `token` explicitly to `put()` (defensive — should be auto-detected but this rules out env discovery issues)
- Return `{ stage: 'formData' | 'put' }` in the error body so we know which phase failed
- `export const maxDuration = 60` for large images on slow mobile networks

This does NOT fix the 500 directly — it surfaces the root cause so we can fix the next PR with full visibility.

## Test plan

- [ ] Merge + redeploy
- [ ] Reproduce on mobile with image attachment
- [ ] Check Vercel function logs for `[blob-upload]` lines
- [ ] Share the actual error to diagnose