### PR TITLE
fix(web): wire up mobile hamburger menu (closes #96, #86, #90, #91, #93, #95)

### DIFF
--- a/apps/web/src/__tests__/NavHeader.test.tsx
+++ b/apps/web/src/__tests__/NavHeader.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NavHeader } from "@/components/NavHeader";
+
+// next/link renders a plain anchor in test env; usePathname provides the current path
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+// next/link just renders its href as an anchor in jsdom
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("NavHeader — hamburger button", () => {
+  it("renders the hamburger button on mobile", () => {
+    render(<NavHeader />);
+    expect(screen.getByTestId("mobile-menu-button")).toBeInTheDocument();
+  });
+
+  it("hamburger button has aria-label 'Menu'", () => {
+    render(<NavHeader />);
+    expect(screen.getByTestId("mobile-menu-button")).toHaveAttribute(
+      "aria-label",
+      "Menu"
+    );
+  });
+
+  it("hamburger has minimum 44px touch target via min-h class", () => {
+    render(<NavHeader />);
+    const btn = screen.getByTestId("mobile-menu-button");
+    expect(btn.className).toMatch(/min-h-\[44px\]/);
+  });
+
+  it("starts with aria-expanded false and menu hidden", () => {
+    render(<NavHeader />);
+    expect(screen.getByTestId("mobile-menu-button")).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+    expect(screen.queryByTestId("mobile-nav-menu")).not.toBeInTheDocument();
+  });
+});
+
+describe("NavHeader — open/close", () => {
+  it("opens menu when hamburger is clicked", async () => {
+    render(<NavHeader />);
+    await userEvent.click(screen.getByTestId("mobile-menu-button"));
+    expect(screen.getByTestId("mobile-nav-menu")).toBeInTheDocument();
+    expect(screen.getByTestId("mobile-menu-button")).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  it("closes menu on second hamburger click (toggle)", async () => {
+    render(<NavHeader />);
+    const btn = screen.getByTestId("mobile-menu-button");
+    await userEvent.click(btn);
+    await userEvent.click(btn);
+    expect(screen.queryByTestId("mobile-nav-menu")).not.toBeInTheDocument();
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("closes menu when Escape is pressed", async () => {
+    render(<NavHeader />);
+    await userEvent.click(screen.getByTestId("mobile-menu-button"));
+    expect(screen.getByTestId("mobile-nav-menu")).toBeInTheDocument();
+
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByTestId("mobile-nav-menu")).not.toBeInTheDocument();
+  });
+
+  it("closes menu when clicking outside", async () => {
+    render(
+      <div>
+        <NavHeader />
+        <div data-testid="outside">Outside area</div>
+      </div>
+    );
+    await userEvent.click(screen.getByTestId("mobile-menu-button"));
+    expect(screen.getByTestId("mobile-nav-menu")).toBeInTheDocument();
+
+    await userEvent.pointer({
+      target: screen.getByTestId("outside"),
+      keys: "[MouseLeft]",
+    });
+    expect(screen.queryByTestId("mobile-nav-menu")).not.toBeInTheDocument();
+  });
+});
+
+describe("NavHeader — nav links", () => {
+  it("renders all four nav links in mobile menu", async () => {
+    render(<NavHeader />);
+    await userEvent.click(screen.getByTestId("mobile-menu-button"));
+
+    expect(
+      screen.getByTestId("mobile-nav-link-dashboard")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("mobile-nav-link-mock-exams")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("mobile-nav-link-vocabulary")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("mobile-nav-link-grammar")
+    ).toBeInTheDocument();
+  });
+
+  it("Dashboard link points to /", async () => {
+    render(<NavHeader />);
+    await userEvent.click(screen.getByTestId("mobile-menu-button"));
+    expect(screen.getByTestId("mobile-nav-link-dashboard")).toHaveAttribute(
+      "href",
+      "/"
+    );
+  });
+
+  it("Mock Exams link points to /exam", async () => {
+    render(<NavHeader />);
+    await userEvent.click(screen.getByTestId("mobile-menu-button"));
+    expect(screen.getByTestId("mobile-nav-link-mock-exams")).toHaveAttribute(
+      "href",
+      "/exam"
+    );
+  });
+
+  it("Vocabulary link points to /vocab", async () => {
+    render(<NavHeader />);
+    await userEvent.click(screen.getByTestId("mobile-menu-button"));
+    expect(screen.getByTestId("mobile-nav-link-vocabulary")).toHaveAttribute(
+      "href",
+      "/vocab"
+    );
+  });
+
+  it("Grammar link points to /grammar", async () => {
+    render(<NavHeader />);
+    await userEvent.click(screen.getByTestId("mobile-menu-button"));
+    expect(screen.getByTestId("mobile-nav-link-grammar")).toHaveAttribute(
+      "href",
+      "/grammar"
+    );
+  });
+
+  it("clicking a link closes the menu", async () => {
+    render(<NavHeader />);
+    await userEvent.click(screen.getByTestId("mobile-menu-button"));
+    await userEvent.click(screen.getByTestId("mobile-nav-link-grammar"));
+    expect(screen.queryByTestId("mobile-nav-menu")).not.toBeInTheDocument();
+  });
+});
+
+describe("NavHeader — accessibility", () => {
+  it("menu panel has role=dialog and aria-label", async () => {
+    render(<NavHeader />);
+    await userEvent.click(screen.getByTestId("mobile-menu-button"));
+    const menu = screen.getByTestId("mobile-nav-menu");
+    expect(menu).toHaveAttribute("role", "dialog");
+    expect(menu).toHaveAttribute("aria-label", "Navigation menu");
+  });
+
+  it("hamburger has aria-controls pointing to menu id", async () => {
+    render(<NavHeader />);
+    expect(screen.getByTestId("mobile-menu-button")).toHaveAttribute(
+      "aria-controls",
+      "mobile-nav-menu"
+    );
+  });
+
+  it("all mobile nav links have min 44px touch target via min-h", async () => {
+    render(<NavHeader />);
+    await userEvent.click(screen.getByTestId("mobile-menu-button"));
+    const links = [
+      screen.getByTestId("mobile-nav-link-dashboard"),
+      screen.getByTestId("mobile-nav-link-mock-exams"),
+      screen.getByTestId("mobile-nav-link-vocabulary"),
+      screen.getByTestId("mobile-nav-link-grammar"),
+    ];
+    links.forEach((link) => {
+      expect(link.className).toMatch(/min-h-\[44px\]/);
+    });
+  });
+});

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { DM_Sans, Instrument_Serif, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { FeedbackFAB } from "@/components/FeedbackFAB";
+import { NavHeader } from "@/components/NavHeader";
 
 const sans = DM_Sans({
   subsets: ["latin"],
@@ -58,57 +59,6 @@ export default function RootLayout({
         <FeedbackFAB />
       </body>
     </html>
-  );
-}
-
-function NavHeader() {
-  return (
-    <header className="sticky top-0 z-50 border-b border-border bg-white/95 backdrop-blur-sm">
-      <nav className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
-        <a href="/" className="flex items-center gap-2">
-          <span className="text-2xl font-semibold text-brand-primary">
-            Fastrack
-          </span>
-          <span className="text-lg font-medium text-text-secondary">
-            Deutsch
-          </span>
-        </a>
-
-        <div className="hidden items-center gap-6 sm:flex">
-          <NavLink href="/">Dashboard</NavLink>
-          <NavLink href="/exam">Mock Exams</NavLink>
-          <NavLink href="/vocab">Vocabulary</NavLink>
-          <NavLink href="/grammar">Grammar</NavLink>
-        </div>
-
-        {/* Mobile hamburger placeholder */}
-        <button
-          className="inline-flex items-center justify-center rounded-md p-2 text-text-secondary hover:bg-surface-container sm:hidden"
-          aria-label="Menu"
-        >
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-            <path d="M3 12h18M3 6h18M3 18h18" />
-          </svg>
-        </button>
-      </nav>
-    </header>
-  );
-}
-
-function NavLink({
-  href,
-  children,
-}: {
-  href: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <a
-      href={href}
-      className="text-sm font-medium text-text-secondary transition-colors hover:text-brand-primary"
-    >
-      {children}
-    </a>
   );
 }
 

--- a/apps/web/src/components/NavHeader.tsx
+++ b/apps/web/src/components/NavHeader.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const NAV_LINKS = [
+  { href: "/", label: "Dashboard" },
+  { href: "/exam", label: "Mock Exams" },
+  { href: "/vocab", label: "Vocabulary" },
+  { href: "/grammar", label: "Grammar" },
+] as const;
+
+export function NavHeader() {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const pathname = usePathname();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const hamburgerRef = useRef<HTMLButtonElement>(null);
+  const firstLinkRef = useRef<HTMLAnchorElement>(null);
+
+  const closeMenu = useCallback(() => setMenuOpen(false), []);
+
+  // Close on route change
+  useEffect(() => {
+    closeMenu();
+  }, [pathname, closeMenu]);
+
+  // Escape key closes
+  useEffect(() => {
+    if (!menuOpen) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        closeMenu();
+        hamburgerRef.current?.focus();
+      }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [menuOpen, closeMenu]);
+
+  // Click outside closes
+  useEffect(() => {
+    if (!menuOpen) return;
+    function onPointer(e: PointerEvent) {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target as Node) &&
+        hamburgerRef.current &&
+        !hamburgerRef.current.contains(e.target as Node)
+      ) {
+        closeMenu();
+      }
+    }
+    document.addEventListener("pointerdown", onPointer);
+    return () => document.removeEventListener("pointerdown", onPointer);
+  }, [menuOpen, closeMenu]);
+
+  // Move focus into menu when it opens
+  useEffect(() => {
+    if (menuOpen) {
+      firstLinkRef.current?.focus();
+    }
+  }, [menuOpen]);
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-border bg-white/95 backdrop-blur-sm">
+      <nav
+        className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8"
+        aria-label="Main navigation"
+      >
+        <Link href="/" className="flex items-center gap-2">
+          <span className="text-2xl font-semibold text-brand-primary">
+            Fastrack
+          </span>
+          <span className="text-lg font-medium text-text-secondary">
+            Deutsch
+          </span>
+        </Link>
+
+        {/* Desktop nav */}
+        <div className="hidden items-center gap-6 sm:flex">
+          {NAV_LINKS.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="text-sm font-medium text-text-secondary transition-colors hover:text-brand-primary"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+
+        {/* Mobile hamburger */}
+        <button
+          ref={hamburgerRef}
+          data-testid="mobile-menu-button"
+          className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md p-2 text-text-secondary hover:bg-surface-container sm:hidden"
+          aria-label="Menu"
+          aria-expanded={menuOpen}
+          aria-controls="mobile-nav-menu"
+          onClick={() => setMenuOpen((prev) => !prev)}
+        >
+          {menuOpen ? (
+            /* X icon when open */
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          ) : (
+            /* Hamburger icon */
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <path d="M3 12h18M3 6h18M3 18h18" />
+            </svg>
+          )}
+        </button>
+      </nav>
+
+      {/* Mobile menu panel */}
+      {menuOpen && (
+        <div
+          id="mobile-nav-menu"
+          ref={menuRef}
+          data-testid="mobile-nav-menu"
+          role="dialog"
+          aria-label="Navigation menu"
+          className="absolute left-0 right-0 top-16 z-40 border-b border-border bg-white shadow-lg sm:hidden"
+        >
+          <nav aria-label="Mobile navigation" className="flex flex-col py-2">
+            {NAV_LINKS.map((link, idx) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                ref={idx === 0 ? firstLinkRef : undefined}
+                data-testid={`mobile-nav-link-${link.label.toLowerCase().replace(/\s+/g, "-")}`}
+                className="min-h-[44px] px-6 py-3 text-base font-medium text-text-secondary transition-colors hover:bg-surface-container hover:text-brand-primary focus:outline-none focus-visible:bg-surface-container focus-visible:text-brand-primary"
+                onClick={closeMenu}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      )}
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary

- Extracts `NavHeader` from `layout.tsx` into `apps/web/src/components/NavHeader.tsx` as a `"use client"` component
- Wires up the mobile hamburger button with open/close state — it was a visual placeholder with no `onClick`
- Mobile menu panel renders all four nav links: Dashboard, Mock Exams, Vocabulary, Grammar
- Close triggers: Escape key, click outside, link navigation
- Full a11y: `aria-expanded`, `aria-controls`, `role="dialog"`, `aria-label`, focus moved to first link on open, focus returned to hamburger on Escape
- Min 44px touch targets on hamburger button and all menu links
- Desktop nav (`sm:` and up) is unchanged

## Issues closed

Closes #96, #86, #90, #91, #93, #95 — all reporting the same non-functional hamburger button.

## Files changed

- `apps/web/src/components/NavHeader.tsx` — new client component
- `apps/web/src/app/layout.tsx` — imports NavHeader, removes inline placeholder
- `apps/web/src/__tests__/NavHeader.test.tsx` — 17 new tests

## Test plan

- [x] `pnpm --filter @fastrack/web build` — clean build, no errors
- [x] `pnpm typecheck` — no new type errors (pre-existing `@vercel/blob` errors unaffected)
- [x] NavHeader tests: 17/17 pass (open, close, Escape, outside click, link list, aria attrs, touch targets)
- [x] All other existing tests continue passing (no regressions)
- [ ] Manual smoke: hamburger opens/closes on mobile viewport, all four links navigate correctly