### PR TITLE
fix(grammar,exam): level-scoped routes, browse-nav, dark mode text (#98, #99, #100)

### DIFF
--- a/apps/web/src/__tests__/grammar/GrammarPageClient.test.tsx
+++ b/apps/web/src/__tests__/grammar/GrammarPageClient.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GrammarPageClient } from '../../../app/grammar/GrammarPageClient';
+
+const levels = [
+  { level: 'A1' as const, color: '#2d8a4e', label: 'Start Deutsch 1', topicCount: 12 },
+  { level: 'B2' as const, color: '#c0390b', label: 'telc Deutsch B2', topicCount: 25 },
+  { level: 'C1' as const, color: '#6b2fa0', label: 'telc Deutsch C1 Hochschule', topicCount: 0 },
+];
+
+describe('GrammarPageClient', () => {
+  it('renders a level card for each level', () => {
+    render(<GrammarPageClient levels={levels} />);
+
+    expect(screen.getByTestId('level-card-A1')).toBeDefined();
+    expect(screen.getByTestId('level-card-B2')).toBeDefined();
+    expect(screen.getByTestId('level-card-C1')).toBeDefined();
+  });
+
+  it('Browse Topics button links to the level page when topics are available', () => {
+    render(<GrammarPageClient levels={levels} />);
+
+    const a1Btn = screen.getByTestId('browse-button-A1');
+    expect(a1Btn.tagName).toBe('A');
+    expect(a1Btn.getAttribute('href')).toBe('/grammar/A1');
+
+    const b2Btn = screen.getByTestId('browse-button-B2');
+    expect(b2Btn.tagName).toBe('A');
+    expect(b2Btn.getAttribute('href')).toBe('/grammar/B2');
+  });
+
+  it('shows Coming Soon button (disabled) when no topics are available', () => {
+    render(<GrammarPageClient levels={levels} />);
+
+    const c1Btn = screen.getByTestId('browse-button-C1');
+    expect(c1Btn.tagName).toBe('BUTTON');
+    expect((c1Btn as HTMLButtonElement).disabled).toBe(true);
+    expect(c1Btn.textContent).toContain('Coming Soon');
+  });
+
+  it('does not render an inline topic list', () => {
+    render(<GrammarPageClient levels={levels} />);
+    expect(screen.queryByTestId('topic-list')).toBeNull();
+  });
+});

--- a/apps/web/src/__tests__/grammar/GrammarPageClient.test.tsx
+++ b/apps/web/src/__tests__/grammar/GrammarPageClient.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { GrammarPageClient } from '../../../app/grammar/GrammarPageClient';
+import { GrammarPageClient } from '../../app/grammar/GrammarPageClient';
 
 const levels = [
   { level: 'A1' as const, color: '#2d8a4e', label: 'Start Deutsch 1', topicCount: 12 },

--- a/apps/web/src/__tests__/grammar/TopicCard.test.tsx
+++ b/apps/web/src/__tests__/grammar/TopicCard.test.tsx
@@ -48,7 +48,7 @@ describe('TopicCard', () => {
     render(<TopicCard topic={mockTopic} levelColor="#4caf50" />);
 
     const link = screen.getByTestId('topic-card-1');
-    expect(link.getAttribute('href')).toBe('/grammar/1');
+    expect(link.getAttribute('href')).toBe('/grammar/A1/1');
   });
 
   it('hides exercise count when no exercises', () => {

--- a/apps/web/src/app/grammar/GrammarPageClient.tsx
+++ b/apps/web/src/app/grammar/GrammarPageClient.tsx
@@ -1,15 +1,13 @@
 'use client';
 
-import { useState } from 'react';
-import type { Level, GrammarTopic } from '@fastrack/types';
-import { TopicCard } from '@/components/grammar/TopicCard';
+import Link from 'next/link';
+import type { Level } from '@fastrack/types';
 
 interface LevelConfig {
   level: Level;
   color: string;
   label: string;
   topicCount: number;
-  topics: GrammarTopic[];
 }
 
 interface GrammarPageClientProps {
@@ -17,9 +15,6 @@ interface GrammarPageClientProps {
 }
 
 export function GrammarPageClient({ levels }: GrammarPageClientProps) {
-  const [selectedLevel, setSelectedLevel] = useState<Level | null>(null);
-  const selected = levels.find((l) => l.level === selectedLevel);
-
   return (
     <div className="space-y-6">
       <div>
@@ -32,16 +27,12 @@ export function GrammarPageClient({ levels }: GrammarPageClientProps) {
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {levels.map(({ level, color, label, topicCount }) => {
           const available = topicCount > 0;
-          const isSelected = selectedLevel === level;
 
           return (
             <div
               key={level}
               data-testid={`level-card-${level}`}
-              className={`rounded-xl border bg-white p-6 transition-shadow ${
-                isSelected ? 'border-2 shadow-md' : 'border-border'
-              }`}
-              style={isSelected ? { borderColor: color } : undefined}
+              className="rounded-xl border border-border bg-surface p-6 transition-shadow hover:shadow-sm"
             >
               <div className="flex items-center gap-3">
                 <span
@@ -62,52 +53,30 @@ export function GrammarPageClient({ levels }: GrammarPageClientProps) {
                 </div>
               </div>
               <div className="mt-4">
-                <button
-                  data-testid={`browse-button-${level}`}
-                  className="w-full rounded-lg px-4 py-2.5 text-sm font-medium text-white transition-colors hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
-                  style={{ backgroundColor: color }}
-                  disabled={!available}
-                  onClick={() =>
-                    setSelectedLevel(isSelected ? null : level)
-                  }
-                >
-                  {!available
-                    ? 'Coming Soon'
-                    : isSelected
-                      ? 'Hide Topics'
-                      : 'Browse Topics'}
-                </button>
+                {available ? (
+                  <Link
+                    href={`/grammar/${level}`}
+                    data-testid={`browse-button-${level}`}
+                    className="block w-full rounded-lg px-4 py-2.5 text-center text-sm font-medium text-white transition-colors hover:opacity-90"
+                    style={{ backgroundColor: color }}
+                  >
+                    Browse Topics
+                  </Link>
+                ) : (
+                  <button
+                    data-testid={`browse-button-${level}`}
+                    className="w-full rounded-lg px-4 py-2.5 text-sm font-medium text-white opacity-50 cursor-not-allowed"
+                    style={{ backgroundColor: color }}
+                    disabled
+                  >
+                    Coming Soon
+                  </button>
+                )}
               </div>
             </div>
           );
         })}
       </div>
-
-      {selected && selected.topics.length > 0 && (
-        <section data-testid="topic-list">
-          <h2 className="mb-3 text-lg font-semibold text-text-primary">
-            {selected.level} Topics
-          </h2>
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {selected.topics.map((topic) => (
-              <TopicCard
-                key={topic.id}
-                topic={topic}
-                levelColor={selected.color}
-              />
-            ))}
-          </div>
-        </section>
-      )}
-
-      {selected && selected.topics.length === 0 && (
-        <div
-          data-testid="no-topics"
-          className="rounded-xl border border-border bg-white p-8 text-center text-text-secondary"
-        >
-          No grammar topics available for {selected.level}.
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/src/app/grammar/[level]/[topicId]/page.tsx
+++ b/apps/web/src/app/grammar/[level]/[topicId]/page.tsx
@@ -1,0 +1,44 @@
+import { notFound } from 'next/navigation';
+import type { Level } from '@fastrack/types';
+import { loadGrammar } from '@/lib/loadGrammar';
+import { TopicDetailPage } from '../../[topicId]/TopicDetailPage';
+
+const VALID_LEVELS: Level[] = ['A1', 'A2', 'B1', 'B2', 'C1'];
+
+interface Props {
+  params: Promise<{ level: string; topicId: string }>;
+}
+
+export default async function GrammarLevelTopicPage({ params }: Props) {
+  const { level: rawLevel, topicId } = await params;
+  const level = rawLevel.toUpperCase() as Level;
+
+  if (!VALID_LEVELS.includes(level)) {
+    notFound();
+  }
+
+  const orderIndex = parseInt(topicId, 10);
+  if (isNaN(orderIndex) || orderIndex < 1) {
+    notFound();
+  }
+
+  const topics = await loadGrammar(level);
+  const topic = topics.find((t) => t.orderIndex === orderIndex);
+  if (!topic) {
+    notFound();
+  }
+
+  const totalTopics = topics.length;
+  const hasPrev = topics.some((t) => t.orderIndex === orderIndex - 1);
+  const hasNext = topics.some((t) => t.orderIndex === orderIndex + 1);
+
+  return (
+    <TopicDetailPage
+      topic={topic}
+      orderIndex={orderIndex}
+      totalTopics={totalTopics}
+      hasPrev={hasPrev}
+      hasNext={hasNext}
+    />
+  );
+}

--- a/apps/web/src/app/grammar/[level]/page.tsx
+++ b/apps/web/src/app/grammar/[level]/page.tsx
@@ -1,0 +1,79 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { LEVEL_CONFIG } from '@fastrack/config';
+import type { Level } from '@fastrack/types';
+import { loadGrammar } from '@/lib/loadGrammar';
+import { TopicCard } from '@/components/grammar/TopicCard';
+
+const VALID_LEVELS: Level[] = ['A1', 'A2', 'B1', 'B2', 'C1'];
+
+interface Props {
+  params: Promise<{ level: string }>;
+}
+
+export default async function GrammarLevelPage({ params }: Props) {
+  const { level: rawLevel } = await params;
+  const level = rawLevel.toUpperCase() as Level;
+
+  if (!VALID_LEVELS.includes(level)) {
+    notFound();
+  }
+
+  const topics = await loadGrammar(level);
+  const cfg = LEVEL_CONFIG[level];
+
+  return (
+    <div className="space-y-6">
+      <nav
+        data-testid="breadcrumb"
+        aria-label="Breadcrumb"
+        className="flex items-center gap-2 text-[13px] text-text-secondary"
+      >
+        <Link
+          href="/grammar"
+          data-testid="back-to-grammar"
+          className="inline-flex items-center gap-1 hover:text-text-primary"
+        >
+          <ArrowLeft size={14} aria-hidden="true" />
+          <span>Grammatik</span>
+        </Link>
+        <span className="text-text-tertiary" aria-hidden="true">
+          /
+        </span>
+        <span className="text-text-primary font-medium">{level}</span>
+      </nav>
+
+      <div className="flex items-center gap-3">
+        <span
+          className="flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold text-white"
+          style={{ backgroundColor: cfg.color }}
+        >
+          {level}
+        </span>
+        <div>
+          <h1 className="text-xl font-bold text-text-primary">{level} Grammar</h1>
+          <p className="text-sm text-text-secondary">{topics.length} topics</p>
+        </div>
+      </div>
+
+      {topics.length > 0 ? (
+        <div
+          data-testid="topic-grid"
+          className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
+        >
+          {topics.map((topic) => (
+            <TopicCard key={topic.id} topic={topic} levelColor={cfg.color} />
+          ))}
+        </div>
+      ) : (
+        <div
+          data-testid="no-topics"
+          className="rounded-xl border border-border bg-surface p-8 text-center text-text-secondary"
+        >
+          No grammar topics available for {level} yet.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/grammar/[topicId]/TopicDetailPage.tsx
+++ b/apps/web/src/app/grammar/[topicId]/TopicDetailPage.tsx
@@ -53,7 +53,13 @@ export function TopicDetailPage({
         <span className="text-text-tertiary" aria-hidden="true">
           /
         </span>
-        <span>{topic.level}</span>
+        <Link
+          href={`/grammar/${topic.level}`}
+          data-testid="back-to-level"
+          className="hover:text-text-primary"
+        >
+          {topic.level}
+        </Link>
         <span className="text-text-tertiary" aria-hidden="true">
           /
         </span>
@@ -94,14 +100,14 @@ export function TopicDetailPage({
         </>
       )}
 
-      {/* Topic navigation footer */}
+      {/* Topic navigation footer — stays within the same level */}
       <div
         className="mt-12 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-6"
       >
         <button
           data-testid="prev-topic"
           disabled={!hasPrev}
-          onClick={() => router.push(`/grammar/${orderIndex - 1}`)}
+          onClick={() => router.push(`/grammar/${topic.level}/${orderIndex - 1}`)}
           className="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-primary transition-colors hover:bg-surface-container disabled:cursor-not-allowed disabled:opacity-40"
         >
           &larr; Zurück
@@ -112,7 +118,7 @@ export function TopicDetailPage({
         <button
           data-testid="next-topic"
           disabled={!hasNext}
-          onClick={() => router.push(`/grammar/${orderIndex + 1}`)}
+          onClick={() => router.push(`/grammar/${topic.level}/${orderIndex + 1}`)}
           className="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-primary transition-colors hover:bg-surface-container disabled:cursor-not-allowed disabled:opacity-40"
         >
           Weiter &rarr;

--- a/apps/web/src/app/grammar/[topicId]/page.tsx
+++ b/apps/web/src/app/grammar/[topicId]/page.tsx
@@ -1,37 +1,11 @@
-import { notFound } from 'next/navigation';
-import { loadGrammar } from '@/lib/loadGrammar';
-import { TopicDetailPage } from './TopicDetailPage';
+import { redirect } from 'next/navigation';
 
 interface Props {
   params: Promise<{ topicId: string }>;
 }
 
-export default async function GrammarTopicPage({ params }: Props) {
+// Legacy route: /grammar/N was always A1. Redirect to the canonical level-scoped URL.
+export default async function GrammarTopicRedirectPage({ params }: Props) {
   const { topicId } = await params;
-  const orderIndex = parseInt(topicId, 10);
-
-  if (isNaN(orderIndex) || orderIndex < 1) {
-    notFound();
-  }
-
-  const topics = await loadGrammar('A1');
-
-  const topic = topics.find((t) => t.orderIndex === orderIndex);
-  if (!topic) {
-    notFound();
-  }
-
-  const totalTopics = topics.length;
-  const hasPrev = orderIndex > 1;
-  const hasNext = topics.some((t) => t.orderIndex === orderIndex + 1);
-
-  return (
-    <TopicDetailPage
-      topic={topic}
-      orderIndex={orderIndex}
-      totalTopics={totalTopics}
-      hasPrev={hasPrev}
-      hasNext={hasNext}
-    />
-  );
+  redirect(`/grammar/A1/${topicId}`);
 }

--- a/apps/web/src/app/grammar/page.tsx
+++ b/apps/web/src/app/grammar/page.tsx
@@ -6,19 +6,17 @@ import { GrammarPageClient } from './GrammarPageClient';
 const levels: Level[] = ['A1', 'A2', 'B1', 'B2', 'C1'];
 
 export default async function GrammarPage() {
-  const topicsByLevel: Record<string, Awaited<ReturnType<typeof loadGrammar>>> = {};
-
-  for (const level of levels) {
-    topicsByLevel[level] = await loadGrammar(level);
-  }
-
-  const levelConfigs = levels.map((level) => ({
-    level,
-    color: LEVEL_CONFIG[level].color,
-    label: LEVEL_CONFIG[level].label,
-    topicCount: topicsByLevel[level].length,
-    topics: topicsByLevel[level],
-  }));
+  const levelConfigs = await Promise.all(
+    levels.map(async (level) => {
+      const topics = await loadGrammar(level);
+      return {
+        level,
+        color: LEVEL_CONFIG[level].color,
+        label: LEVEL_CONFIG[level].label,
+        topicCount: topics.length,
+      };
+    }),
+  );
 
   return <GrammarPageClient levels={levelConfigs} />;
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -64,7 +64,7 @@ export default function RootLayout({
 
 function Footer() {
   return (
-    <footer className="border-t border-border bg-white py-6">
+    <footer className="border-t border-border bg-surface py-6">
       <div className="mx-auto max-w-7xl px-4 text-center text-sm text-text-secondary sm:px-6 lg:px-8">
         Fastrack Deutsch — telc exam prep. Offline-first, content-driven.
       </div>

--- a/apps/web/src/components/exam/ExamRunnerHeader.tsx
+++ b/apps/web/src/components/exam/ExamRunnerHeader.tsx
@@ -38,7 +38,7 @@ export function ExamRunnerHeader({
   const pct = Math.max(0, Math.min(1, progress)) * 100;
 
   return (
-    <div className="-mx-4 mb-6 border-b border-border bg-white sm:mx-0 sm:rounded-t-xl">
+    <div className="-mx-4 mb-6 border-b border-border bg-surface sm:mx-0 sm:rounded-t-xl">
       {/* Visually-hidden section heading — gives screen readers a proper
           landmark to announce and keeps the role=heading contract for e2e. */}
       <h1 className="sr-only">{sectionName}</h1>
@@ -87,7 +87,7 @@ export function ExamRunnerHeader({
           aria-modal="true"
           data-testid="exam-exit-dialog"
         >
-          <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-lg">
+          <div className="w-full max-w-sm rounded-xl bg-surface p-6 shadow-lg">
             <h2 className="text-base font-semibold text-text-primary">
               Prüfung wirklich beenden?
             </h2>

--- a/apps/web/src/components/exam/ListeningExam.tsx
+++ b/apps/web/src/components/exam/ListeningExam.tsx
@@ -158,7 +158,7 @@ export function ListeningExam({ mockId, level, section }: ListeningExamProps) {
                     ? 'bg-brand-600 text-white'
                     : partDone
                       ? 'bg-pass-surface text-pass'
-                      : 'border border-border bg-white text-text-secondary hover:border-border-hover'
+                      : 'border border-border bg-surface text-text-secondary hover:border-border-hover'
                 }`}
               >
                 Teil {p.partNumber}
@@ -167,7 +167,7 @@ export function ListeningExam({ mockId, level, section }: ListeningExamProps) {
           })}
         </div>
 
-        <div className="rounded-lg border border-border bg-white p-4">
+        <div className="rounded-lg border border-border bg-surface p-4">
           <p className="text-sm font-medium text-text-primary">{part.instructions}</p>
           {part.instructionsTranslation && (
             <p className="mt-1 text-xs text-text-secondary">{part.instructionsTranslation}</p>
@@ -186,7 +186,7 @@ export function ListeningExam({ mockId, level, section }: ListeningExamProps) {
 
         <div className="space-y-4">
           {part.questions.map((q, qi) => (
-            <div key={q.id} className="rounded-xl border border-border bg-white p-5">
+            <div key={q.id} className="rounded-xl border border-border bg-surface p-5">
               <p className="mb-3 font-medium text-text-primary">
                 {qi + 1}. {q.questionText}
               </p>

--- a/apps/web/src/components/exam/ReadingExam.tsx
+++ b/apps/web/src/components/exam/ReadingExam.tsx
@@ -157,7 +157,7 @@ export function ReadingExam({ mockId, level, section }: ReadingExamProps) {
                     ? 'bg-brand-600 text-white'
                     : done
                       ? 'bg-pass-surface text-pass'
-                      : 'border border-border bg-white text-text-secondary hover:border-border-hover'
+                      : 'border border-border bg-surface text-text-secondary hover:border-border-hover'
                 }`}
               >
                 Teil {p.partNumber}
@@ -214,7 +214,7 @@ function PartView({
 
   return (
     <div className="space-y-4">
-      <div className="rounded-lg border border-border bg-white p-4">
+      <div className="rounded-lg border border-border bg-surface p-4">
         <p className="text-sm font-medium text-text-primary">{part.instructions}</p>
         {part.instructionsTranslation && (
           <p className="mt-1 text-xs text-text-secondary">{part.instructionsTranslation}</p>
@@ -226,7 +226,7 @@ function PartView({
           {part.texts
             .filter((t) => t.type !== 'ad')
             .map((text) => (
-              <div key={text.id} className="rounded-xl border border-border bg-white p-5">
+              <div key={text.id} className="rounded-xl border border-border bg-surface p-5">
                 {text.source && (
                   <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-text-tertiary">
                     {text.source}
@@ -259,7 +259,7 @@ function PartView({
 
       <div className="space-y-4">
         {part.questions.map((q, qi) => (
-          <div key={q.id} className="rounded-xl border border-border bg-white p-5">
+          <div key={q.id} className="rounded-xl border border-border bg-surface p-5">
             <p className="mb-3 font-medium text-text-primary">
               {qi + 1}. {q.questionText}
             </p>

--- a/apps/web/src/components/exam/SectionHub.tsx
+++ b/apps/web/src/components/exam/SectionHub.tsx
@@ -149,7 +149,7 @@ function Group({
         </h2>
         <span className="text-xs text-text-tertiary">{threshold}</span>
       </div>
-      <div className="divide-y divide-border rounded-xl border border-border bg-white">
+      <div className="divide-y divide-border rounded-xl border border-border bg-surface">
         {sections.map((s) => {
           const Icon = ICON_BY_KEY[s.key];
           const status = statusOf(s.key);

--- a/apps/web/src/components/exam/SectionIntro.tsx
+++ b/apps/web/src/components/exam/SectionIntro.tsx
@@ -35,7 +35,7 @@ export function SectionIntro({
         <h1 className="text-2xl font-bold text-text-primary">{title}</h1>
         <p className="mt-1 text-sm text-text-secondary">{description}</p>
       </div>
-      <div className="rounded-xl border border-border bg-white p-6 text-left space-y-3">
+      <div className="rounded-xl border border-border bg-surface p-6 text-left space-y-3">
         <p className="text-sm text-text-secondary">
           Sie haben{' '}
           <span className="font-semibold text-text-primary">{minutes} Minuten</span>.

--- a/apps/web/src/components/exam/SprachbausteineExam.tsx
+++ b/apps/web/src/components/exam/SprachbausteineExam.tsx
@@ -184,7 +184,7 @@ export function SprachbausteineExam({ mockId, level, section }: SprachbausteineE
                   ? 'bg-brand-600 text-white'
                   : done
                     ? 'bg-pass-surface text-pass'
-                    : 'border border-border bg-white text-text-secondary hover:border-border-hover'
+                    : 'border border-border bg-surface text-text-secondary hover:border-border-hover'
               }`}
             >
               Teil {p.partNumber}
@@ -262,14 +262,14 @@ function PartView({
 
   return (
     <div className="space-y-4">
-      <div className="rounded-lg border border-border bg-white p-4">
+      <div className="rounded-lg border border-border bg-surface p-4">
         <p className="text-sm font-medium text-text-primary">{part.instructions}</p>
         <p className="mt-2 text-xs text-text-secondary">
           {answeredCount}/{part.questions.length} Lücken ausgefüllt
         </p>
       </div>
 
-      <div className="rounded-xl border border-border bg-white p-5">
+      <div className="rounded-xl border border-border bg-surface p-5">
         <div className="whitespace-pre-wrap font-sans text-[15px] leading-8 text-text-primary">
           {segments.map((seg, idx) => {
             if (seg.kind === 'text') {
@@ -449,7 +449,7 @@ function ReviewPart({
   const segments = useMemo(() => parseTextSegments(part.text), [part.text]);
 
   return (
-    <div className="rounded-xl border border-border bg-white p-5 space-y-4">
+    <div className="rounded-xl border border-border bg-surface p-5 space-y-4">
       <h3 className="font-semibold text-text-primary">Teil {part.partNumber}</h3>
       <div className="whitespace-pre-wrap font-sans text-[15px] leading-8 text-text-primary">
         {segments.map((seg, idx) => {

--- a/apps/web/src/components/exam/WritingExam.tsx
+++ b/apps/web/src/components/exam/WritingExam.tsx
@@ -145,7 +145,7 @@ function TaskCard({
         Aufgabe {task.taskNumber}
       </h2>
 
-      <div className="rounded-lg border border-border bg-white p-5">
+      <div className="rounded-lg border border-border bg-surface p-5">
         <p className="whitespace-pre-line text-sm text-text-primary">{task.instructions}</p>
         {task.instructionsTranslation && (
           <p className="mt-2 whitespace-pre-line text-xs text-text-secondary">
@@ -155,7 +155,7 @@ function TaskCard({
       </div>
 
       {task.type === 'form_fill' && task.formFields && (
-        <div className="rounded-xl border border-border bg-white p-5">
+        <div className="rounded-xl border border-border bg-surface p-5">
           <p className="mb-4 text-sm font-medium text-text-secondary">Formular ausfüllen:</p>
           <div className="space-y-3">
             {task.formFields.map((field) => (
@@ -177,7 +177,7 @@ function TaskCard({
       )}
 
       {(task.type === 'short_message' || task.type === 'letter' || task.type === 'essay') && (
-        <div className="rounded-xl border border-border bg-white p-5">
+        <div className="rounded-xl border border-border bg-surface p-5">
           <textarea
             value={fields['_freetext'] ?? ''}
             onChange={(e) => onFieldChange('_freetext', e.target.value)}
@@ -225,7 +225,7 @@ function WritingResults({
 }) {
   return (
     <div className="space-y-6">
-      <div className="rounded-xl border border-border bg-white p-6 text-center">
+      <div className="rounded-xl border border-border bg-surface p-6 text-center">
         <div className="text-4xl">✍️</div>
         <h2 className="mt-3 text-xl font-bold text-text-primary">Schreiben eingereicht</h2>
         <p className="mt-1 text-sm text-text-secondary">
@@ -234,7 +234,7 @@ function WritingResults({
         </p>
       </div>
 
-      <div className="rounded-xl border border-border bg-white p-5 space-y-3">
+      <div className="rounded-xl border border-border bg-surface p-5 space-y-3">
         <h3 className="font-semibold text-text-primary">Selbsteinschätzung</h3>
         <p className="text-sm text-text-secondary">
           Wie gut haben Sie Ihrer Meinung nach abgeschnitten? (0-100%)
@@ -264,7 +264,7 @@ function WritingResults({
         return (
           <div
             key={task.taskNumber}
-            className="rounded-xl border border-border bg-white p-5 space-y-4"
+            className="rounded-xl border border-border bg-surface p-5 space-y-4"
           >
             <h3 className="font-semibold text-text-primary">Aufgabe {task.taskNumber}</h3>
 

--- a/apps/web/src/components/grammar/TopicCard.tsx
+++ b/apps/web/src/components/grammar/TopicCard.tsx
@@ -14,9 +14,9 @@ export function TopicCard({ topic, levelColor }: TopicCardProps) {
 
   return (
     <Link
-      href={`/grammar/${topic.orderIndex}`}
+      href={`/grammar/${topic.level}/${topic.orderIndex}`}
       data-testid={`topic-card-${topic.orderIndex}`}
-      className="block rounded-xl border border-border bg-white p-5 transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-brand-primary"
+      className="block rounded-xl border border-border bg-surface p-5 transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-brand-primary"
     >
       <div className="flex items-start gap-3">
         <span


### PR DESCRIPTION
## Summary

- **#100 — Grammar B2+ topics return 404**: Added `/grammar/[level]/[topicId]` route that calls `loadGrammar(level)` with the correct level. Old `/grammar/[topicId]` now redirects to `/grammar/A1/[topicId]` for backward compat. TopicCard href updated from `/grammar/N` to `/grammar/[level]/N`. Prev/next navigation stays within the same level.
- **#99 — Browse Topics inline expansion confusing on mobile**: Replaced the toggle button that expanded an inline list with a `Link` that navigates to `/grammar/[level]`. New `/grammar/[level]` page shows a breadcrumb + grid of all topics for that level.
- **#98 — Exam reading page text invisible in dark mode**: Replaced all `bg-white` with `bg-surface` in exam components. In dark mode, CSS variables remap `--color-text-primary` to near-white; `bg-white` stayed literal white, making text invisible. `bg-surface` follows the same CSS variable as the background.

## Quality Gates

| Gate | Result |
|------|--------|
| typecheck | Clean (pre-existing `@vercel/blob` errors are unrelated to this PR) |
| grammar tests | 25/25 passing (21 existing + 4 new) |
| exam tests | All passing |
| compliance | n/a (no auth/PII touched) |
| language-checker | n/a (no German content changed) |

## Test plan

- [ ] `/grammar/B2/20` renders B2 topic "Funktionsverbgefüge" correctly
- [ ] `/grammar/A1/1` renders A1 topic correctly
- [ ] `/grammar/20` redirects to `/grammar/A1/20`
- [ ] "Browse Topics" on `/grammar` navigates to `/grammar/B2` (separate page, not inline)
- [ ] `/grammar/B2` shows all 25 B2 grammar topics in a grid with breadcrumb
- [ ] Topic prev/next navigation stays within the same level
- [ ] `/exam/B1_mock_10/reading` renders visible text in system dark mode (no white-on-near-white)

Closes #98, #99, #100