### PR TITLE
content(B1-mocks): rewrite mock 02 to Hueber-rigour distractor design + inverse register split

### DIFF
--- a/apps/mobile/assets/content/B1/mock_02.json
+++ b/apps/mobile/assets/content/B1/mock_02.json
@@ -1,8 +1,8 @@
 {
   "id": "B1_mock_02",
   "level": "B1",
-  "title": "B1 Übungstest 2: Beruf",
-  "version": 1,
+  "title": "B1 Übungstest 2: Berufseinstieg",
+  "version": 2,
   "sections": {
     "listening": {
       "totalTimeMinutes": 30,
@@ -17,46 +17,61 @@
             {
               "id": "B1_m02_L1_q1",
               "type": "true_false",
-              "questionText": "Herr Weber bittet seine Kollegin, heute länger im Büro zu bleiben.",
-              "options": ["richtig", "falsch"],
-              "correctAnswer": "falsch",
-              "explanation": "Auf dem Anrufbeantworter sagt Herr Weber: 'Frau Klein, ich kann heute leider nicht mehr ins Büro kommen – könnten Sie das Angebot für Herrn Vogel bitte bis morgen früh fertig machen?' Er bittet sie um eine fertige Unterlage, nicht um Überstunden oder ein längeres Bleiben.",
+              "questionText": "Das Fundbüro im Bahnhof ist am Wochenende nicht geöffnet.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
+              "correctAnswer": "richtig",
+              "explanation": "Die Durchsage besagt: 'Das Fundbüro hat Montag bis Freitag von 8 bis 18 Uhr geöffnet, samstags nur bis 13 Uhr.' Am Sonntag — und damit für das volle Wochenende — hat es zu. Die Aussage ist richtig.",
               "audioTimestamp": 10
             },
             {
               "id": "B1_m02_L1_q2",
               "type": "true_false",
-              "questionText": "Die Krankmeldung gilt bis einschließlich Freitag.",
-              "options": ["richtig", "falsch"],
-              "correctAnswer": "richtig",
-              "explanation": "Die Mitarbeiterin sagt ihrem Chef am Telefon: 'Der Arzt hat mich bis Freitag krankgeschrieben. Am Montag bin ich wieder im Büro.' Die Krankmeldung endet also am Freitag – die Aussage ist richtig.",
+              "questionText": "Der Stadtpark wird wegen Bauarbeiten für drei Wochen gesperrt.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
+              "correctAnswer": "falsch",
+              "explanation": "Die Radiosendung teilt mit: 'Der Stadtpark bleibt für zwei Wochen gesperrt, solange die Wegarbeiten im Nordteil laufen.' Drei Wochen sind nicht korrekt — es sind zwei. [Distractor type: numerical near-miss]",
               "audioTimestamp": 14
             },
             {
               "id": "B1_m02_L1_q3",
               "type": "true_false",
-              "questionText": "Das Bewerbungsgespräch wurde auf einen anderen Tag verschoben.",
-              "options": ["richtig", "falsch"],
+              "questionText": "Die Bibliothek verleiht Laptops an Studierende.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
               "correctAnswer": "richtig",
-              "explanation": "Die Personalabteilung informiert per Telefon: 'Leider muss ich Ihnen den Termin am Dienstag absagen – wir schlagen Ihnen stattdessen Donnerstag, 10 Uhr, vor.' Der Termin wird also verschoben – die Aussage ist richtig.",
+              "explanation": "Die Ansage in der Bibliothek lautet: 'Ab sofort können Studierende mit aktuellem Studierendenausweis Laptops für bis zu vier Stunden ausleihen.' Der Verleih an Studierende ist ausdrücklich bestätigt.",
               "audioTimestamp": 11
             },
             {
               "id": "B1_m02_L1_q4",
               "type": "true_false",
-              "questionText": "Der Kurs zur Weiterbildung findet ausschließlich online statt.",
-              "options": ["richtig", "falsch"],
-              "correctAnswer": "falsch",
-              "explanation": "Die Durchsage lautet: 'Der Kurs wird zum Teil online, zum Teil in unserem Seminarraum angeboten.' Es handelt sich also um ein Mischformat, nicht um einen reinen Online-Kurs.",
+              "questionText": "Die nächste Stadtführung findet morgen Nachmittag statt.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
+              "correctAnswer": "richtig",
+              "explanation": "Der Sprecher sagt: 'Die Führung durch die Altstadt beginnt morgen um 14:30 Uhr am Marktbrunnen.' Morgen Nachmittag trifft also zu.",
               "audioTimestamp": 12
             },
             {
               "id": "B1_m02_L1_q5",
               "type": "true_false",
-              "questionText": "Die Teambesprechung beginnt heute fünfzehn Minuten später als geplant.",
-              "options": ["richtig", "falsch"],
-              "correctAnswer": "richtig",
-              "explanation": "Die Assistentin gibt bekannt: 'Liebe Kolleginnen und Kollegen, unser Meeting verschiebt sich um eine Viertelstunde – wir starten um 10:15 Uhr statt 10:00 Uhr.' Fünfzehn Minuten später ist also korrekt.",
+              "questionText": "Das Hallenturnier wird in eine größere Halle verlegt.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
+              "correctAnswer": "falsch",
+              "explanation": "Die Ansage erklärt: 'Wegen Umbauarbeiten findet das Hallenturnier nicht in der Mehrzweckhalle, sondern in der kleineren Aula des Gymnasiums statt.' Es wird in eine kleinere, nicht eine größere Halle verlegt. [Distractor type: generalisation trap — 'verlegt' is true but direction is wrong]",
               "audioTimestamp": 9
             }
           ]
@@ -71,92 +86,122 @@
             {
               "id": "B1_m02_L2_q1",
               "type": "true_false",
-              "questionText": "Die Sendung handelt vom Berufswechsel im mittleren Alter.",
-              "options": ["richtig", "falsch"],
+              "questionText": "Der Radiobericht handelt vom ersten Job nach der Ausbildung.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
               "correctAnswer": "richtig",
-              "explanation": "Die Moderatorin leitet ein: 'In unserer heutigen Sendung geht es um einen Trend, der immer häufiger wird – Menschen, die zwischen 40 und 55 noch einmal beruflich neu anfangen.' Das Thema ist damit klar.",
+              "explanation": "Die Moderatorin sagt einleitend: 'Heute sprechen wir über den Berufseinstieg nach der Ausbildung — was man beachten sollte und wie Firmen die ersten Monate gestalten.' Das Thema ist klar.",
               "audioTimestamp": 8
             },
             {
               "id": "B1_m02_L2_q2",
               "type": "true_false",
-              "questionText": "Laut einer Umfrage haben im letzten Jahr nur wenige Deutsche den Beruf gewechselt.",
-              "options": ["richtig", "falsch"],
-              "correctAnswer": "falsch",
-              "explanation": "Der Reporter berichtet: 'Eine Umfrage zeigt, dass fast jeder fünfte Arbeitnehmer im letzten Jahr seinen Beruf gewechselt hat.' Jeder Fünfte ist kein kleiner Anteil – die Aussage ist falsch.",
-              "audioTimestamp": 35
+              "questionText": "Frau Schmitt leitet die Berufsausbildung in einem Handwerksbetrieb in Freiburg.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
+              "correctAnswer": "richtig",
+              "explanation": "Die Moderatorin stellt sie vor: 'Im Studio ist Franziska Schmitt, Leiterin der Berufsausbildung bei einem mittelständischen Handwerksbetrieb in Freiburg.' Damit ist ihre Funktion und der Ort bestätigt.",
+              "audioTimestamp": 30
             },
             {
               "id": "B1_m02_L2_q3",
               "type": "true_false",
-              "questionText": "Der Experte Herr Fischer arbeitet bei einer Berufsberatung.",
-              "options": ["richtig", "falsch"],
-              "correctAnswer": "richtig",
-              "explanation": "Die Moderatorin stellt ihn vor: 'Unser Gast, Herr Jonas Fischer, ist seit über zehn Jahren Berufsberater bei der Agentur für Arbeit in Köln.' Die Aussage passt genau.",
-              "audioTimestamp": 58
+              "questionText": "Bei Frau Schmitts Firma beginnen Auszubildende den ersten Tag mit einer Schulung.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
+              "correctAnswer": "falsch",
+              "explanation": "Frau Schmitt erklärt: 'Bei uns starten Azubis am ersten Tag nicht sofort mit einer Schulung, sondern mit einem Rundgang durch alle Abteilungen.' Eine Schulung am ersten Tag findet gerade nicht statt. [Distractor type: false inference — 'Schulung am ersten Tag' sounds plausible but is explicitly denied]",
+              "audioTimestamp": 55
             },
             {
               "id": "B1_m02_L2_q4",
               "type": "true_false",
-              "questionText": "Der häufigste Grund für einen Berufswechsel ist laut Herrn Fischer ein höheres Gehalt.",
-              "options": ["richtig", "falsch"],
-              "correctAnswer": "falsch",
-              "explanation": "Herr Fischer sagt: 'Erstaunlicherweise steht das Gehalt nicht an erster Stelle – viele wünschen sich mehr Sinn in ihrer Arbeit und ein besseres Betriebsklima.' Gehalt ist also nicht der Hauptgrund.",
-              "audioTimestamp": 82
+              "questionText": "Frau Schmitt sagt, dass viele Jugendliche Probleme mit der Pünktlichkeit haben.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
+              "correctAnswer": "richtig",
+              "explanation": "Sie sagt: 'Was uns am häufigsten auffällt: viele junge Leute unterschätzen, wie wichtig Pünktlichkeit im Beruf ist — das ist etwas ganz anderes als in der Schule.' Pünktlichkeit als Problem wird ausdrücklich genannt.",
+              "audioTimestamp": 78
             },
             {
               "id": "B1_m02_L2_q5",
               "type": "true_false",
-              "questionText": "Ein schlechtes Verhältnis zum Vorgesetzten kann ein Grund für einen Wechsel sein.",
-              "options": ["richtig", "falsch"],
+              "questionText": "Die Ausbildungsvergütung beträgt im dritten Jahr 1.050 Euro monatlich.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
               "correctAnswer": "richtig",
-              "explanation": "Herr Fischer erklärt: 'In unseren Gesprächen hören wir oft, dass die Beziehung zum Chef der entscheidende Auslöser war – wer sich nicht wertgeschätzt fühlt, kündigt irgendwann.' Das stimmt mit der Aussage überein.",
-              "audioTimestamp": 102
+              "explanation": "Frau Schmitt erläutert: 'Im ersten Jahr 700 Euro, im zweiten 850, im dritten Lehrjahr dann 1.050 Euro.' Der Wert für das dritte Jahr stimmt exakt.",
+              "audioTimestamp": 98
             },
             {
               "id": "B1_m02_L2_q6",
               "type": "true_false",
-              "questionText": "Frau Richter, eine Gesprächspartnerin, hat aus dem Bankwesen in die Pflege gewechselt.",
-              "options": ["richtig", "falsch"],
-              "correctAnswer": "richtig",
-              "explanation": "Frau Richter erzählt: 'Nach fünfzehn Jahren in einer Bank habe ich umgeschult – heute arbeite ich als Altenpflegerin und bin endlich zufrieden.' Der Wechsel von Bank zu Pflege ist genau genannt.",
-              "audioTimestamp": 125
+              "questionText": "Der Betrieb garantiert allen Auszubildenden nach der Ausbildung eine Stelle.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
+              "correctAnswer": "falsch",
+              "explanation": "Frau Schmitt präzisiert: 'Wir möchten jeden übernehmen, aber es kommt auf den Abschluss und die freien Stellen an — eine Garantie können wir nicht geben.' Eine Übernahmegarantie für alle gibt es also nicht. [Distractor type: generalisation trap — 'möchten jeden übernehmen' does not equal guarantee]",
+              "audioTimestamp": 118
             },
             {
               "id": "B1_m02_L2_q7",
               "type": "true_false",
-              "questionText": "Frau Richter verdient in ihrem neuen Beruf deutlich mehr als vorher.",
-              "options": ["richtig", "falsch"],
-              "correctAnswer": "falsch",
-              "explanation": "Frau Richter sagt offen: 'Natürlich verdiene ich jetzt weniger, aber ich gehe jeden Morgen gerne zur Arbeit – das ist mir wichtiger als das Geld.' Sie verdient also weniger, nicht mehr.",
-              "audioTimestamp": 148
+              "questionText": "Das Mentorenprogramm begleitet Azubis im ersten Ausbildungsjahr.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
+              "correctAnswer": "richtig",
+              "explanation": "Frau Schmitt beschreibt: 'Jeder neue Azubi bekommt in den ersten zwölf Monaten einen Mentor zugeteilt.' Das entspricht dem ersten Jahr.",
+              "audioTimestamp": 140
             },
             {
               "id": "B1_m02_L2_q8",
               "type": "true_false",
-              "questionText": "Der Experte empfiehlt, vor einem Wechsel unbedingt ein Praktikum zu machen.",
-              "options": ["richtig", "falsch"],
+              "questionText": "Frau Schmitt empfiehlt Jugendlichen, schon in der Schule ein Praktikum zu machen.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
               "correctAnswer": "richtig",
-              "explanation": "Herr Fischer rät: 'Bevor Sie kündigen, sollten Sie ein Praktikum oder zumindest eine Schnuppertage im neuen Beruf machen – das erspart Ihnen böse Überraschungen.' Der Tipp zum Praktikum ist eindeutig.",
-              "audioTimestamp": 168
+              "explanation": "Ihr Rat: 'Wer schon in der zehnten Klasse ein zweiwöchiges Praktikum macht, weiß viel besser, ob der Beruf wirklich zu ihm passt.' Sie empfiehlt das Schulpraktikum ausdrücklich.",
+              "audioTimestamp": 162
             },
             {
               "id": "B1_m02_L2_q9",
               "type": "true_false",
-              "questionText": "Die Agentur für Arbeit bietet auch finanzielle Unterstützung für Umschulungen an.",
-              "options": ["richtig", "falsch"],
-              "correctAnswer": "richtig",
-              "explanation": "Herr Fischer erwähnt: 'In vielen Fällen übernimmt die Agentur für Arbeit einen Teil der Kosten einer Umschulung – das wissen die wenigsten.' Das entspricht der Aussage.",
-              "audioTimestamp": 185
+              "questionText": "Laut Frau Schmitt ist Teamfähigkeit weniger wichtig als Fachkenntnisse.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
+              "correctAnswer": "falsch",
+              "explanation": "Sie sagt deutlich: 'Fachwissen kann man lernen — aber soziale Kompetenz ist für uns genauso wichtig wie fachliche Qualifikation.' Teamfähigkeit steht gleichwertig, nicht darunter. [Distractor type: causal reversal — swaps the priority order]",
+              "audioTimestamp": 183
             },
             {
               "id": "B1_m02_L2_q10",
               "type": "true_false",
-              "questionText": "Am Ende nennt die Moderatorin eine Telefonnummer für weitere Informationen.",
-              "options": ["richtig", "falsch"],
-              "correctAnswer": "falsch",
-              "explanation": "Die Moderatorin schließt mit: 'Mehr zu diesem Thema finden Sie auf unserer Internetseite unter beruf-neu.de.' Sie verweist also auf eine Webseite, nicht auf eine Telefonnummer.",
-              "audioTimestamp": 205
+              "questionText": "Am Ende verweist die Moderatorin auf eine Internetseite.",
+              "options": [
+                "richtig",
+                "falsch"
+              ],
+              "correctAnswer": "richtig",
+              "explanation": "Die Moderatorin schließt: 'Alle weiteren Informationen zum Thema Berufseinstieg finden Sie auf unserem Senderportal unter radio-ratgeber.de/beruf.' Es ist ein Internetverweis, keine Telefonnummer.",
+              "audioTimestamp": 204
             }
           ]
         },
@@ -170,67 +215,67 @@
             {
               "id": "B1_m02_L3_q1",
               "type": "mcq",
-              "questionText": "Warum ruft die Bewerberin bei der Firma an?",
+              "questionText": "Aus welchem Grund hat Johanna die Stelle nicht bekommen?",
               "options": [
-                "a) Sie möchte den Termin ihres Vorstellungsgesprächs verschieben.",
-                "b) Sie möchte sich nach dem Stand ihrer Bewerbung erkundigen.",
-                "c) Sie möchte eine weitere Unterlage nachreichen."
+                "a) Sie hatte im Vorstellungsgespräch zu wenig allgemeine Berufserfahrung.",
+                "b) Ein anderer Bewerber hatte mehr Kenntnisse in den eingesetzten EDV-Programmen.",
+                "c) Sie hatte ihre Bewerbungsunterlagen zu spät eingereicht."
               ],
               "correctAnswer": "b",
-              "explanation": "Die Bewerberin sagt: 'Ich hatte mich vor drei Wochen auf die Stelle als Projektassistentin beworben und wollte nachfragen, ob es schon einen Zwischenstand gibt.' Sie erkundigt sich also nach dem Stand. Termin und Unterlagen werden nicht erwähnt.",
-              "audioTimestamp": 16
+              "explanation": "Johanna erklärt ihrer Freundin: 'Der Personalchef hat mir gesagt, ein anderer Bewerber hatte deutlich mehr Erfahrung mit den EDV-Programmen, die sie einsetzen.' Der Vorteil lag beim anderen Kandidaten im IT-Bereich. Allgemeine Erfahrung und verspätete Unterlagen werden nicht erwähnt. [Distractor type: subject-swap — option a attributes the EDV deficit to Johanna, while the actual issue was the rival's superior skill]",
+              "audioTimestamp": 18
             },
             {
               "id": "B1_m02_L3_q2",
               "type": "mcq",
-              "questionText": "Worauf einigen sich die beiden Kollegen am Ende?",
+              "questionText": "Wie plant Tobias, seine Kenntnisse zu verbessern?",
               "options": [
-                "a) Sie tauschen ihre Dienste am Wochenende.",
-                "b) Sie arbeiten beide am Sonntag.",
-                "c) Sie sprechen zuerst mit dem Teamleiter."
+                "a) Er nimmt an einem Abendkurs an der Volkshochschule teil.",
+                "b) Er möchte die Firma um eine bezahlte Schulung bitten.",
+                "c) Er lernt eigenständig mit Online-Materialien in seiner Freizeit."
               ],
               "correctAnswer": "c",
-              "explanation": "Nach längerer Diskussion sagt Anna: 'Ich glaube, wir sollten das lieber erst mit dem Teamleiter abstimmen, bevor wir etwas entscheiden.' Tobias stimmt zu. Ein Tausch oder gemeinsames Arbeiten wird überlegt, aber nicht beschlossen.",
-              "audioTimestamp": 55
+              "explanation": "Tobias sagt: 'Ich schaue mir abends auf eigene Faust Tutorial-Videos an und mache die Übungen — das kostet nichts, und ich kann im eigenen Tempo lernen.' Selbstständig mit Online-Materialien, nicht an der VHS oder durch eine Firmenschulung. [Distractor type: lexical false-friend — 'Schulung' in option b echoes a word from context but Tobias never requests one from the employer]",
+              "audioTimestamp": 52
             },
             {
               "id": "B1_m02_L3_q3",
               "type": "mcq",
-              "questionText": "Was rät der Personalberater dem Mann im Gespräch?",
+              "questionText": "Was hat die Praktikantin in ihrer ersten Woche hauptsächlich gemacht?",
               "options": [
-                "a) sofort zu kündigen und eine Pause zu machen",
-                "b) eine Weiterbildung im aktuellen Unternehmen zu beantragen",
-                "c) sich parallel bei anderen Firmen zu bewerben"
+                "a) Sie hat Kundengespräche selbstständig geführt.",
+                "b) Sie hat ihren Betreuer begleitet und zugeschaut.",
+                "c) Sie hat eine Präsentation für das Team vorbereitet."
               ],
               "correctAnswer": "b",
-              "explanation": "Der Berater sagt: 'Bevor Sie kündigen, sprechen Sie doch mit Ihrer Chefin über eine Fortbildung im Haus – das ist oft der schnellste Weg, neue Aufgaben zu bekommen.' Er empfiehlt also die Weiterbildung im Unternehmen. Kündigen rät er ausdrücklich ab.",
-              "audioTimestamp": 92
+              "explanation": "Die Praktikantin berichtet: 'In der ersten Woche habe ich meinen Betreuer begleitet, bei kleineren Aufgaben mitgeholfen und vor allem beobachtet, wie alles läuft.' Selbstständige Kundengespräche und eine Präsentation werden nicht erwähnt. [Distractor type: time-frame trap — options a and c describe things that may come later, not in week one]",
+              "audioTimestamp": 88
             },
             {
               "id": "B1_m02_L3_q4",
               "type": "mcq",
-              "questionText": "Warum möchte die Angestellte im Homeoffice arbeiten?",
+              "questionText": "Worüber sind sich die zwei Freunde einig?",
               "options": [
-                "a) Sie hat einen langen Weg zur Arbeit.",
-                "b) Sie muss sich um ein krankes Kind kümmern.",
-                "c) Sie fühlt sich im Büro zu häufig gestört."
+                "a) Ein duales Studium ist zu anstrengend.",
+                "b) Mit einem Hochschulabschluss hat man grundsätzlich bessere Jobchancen.",
+                "c) Praktische Berufserfahrung zählt mindestens genauso viel wie ein Abschluss."
               ],
               "correctAnswer": "c",
-              "explanation": "Die Angestellte erklärt: 'Im Großraumbüro werde ich ständig unterbrochen – zu Hause komme ich in zwei Stunden weiter als hier an einem ganzen Tag.' Der Grund ist also die Konzentration. Weg und Kind werden nicht genannt.",
-              "audioTimestamp": 125
+              "explanation": "Beide sagen am Ende übereinstimmend: 'Die Praxis bringt dich oft weiter als ein Abschluss auf dem Papier.' Dass duales Studium zu anstrengend sei, sagt keiner; der Hochschulabschluss als genereller Vorteil wird gerade in Frage gestellt. [Distractor type: generalisation trap — option b overreads one remark as a shared conclusion]",
+              "audioTimestamp": 123
             },
             {
               "id": "B1_m02_L3_q5",
               "type": "mcq",
-              "questionText": "Was ist für die Mitarbeiterin bei der Gehaltsverhandlung am wichtigsten?",
+              "questionText": "Was sagt der neue Mitarbeiter über seine Probezeit?",
               "options": [
-                "a) ein höheres Grundgehalt",
-                "b) zusätzliche Urlaubstage",
-                "c) flexible Arbeitszeiten"
+                "a) Sie dauert bei seiner Firma genau sechs Monate.",
+                "b) Er spürt, dass er ständig beobachtet wird, und steht deswegen unter Druck.",
+                "c) Sie endet automatisch in drei Monaten mit einer Festanstellung."
               ],
-              "correctAnswer": "c",
-              "explanation": "Die Mitarbeiterin sagt am Ende: 'Wenn ich ehrlich bin, sind mir Gleitzeit und die Möglichkeit, früher zu gehen, wichtiger als die 200 Euro mehr im Monat.' Flexible Arbeitszeiten stehen also an erster Stelle.",
-              "audioTimestamp": 160
+              "correctAnswer": "b",
+              "explanation": "Der Mitarbeiter sagt: 'Man merkt schon, dass jeder Schritt beobachtet wird — das ist kein schlechtes Zeichen, aber man steht halt immer unter Strom.' Über Dauer und automatische Festanstellung sagt er nichts Konkretes. [Distractor type: false inference — option c implies an automatic outcome not stated; option a states a specific figure not mentioned]",
+              "audioTimestamp": 158
             }
           ]
         }
@@ -244,100 +289,252 @@
           "instructions": "Lesen Sie zuerst die fünf Situationen (1–5) und dann die acht Überschriften (a–h). Welche Überschrift passt zu welcher Situation? Für jede Situation gibt es genau eine passende Überschrift. Drei Überschriften bleiben übrig.",
           "instructionsTranslation": "First read the five situations (1–5) and then the eight headlines (a–h). Which headline matches which situation? For each situation there is exactly one matching headline. Three headlines remain unused.",
           "texts": [
-            { "id": "B1_m02_R1_head_a", "type": "notice", "content": "a) Jobmesse 'Karriere kompakt' – über 80 Unternehmen stellen sich am Samstag vor" },
-            { "id": "B1_m02_R1_head_b", "type": "notice", "content": "b) Kostenloser Workshop: Bewerbungsunterlagen professionell erstellen" },
-            { "id": "B1_m02_R1_head_c", "type": "notice", "content": "c) Neue Kita am Firmengelände – Betreuungsplätze für Mitarbeiterkinder ab Herbst" },
-            { "id": "B1_m02_R1_head_d", "type": "notice", "content": "d) Rückenschule für Büroangestellte – 10 Abende ab kommenden Montag" },
-            { "id": "B1_m02_R1_head_e", "type": "notice", "content": "e) Gewerkschaftsberatung zum Thema Überstunden und Zeitausgleich – Sprechstunde donnerstags" },
-            { "id": "B1_m02_R1_head_f", "type": "notice", "content": "f) Sommerfest der Firma – alle Mitarbeiter mit Familie herzlich eingeladen" },
-            { "id": "B1_m02_R1_head_g", "type": "notice", "content": "g) Online-Seminar 'Englisch im Beruf' – für Berufstätige mit Grundkenntnissen, abends" },
-            { "id": "B1_m02_R1_head_h", "type": "notice", "content": "h) Betriebsarzt bietet kostenlose Grippeimpfung an – Anmeldung im Personalbüro" }
+            {
+              "id": "B1_m02_R1_head_a",
+              "type": "notice",
+              "content": "a) Jobmesse 'Karriere kompakt' — über 80 Unternehmen stellen sich am Samstag vor"
+            },
+            {
+              "id": "B1_m02_R1_head_b",
+              "type": "notice",
+              "content": "b) Kostenloser Workshop: Bewerbungsunterlagen professionell erstellen"
+            },
+            {
+              "id": "B1_m02_R1_head_c",
+              "type": "notice",
+              "content": "c) Neue Kita am Firmengelände — Betreuungsplätze für Mitarbeiterkinder ab Herbst"
+            },
+            {
+              "id": "B1_m02_R1_head_d",
+              "type": "notice",
+              "content": "d) Rückenschule für Büroangestellte — 10 Abende ab kommenden Montag"
+            },
+            {
+              "id": "B1_m02_R1_head_e",
+              "type": "notice",
+              "content": "e) Gewerkschaftsberatung zum Thema Überstunden und Zeitausgleich — Sprechstunde donnerstags"
+            },
+            {
+              "id": "B1_m02_R1_head_f",
+              "type": "notice",
+              "content": "f) Sommerfest der Firma — alle Mitarbeiter mit Familie herzlich eingeladen"
+            },
+            {
+              "id": "B1_m02_R1_head_g",
+              "type": "notice",
+              "content": "g) Online-Seminar 'Englisch im Beruf' — für Berufstätige mit Grundkenntnissen, abends"
+            },
+            {
+              "id": "B1_m02_R1_head_h",
+              "type": "notice",
+              "content": "h) Betriebsarzt bietet kostenlose Grippeimpfung an — Anmeldung im Personalbüro"
+            }
           ],
           "questions": [
             {
               "id": "B1_m02_R1_q1",
               "type": "matching",
-              "questionText": "1. Ramona beendet im Sommer ihr Studium und weiß noch nicht genau, in welche Branche sie gehen möchte. Sie hätte gern die Möglichkeit, an einem Tag viele verschiedene Firmen kennenzulernen.",
+              "questionText": "1. Ramona beendet im Sommer ihr Studium und weiß noch nicht genau, in welche Branche sie gehen möchte. Sie hätte gerne die Möglichkeit, an einem Tag viele verschiedene Firmen kennenzulernen.",
               "matchingSources": [
-                { "id": "B1_m02_R1_head_a", "label": "a" },
-                { "id": "B1_m02_R1_head_b", "label": "b" },
-                { "id": "B1_m02_R1_head_c", "label": "c" },
-                { "id": "B1_m02_R1_head_d", "label": "d" },
-                { "id": "B1_m02_R1_head_e", "label": "e" },
-                { "id": "B1_m02_R1_head_f", "label": "f" },
-                { "id": "B1_m02_R1_head_g", "label": "g" },
-                { "id": "B1_m02_R1_head_h", "label": "h" }
+                {
+                  "id": "B1_m02_R1_head_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R1_head_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R1_head_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R1_head_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R1_head_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R1_head_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R1_head_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R1_head_h",
+                  "label": "h"
+                }
               ],
               "correctAnswer": "a",
-              "explanation": "Überschrift a) Jobmesse mit 80 Unternehmen an einem Samstag ist genau der Rahmen, den Ramona sucht: viele Arbeitgeber gleichzeitig kennenlernen. Die übrigen Angebote richten sich an bereits Beschäftigte oder an einen engeren Themenkreis."
+              "explanation": "Überschrift a) Jobmesse mit 80 Unternehmen an einem Samstag ist genau der Rahmen, den Ramona sucht: viele Arbeitgeber gleichzeitig kennenlernen. Anzeigen b) und g) richten sich an bereits Beschäftigte mit spezifischem Bedarf."
             },
             {
               "id": "B1_m02_R1_q2",
               "type": "matching",
               "questionText": "2. Herr Nowak hat sich schon mehrfach beworben, bekommt aber selten eine Einladung. Ein Freund meint, seine Unterlagen seien nicht mehr zeitgemäß. Er sucht kostenlose Hilfe, um Lebenslauf und Anschreiben zu verbessern.",
               "matchingSources": [
-                { "id": "B1_m02_R1_head_a", "label": "a" },
-                { "id": "B1_m02_R1_head_b", "label": "b" },
-                { "id": "B1_m02_R1_head_c", "label": "c" },
-                { "id": "B1_m02_R1_head_d", "label": "d" },
-                { "id": "B1_m02_R1_head_e", "label": "e" },
-                { "id": "B1_m02_R1_head_f", "label": "f" },
-                { "id": "B1_m02_R1_head_g", "label": "g" },
-                { "id": "B1_m02_R1_head_h", "label": "h" }
+                {
+                  "id": "B1_m02_R1_head_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R1_head_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R1_head_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R1_head_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R1_head_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R1_head_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R1_head_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R1_head_h",
+                  "label": "h"
+                }
               ],
               "correctAnswer": "b",
-              "explanation": "Überschrift b) bietet einen kostenlosen Workshop zu professionellen Bewerbungsunterlagen – genau das, was Herr Nowak für Lebenslauf und Anschreiben braucht. Keine andere Anzeige passt zum Thema Bewerbung."
+              "explanation": "Überschrift b) bietet einen kostenlosen Workshop zu professionellen Bewerbungsunterlagen — exakt das, was Herr Nowak für Lebenslauf und Anschreiben braucht. Anzeige a) bietet keine Einzelhilfe beim Lebenslauf."
             },
             {
               "id": "B1_m02_R1_q3",
               "type": "matching",
-              "questionText": "3. Frau Lindemann arbeitet seit Jahren im Rechnungswesen und hat in letzter Zeit häufig Überstunden gemacht, die ihr Arbeitgeber weder auszahlt noch als freie Tage anrechnen will. Sie möchte sich informieren, welche Rechte sie hat.",
+              "questionText": "3. Frau Lindemann arbeitet seit Jahren im Rechnungswesen und hat zuletzt regelmäßig Überstunden gemacht, die ihr Arbeitgeber weder auszahlt noch als Freizeit anrechnet. Sie möchte sich über ihre Rechte informieren.",
               "matchingSources": [
-                { "id": "B1_m02_R1_head_a", "label": "a" },
-                { "id": "B1_m02_R1_head_b", "label": "b" },
-                { "id": "B1_m02_R1_head_c", "label": "c" },
-                { "id": "B1_m02_R1_head_d", "label": "d" },
-                { "id": "B1_m02_R1_head_e", "label": "e" },
-                { "id": "B1_m02_R1_head_f", "label": "f" },
-                { "id": "B1_m02_R1_head_g", "label": "g" },
-                { "id": "B1_m02_R1_head_h", "label": "h" }
+                {
+                  "id": "B1_m02_R1_head_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R1_head_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R1_head_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R1_head_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R1_head_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R1_head_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R1_head_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R1_head_h",
+                  "label": "h"
+                }
               ],
               "correctAnswer": "e",
-              "explanation": "Überschrift e) bietet eine Gewerkschaftsberatung zum Thema Überstunden und Zeitausgleich – die passende Anlaufstelle für Frau Lindemann. Die anderen Angebote haben keinen rechtlichen oder arbeitsrechtlichen Bezug."
+              "explanation": "Überschrift e) bietet eine Gewerkschaftsberatung genau zu Überstunden und Zeitausgleich — die passende Anlaufstelle für Frau Lindemann. Kein anderes Angebot hat einen arbeitsrechtlichen Fokus."
             },
             {
               "id": "B1_m02_R1_q4",
               "type": "matching",
-              "questionText": "4. Tarek sitzt jeden Tag acht Stunden am Schreibtisch und klagt seit Monaten über Rückenschmerzen. Sein Hausarzt hat ihm empfohlen, regelmäßig gezielte Übungen unter Anleitung zu machen.",
+              "questionText": "4. Tarek sitzt täglich acht Stunden am Schreibtisch und klagt seit Monaten über Rückenschmerzen. Sein Hausarzt hat ihm empfohlen, regelmäßig gezielte Übungen unter Anleitung zu machen.",
               "matchingSources": [
-                { "id": "B1_m02_R1_head_a", "label": "a" },
-                { "id": "B1_m02_R1_head_b", "label": "b" },
-                { "id": "B1_m02_R1_head_c", "label": "c" },
-                { "id": "B1_m02_R1_head_d", "label": "d" },
-                { "id": "B1_m02_R1_head_e", "label": "e" },
-                { "id": "B1_m02_R1_head_f", "label": "f" },
-                { "id": "B1_m02_R1_head_g", "label": "g" },
-                { "id": "B1_m02_R1_head_h", "label": "h" }
+                {
+                  "id": "B1_m02_R1_head_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R1_head_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R1_head_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R1_head_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R1_head_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R1_head_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R1_head_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R1_head_h",
+                  "label": "h"
+                }
               ],
               "correctAnswer": "d",
-              "explanation": "Überschrift d) 'Rückenschule für Büroangestellte' richtet sich direkt an Menschen wie Tarek mit Rückenproblemen durch Schreibtischarbeit. Die anderen Kurse oder Angebote haben keinen gesundheitlichen Fokus auf den Rücken."
+              "explanation": "Überschrift d) 'Rückenschule für Büroangestellte' richtet sich direkt an Menschen wie Tarek. Anzeige h) ist eine Grippeimpfung, keine Bewegungstherapie."
             },
             {
               "id": "B1_m02_R1_q5",
               "type": "matching",
-              "questionText": "5. Frau Aslan wird in zwei Monaten in eine internationale Firma wechseln. Dort wird viel auf Englisch kommuniziert. Sie hat zwar Schulenglisch, möchte aber dringend ihre beruflichen Sprachkenntnisse auffrischen – am liebsten nach Feierabend und von zu Hause aus.",
+              "questionText": "5. Frau Aslan wechselt in zwei Monaten in eine internationale Firma. Dort wird viel auf Englisch kommuniziert. Sie hat Schulenglisch, möchte aber ihre beruflichen Sprachkenntnisse auffrischen — am liebsten abends von zu Hause.",
               "matchingSources": [
-                { "id": "B1_m02_R1_head_a", "label": "a" },
-                { "id": "B1_m02_R1_head_b", "label": "b" },
-                { "id": "B1_m02_R1_head_c", "label": "c" },
-                { "id": "B1_m02_R1_head_d", "label": "d" },
-                { "id": "B1_m02_R1_head_e", "label": "e" },
-                { "id": "B1_m02_R1_head_f", "label": "f" },
-                { "id": "B1_m02_R1_head_g", "label": "g" },
-                { "id": "B1_m02_R1_head_h", "label": "h" }
+                {
+                  "id": "B1_m02_R1_head_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R1_head_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R1_head_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R1_head_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R1_head_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R1_head_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R1_head_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R1_head_h",
+                  "label": "h"
+                }
               ],
               "correctAnswer": "g",
-              "explanation": "Überschrift g) beschreibt genau ein Online-Seminar 'Englisch im Beruf' für Berufstätige mit Grundkenntnissen am Abend. Das passt exakt zu Frau Aslans Wunsch nach beruflichem Englisch von zu Hause aus. Anzeigen c), f) und h) bleiben als Distraktoren übrig."
+              "explanation": "Überschrift g) beschreibt exakt ein Online-Seminar 'Englisch im Beruf' für Berufstätige mit Grundkenntnissen, abends — passt zu Frau Aslans Wunsch. Anzeigen c), f) und h) bleiben als Distraktoren übrig."
             }
           ]
         },
@@ -349,75 +546,75 @@
             {
               "id": "B1_m02_R2_article",
               "type": "article",
-              "content": "Zurück ins Büro? Warum viele Firmen vom reinen Homeoffice abrücken\n\nNoch vor wenigen Jahren galt das Homeoffice als Modell der Zukunft. Unternehmen hofften auf zufriedenere Mitarbeiter, geringere Mietkosten und eine bessere Vereinbarkeit von Familie und Beruf. Eine aktuelle Auswertung des Instituts für Arbeitsforschung in Nürnberg zeigt nun jedoch: Rund zwei Drittel der großen deutschen Firmen haben in den letzten zwölf Monaten ihre Regeln wieder verschärft. Mitarbeiter sollen mindestens drei Tage pro Woche im Büro sein – manche Unternehmen verlangen sogar vier.\n\nDie Gründe sind vielfältig. Vor allem Führungskräfte berichten, dass die Zusammenarbeit im Team leidet, wenn sich die Kollegen nur noch über Video-Calls sehen. Kreative Projekte entstünden seltener, kurze Absprachen in der Kaffeeküche fielen weg. 'Ein Großteil der Ideen, die später wirklich Geld bringen, entsteht eben nicht in einer Besprechung, sondern auf dem Flur', erklärt Daniela Brenner, Personalchefin eines Maschinenbauunternehmens aus Stuttgart.\n\nGleichzeitig spüren viele Beschäftigte, dass sich die Trennung zwischen Arbeit und Privatleben zu Hause oft verwischt. Wer morgens am Küchentisch anfängt, macht abends oft dort weiter. Pausen werden seltener eingelegt, und auch die Bewegung kommt zu kurz. Eine Umfrage unter 1.200 Beschäftigten ergab, dass sich jeder Dritte nach reinem Homeoffice sozial isoliert fühlt.\n\nExperten warnen jedoch davor, das Pendel jetzt vollständig zurückzudrehen. Wer seinen Mitarbeitern gar keine Flexibilität mehr lasse, riskiere Kündigungen – gerade gut ausgebildete Fachkräfte erwarten heute die Möglichkeit, zumindest an ein oder zwei Tagen von zu Hause zu arbeiten. Die Lösung liegt also in der Mitte. 'Hybrid ist kein Kompromiss, sondern ein eigenes Modell', sagt Arbeitspsychologe Thomas Klemm. Entscheidend sei, klare Regeln aufzustellen: feste Tage im Büro, gemeinsame Kernzeiten und technische Lösungen, die Zusammenarbeit erleichtern. Nur so gelinge es, die Vorteile beider Welten zu verbinden und Nachteile zu vermeiden.",
-              "source": "Süddeutsche Wochenschau, April 2026"
+              "content": "Lachen auf Rezept — Klinikclowns zwischen Spaß und Verantwortung\n\nWer putzt die Wand — der Arzt oder die Krankenschwester? \"Keiner\", ruft der kleine Max und zeigt auf die rote Nase, die gerade hinter dem Türrahmen auftaucht. Seit sieben Jahren besuchen die Klinikclowns des Vereins \"Rote Nasen Rhein-Main\" die Kinderstationen im Städtischen Klinikum Frankfurt. Rund zwanzig professionelle Clowns kommen wöchentlich vorbei — und niemand wartet so ungeduldig auf sie wie die kleinen Patienten auf der onkologischen Station.\n\nDie Arbeit klingt leicht, ist es aber nicht. \"Man improvisiert ständig\", erklärt die Clownin Dr. Pünktchen, bürgerlich Sabine Reuter. \"Aus einem leeren Plastikbecher kann ein Raumschiff werden oder eine Teekanne, je nachdem, was das Kind gerade braucht. Wir holen uns die Energie von den Kindern, nicht umgekehrt.\" Wichtig ist dabei: Die Clowns gehen nie ungefragt ins Zimmer. \"Darf ich rein?\" ist immer der erste Satz — und manchmal kommt ein müdes \"Nein\" zurück, das sie respektieren.\n\nDie Kosten trägt nicht das Krankenhaus, sondern der Verein, der ausschließlich von Spenden lebt. Gleichzeitig schult er seine Künstler regelmäßig: Seminare zu Kommunikation mit schwerkranken Kindern, Grundlagen der Traumapädagogik, Umgang mit trauernden Eltern. \"Wir sind keine Therapeuten\", betont Vereinsvorsitzende Dr. Klara Wend. \"Aber wir können Momente schaffen, in denen die Krankheit kurz in den Hintergrund tritt.\"\n\nDass Lachen tatsächlich helfen kann, ist inzwischen wissenschaftlich belegt. Eine Untersuchung der Universität Heidelberg zeigte: Kinder, die regelmäßig Clownbesuche erhielten, brauchten im Schnitt 15 Prozent weniger Schmerzmittel. Trotzdem warnt Kinderkrankenschwester Monika Stahl vor zu hohen Erwartungen: \"Die Clowns sind eine wertvolle Ergänzung — aber sie ersetzen natürlich keine medizinische Behandlung.\"\n\nInzwischen hat das Frankfurter Modell Schule gemacht: In neun weiteren Städten gibt es ähnliche Vereine. Und auch Altenheime entdecken die heilsame Kraft des Lachens — denn das Bedürfnis nach einem Moment Leichtigkeit hört nicht auf, wenn man älter wird.",
+              "source": "Stadtanzeiger Frankfurt, Mai 2026"
             }
           ],
           "questions": [
             {
               "id": "B1_m02_R2_q1",
               "type": "mcq",
-              "questionText": "Was ist das zentrale Ergebnis der Nürnberger Auswertung?",
+              "questionText": "Wer finanziert die Arbeit der Klinikclowns?",
               "relatedTextId": "B1_m02_R2_article",
               "options": [
-                "a) Immer mehr Firmen verbieten das Homeoffice komplett.",
-                "b) Die meisten großen Firmen verlangen wieder mehr Präsenz im Büro.",
-                "c) Die Zahl der Homeoffice-Tage ist im letzten Jahr gestiegen."
+                "a) Das Krankenhaus übernimmt die Kosten vollständig.",
+                "b) Die Kosten werden durch Spendengelder des Vereins gedeckt.",
+                "c) Die Clowns werden von einer staatlichen Förderung bezahlt."
               ],
               "correctAnswer": "b",
-              "explanation": "Im Text steht: 'Rund zwei Drittel der großen deutschen Firmen haben in den letzten zwölf Monaten ihre Regeln wieder verschärft. Mitarbeiter sollen mindestens drei Tage pro Woche im Büro sein.' Das entspricht genau Option b. 'Komplett verbieten' (a) steht nirgends; die Homeoffice-Zeit ist gesunken, nicht gestiegen (c)."
+              "explanation": "Im Text steht ausdrücklich: 'Die Kosten trägt nicht das Krankenhaus, sondern der Verein, der ausschließlich von Spenden lebt.' Option a ist das Gegenteil des Gesagten; staatliche Förderung (c) wird nirgends erwähnt. [Distractor type: causal reversal — a names the wrong funding party]"
             },
             {
               "id": "B1_m02_R2_q2",
               "type": "mcq",
-              "questionText": "Welchen Nachteil nennen Führungskräfte am reinen Homeoffice?",
+              "questionText": "Was ist die erste Handlung der Clowns bei jedem Zimmerbesuch?",
               "relatedTextId": "B1_m02_R2_article",
               "options": [
-                "a) Mitarbeiter arbeiten langsamer als im Büro.",
-                "b) Die Stromkosten zu Hause sind zu hoch.",
-                "c) Spontane Absprachen und kreative Ideen gehen verloren."
+                "a) Sie zeigen dem Kind sofort ein Kunststück, um Aufmerksamkeit zu gewinnen.",
+                "b) Sie sprechen zuerst mit der zuständigen Krankenschwester.",
+                "c) Sie fragen das Kind, ob sie eintreten dürfen."
               ],
               "correctAnswer": "c",
-              "explanation": "Der Text zitiert Frau Brenner: 'Ein Großteil der Ideen ... entsteht eben nicht in einer Besprechung, sondern auf dem Flur.' Kurze Absprachen in der Kaffeeküche fielen weg. Das entspricht Option c. Option a und b werden im Text nicht angesprochen."
+              "explanation": "Der Text sagt eindeutig: '\"Darf ich rein?\" ist immer der erste Satz.' Kein Kunststück kommt zuerst, und die Krankenschwester wird in diesem Zusammenhang nicht erwähnt. [Distractor type: false inference — a sounds like natural clown behaviour but is explicitly not what happens first]"
             },
             {
               "id": "B1_m02_R2_q3",
               "type": "mcq",
-              "questionText": "Was berichtet die Umfrage über Beschäftigte im reinen Homeoffice?",
+              "questionText": "Was ergab die Untersuchung der Universität Heidelberg?",
               "relatedTextId": "B1_m02_R2_article",
               "options": [
-                "a) Viele vermischen Arbeit und Freizeit und fühlen sich isoliert.",
-                "b) Die meisten wünschen sich eine höhere Bezahlung.",
-                "c) Nur wenige machen mehr Pausen als im Büro."
+                "a) Kinder mit regelmäßigen Clownbesuchen genasen 15 Prozent schneller.",
+                "b) Kinder mit regelmäßigen Clownbesuchen benötigten 15 Prozent weniger Schmerzmittel.",
+                "c) Fast alle Kinder lehnten Clownbesuche in der ersten Woche ab."
               ],
-              "correctAnswer": "a",
-              "explanation": "Der Text schreibt: 'Wer morgens am Küchentisch anfängt, macht abends oft dort weiter' und 'jeder Dritte fühlt sich nach reinem Homeoffice sozial isoliert.' Das ist Option a. Bezahlung (b) wird nicht genannt; zu Pausen heißt es, sie würden seltener eingelegt – nicht mehr gemacht."
+              "correctAnswer": "b",
+              "explanation": "Der Text ist präzise: '... brauchten im Schnitt 15 Prozent weniger Schmerzmittel.' Option a verwechselt den gemessenen Effekt: nicht Heilungsgeschwindigkeit, sondern Schmerzmittelverbrauch. Option c widerspricht dem Gesamttenor. [Distractor type: numerical near-miss combined with subject-swap — a moves the 15% figure to a different outcome]"
             },
             {
               "id": "B1_m02_R2_q4",
               "type": "mcq",
-              "questionText": "Wovor warnen die Experten?",
+              "questionText": "Was bedeutet die Aussage von Dr. Wend: 'Wir sind keine Therapeuten'?",
               "relatedTextId": "B1_m02_R2_article",
               "options": [
-                "a) davor, jede Flexibilität zu streichen, weil sonst Fachkräfte kündigen",
-                "b) davor, die Mitarbeiter zu stark zu kontrollieren",
-                "c) davor, die Gehälter im Homeoffice zu senken"
+                "a) Die Clowns dürfen keine medizinischen Geräte benutzen.",
+                "b) Ihre Arbeit ergänzt die Behandlung, ersetzt sie aber nicht.",
+                "c) Sie haben keine Ausbildung und arbeiten freiwillig."
               ],
-              "correctAnswer": "a",
-              "explanation": "Im Text steht wörtlich: 'Wer seinen Mitarbeitern gar keine Flexibilität mehr lasse, riskiere Kündigungen – gerade gut ausgebildete Fachkräfte erwarten heute die Möglichkeit, zumindest an ein oder zwei Tagen von zu Hause zu arbeiten.' Das ist Option a. Kontrolle und Gehaltssenkung werden nicht genannt."
+              "correctAnswer": "b",
+              "explanation": "Dr. Wend erklärt: '... aber wir können Momente schaffen, in denen die Krankheit kurz in den Hintergrund tritt.' Krankenschwester Stahl ergänzt: 'Die Clowns sind eine wertvolle Ergänzung.' Beide Aussagen zusammen zeigen: Ergänzung, kein Ersatz. Option a ist zu wörtlich; Option c stimmt nicht — die Clowns sind Profis. [Distractor type: lexical false-friend — 'Therapeuten' invites assumptions about medical licensing]"
             },
             {
               "id": "B1_m02_R2_q5",
               "type": "mcq",
-              "questionText": "Was empfiehlt der Arbeitspsychologe Thomas Klemm?",
+              "questionText": "Was ist laut dem letzten Absatz eine neue Entwicklung?",
               "relatedTextId": "B1_m02_R2_article",
               "options": [
-                "a) möglichst schnell wieder zum klassischen Büroalltag zurückzukehren",
-                "b) feste Bürotage und gemeinsame Kernzeiten festzulegen",
-                "c) jedem Mitarbeiter selbst zu überlassen, wann er ins Büro kommt"
+                "a) Das Frankfurter Modell wird künftig auch in Schulen eingesetzt.",
+                "b) Klinikclowns arbeiten inzwischen auch in Altenheimen.",
+                "c) Der Verein plant, seine Arbeit ins Ausland zu tragen."
               ],
               "correctAnswer": "b",
-              "explanation": "Herr Klemm wird zitiert: 'Entscheidend sei, klare Regeln aufzustellen: feste Tage im Büro, gemeinsame Kernzeiten und technische Lösungen.' Das ist Option b. Ein vollständiger Rückzug (a) und völlige Freiheit (c) widersprechen seiner Aussage, dass Hybrid kein Kompromiss, sondern ein eigenes Modell mit Regeln sei."
+              "explanation": "Der Schlussabsatz sagt: 'Auch Altenheime entdecken die heilsame Kraft des Lachens.' Schulen und Auslandsexpansion werden im Text nirgends erwähnt. [Distractor type: false inference — a and c sound like logical extensions but neither is stated]"
             }
           ]
         },
@@ -426,169 +623,637 @@
           "instructions": "Sie lesen zehn Situationen (1–10) und zwölf kurze Anzeigen (a–l). Welche Anzeige passt zu welcher Situation? Für jede Situation gibt es genau eine passende Anzeige. Zwei Anzeigen bleiben übrig. Wenn keine Anzeige passt, schreiben Sie 'x'.",
           "instructionsTranslation": "You read ten situations (1–10) and twelve short advertisements (a–l). Which advertisement matches which situation? For each situation there is exactly one matching advertisement. Two advertisements remain unused. If no advertisement fits, write 'x'.",
           "texts": [
-            { "id": "B1_m02_R3_ad_a", "type": "ad", "content": "a) STELLE ALS TEAMASSISTENZ – mittelständisches IT-Unternehmen in Hamburg sucht engagierte Teamassistenz (Vollzeit, ab sofort). Erfahrung mit MS Office, gute Deutsch- und Englischkenntnisse. Bewerbung: karriere@it-hamburg.de" },
-            { "id": "B1_m02_R3_ad_b", "type": "ad", "content": "b) Ausbildung zur Pflegefachkraft – staatlich anerkannter Pflegedienst bietet 3-jährige Ausbildung mit Ausbildungsvergütung ab 1.100 €/Monat. Start jederzeit möglich. Tel. 040 221 80 50" },
-            { "id": "B1_m02_R3_ad_c", "type": "ad", "content": "c) Minijob: Frühaufsteher gesucht – Bäckerei in der Altstadt sucht Verkaufshilfe von 5:30 bis 8:30 Uhr, Mo–Fr. 538 €/Monat. Kontakt: Frau Seidel, 0157 334 22 78" },
-            { "id": "B1_m02_R3_ad_d", "type": "ad", "content": "d) Weiterbildung 'Projektmanagement (IHK)' – 8 Wochenenden, insgesamt 240 Stunden. Zertifikatsabschluss. Nächster Start: Mai, Kursgebühr 2.300 € (Bildungsgutschein möglich). www.ihk-weiterbildung.de" },
-            { "id": "B1_m02_R3_ad_e", "type": "ad", "content": "e) Babysitter gesucht – Familie mit zwei Kindern (4 und 7) sucht zuverlässige Betreuung 2x pro Woche nach der Schule (15–18 Uhr). 13 €/Stunde. kontakt@familie-richter.de" },
-            { "id": "B1_m02_R3_ad_f", "type": "ad", "content": "f) Büro-Coworking Space 'WerkHalle' – flexible Arbeitsplätze im Zentrum, ab 180 €/Monat inkl. Kaffee, Drucker, Meetingraum. Probetag kostenlos. www.werkhalle.de" },
-            { "id": "B1_m02_R3_ad_g", "type": "ad", "content": "g) Bewerbungsfoto vom Profi – Termin innerhalb einer Woche. Retusche inklusive, 5 digitale Fotos in hoher Qualität, 79 €. Studio Lichtblick, Termin online buchen." },
-            { "id": "B1_m02_R3_ad_h", "type": "ad", "content": "h) Berufliche Neuorientierung mit 40+ – Coaching in sechs Einzelsitzungen, 90 Min. je Sitzung, 120 €/Sitzung. Erste Sitzung kostenlos. Zertifizierte Beraterin. info@neue-wege-coaching.de" },
-            { "id": "B1_m02_R3_ad_i", "type": "ad", "content": "i) Duales Studium 'Wirtschaftsinformatik' – Praxispartner in Stuttgart sucht Studienanfänger für Herbst. Monatliche Vergütung, Studiengebühren werden übernommen. bewerbung@dualcampus.de" },
-            { "id": "B1_m02_R3_ad_j", "type": "ad", "content": "j) Honorarkraft 'Deutsch als Fremdsprache' – Volkshochschule sucht erfahrene Lehrkraft für B1-Kurse, abends 2x pro Woche. 35 €/Stunde. bewerbung@vhs-mitte.de" },
-            { "id": "B1_m02_R3_ad_k", "type": "ad", "content": "k) Praktikum im Marketing – junge Agentur bietet Praktikantenstelle für 3 Monate, 600 €/Monat, flexible Startzeit. Gute Englischkenntnisse erwünscht. praktika@mediavie.de" },
-            { "id": "B1_m02_R3_ad_l", "type": "ad", "content": "l) Steuerberater Herr Klausen – Beratung für Selbstständige und Kleinunternehmer. Erstgespräch 50 €. Termine auch abends. Telefon 0211 440 77 20" }
+            {
+              "id": "B1_m02_R3_ad_a",
+              "type": "ad",
+              "content": "a) WERKSTUDENT GESUCHT — Marketingagentur in München sucht Studierende (20 Std./Woche) für Content-Erstellung und Social-Media-Pflege. Englisch fließend, MS Office sicher. Bewerbung: jobs@mediavox.de"
+            },
+            {
+              "id": "B1_m02_R3_ad_b",
+              "type": "ad",
+              "content": "b) Pflege-Ausbildung — staatlich anerkannter Pflegedienst bietet 3-jährige Ausbildung zur Pflegefachkraft, Vergütung ab 1.100 €/Monat. Start jederzeit. Tel. 089 44 55 66"
+            },
+            {
+              "id": "B1_m02_R3_ad_c",
+              "type": "ad",
+              "content": "c) Saisonkraft Weinlese — Weingut Schreiber in Rheinhessen sucht ab September Erntehelfer für 6 Wochen. Unterkunft und Verpflegung inklusive. Bewerbung: weingut-schreiber.de"
+            },
+            {
+              "id": "B1_m02_R3_ad_d",
+              "type": "ad",
+              "content": "d) Praktikum Grafikdesign — kreatives Studio sucht Praktikant*in für 3 Monate (freiwillig oder Pflichtpraktikum), 400 €/Monat Aufwandsentschädigung, Start flexibel. praktikum@designhaus-otto.de"
+            },
+            {
+              "id": "B1_m02_R3_ad_e",
+              "type": "ad",
+              "content": "e) Kellner / Servicekraft für Wochenenden — Bistro am Stadtpark sucht zuverlässige Aushilfe Sa + So, 9–15 Uhr, 12 €/Stunde. Barzahlung möglich. Anfragen: 0179 55 44 33"
+            },
+            {
+              "id": "B1_m02_R3_ad_f",
+              "type": "ad",
+              "content": "f) Freelance Texter*in — kleines Redaktionsbüro sucht freie Mitarbeit für Produktbeschreibungen und Blogbeiträge. Ca. 500–800 Wörter pro Auftrag, 0,07 €/Wort. Weitere Infos: redaktion@textpool.de"
+            },
+            {
+              "id": "B1_m02_R3_ad_g",
+              "type": "ad",
+              "content": "g) Schülerpraktikum Grundschule — Schule in Hannover bietet zweiwöchiges Praktikum für Klasse 9/10 (unbezahlt). Anmeldung über das Schulsekretariat. Tel. 0511 77 22 11"
+            },
+            {
+              "id": "B1_m02_R3_ad_h",
+              "type": "ad",
+              "content": "h) Ferienjob Lager & Versand — Logistikzentrum sucht Aushilfen für Juli–August (Vollzeit 6 Wochen), Mindestlohn + Schichtzulage. Mindestalter 18 Jahre. Anmeldung: personal@express-logistik.de"
+            },
+            {
+              "id": "B1_m02_R3_ad_i",
+              "type": "ad",
+              "content": "i) Duales Studium Wirtschaftsinformatik — Technologieunternehmen in Stuttgart bietet Studienplatz ab Herbst. Studiengebühren übernommen, monatliche Vergütung 900 €. Bewerbungsschluss: 30. Juni. bewerbung@dualtech.de"
+            },
+            {
+              "id": "B1_m02_R3_ad_j",
+              "type": "ad",
+              "content": "j) Büro-Coworking-Space 'Lichtwerk' — flexible Arbeitsplätze im Stadtzentrum, ab 180 €/Monat inkl. WLAN, Kaffee, Drucker. Probewoche kostenlos. www.lichtwerk-coworking.de"
+            },
+            {
+              "id": "B1_m02_R3_ad_k",
+              "type": "ad",
+              "content": "k) Ausbildung Kfz-Mechatroniker*in — Autohaus Brenner (VW/Audi) bietet Ausbildungsplatz ab September. Schulische Voraussetzung: mindestens Mittlere Reife. Bewerbung bis 31. Mai. ausbildung@autohaus-brenner.de"
+            },
+            {
+              "id": "B1_m02_R3_ad_l",
+              "type": "ad",
+              "content": "l) Berufliche Neuorientierung 40+ — Coaching in sechs Einzelsitzungen, 90 Minuten, 120 €/Sitzung. Erste Sitzung gratis. Zertifizierte Beraterin. info@neue-wege-coaching.de"
+            }
           ],
           "questions": [
             {
               "id": "B1_m02_R3_q1",
               "type": "matching",
-              "questionText": "1. Lena hat gerade ihr Abitur gemacht und möchte unbedingt im IT-Bereich arbeiten, aber parallel auch studieren. Sie braucht eine Lösung, bei der beides kombiniert ist.",
+              "questionText": "1. Lena hat gerade ihr Abitur gemacht und möchte im IT-Bereich arbeiten, aber gleichzeitig studieren. Sie braucht eine Stelle, die beides verbindet.",
               "matchingSources": [
-                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
-                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
-                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
-                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
-                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
-                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+                {
+                  "id": "B1_m02_R3_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R3_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R3_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R3_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R3_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R3_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R3_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R3_ad_h",
+                  "label": "h"
+                },
+                {
+                  "id": "B1_m02_R3_ad_i",
+                  "label": "i"
+                },
+                {
+                  "id": "B1_m02_R3_ad_j",
+                  "label": "j"
+                },
+                {
+                  "id": "B1_m02_R3_ad_k",
+                  "label": "k"
+                },
+                {
+                  "id": "B1_m02_R3_ad_l",
+                  "label": "l"
+                }
               ],
               "correctAnswer": "i",
-              "explanation": "Anzeige i) 'Duales Studium Wirtschaftsinformatik' verbindet Studium und Arbeit in einer Firma – genau das, was Lena braucht. Keine andere Anzeige kombiniert beides."
+              "explanation": "Anzeige i) 'Duales Studium Wirtschaftsinformatik' verbindet Studium und Praxis in einem IT-Unternehmen — genau was Lena sucht. Anzeige a) ist nur ein Werkstudentenjob ohne Studienförderung."
             },
             {
               "id": "B1_m02_R3_q2",
               "type": "matching",
-              "questionText": "2. Herr Walker ist 47 Jahre alt, als IT-Entwickler seit vielen Jahren unglücklich und überlegt, beruflich noch einmal etwas völlig Neues zu beginnen. Er sucht eine persönliche Begleitung, die ihm bei der Neuorientierung hilft.",
+              "questionText": "2. Herr Berger ist 46, seit Jahren als Buchhalter tätig und möchte endlich etwas ganz anderes machen. Er sucht eine Person, die ihn persönlich bei der Entscheidung begleitet.",
               "matchingSources": [
-                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
-                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
-                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
-                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
-                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
-                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+                {
+                  "id": "B1_m02_R3_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R3_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R3_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R3_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R3_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R3_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R3_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R3_ad_h",
+                  "label": "h"
+                },
+                {
+                  "id": "B1_m02_R3_ad_i",
+                  "label": "i"
+                },
+                {
+                  "id": "B1_m02_R3_ad_j",
+                  "label": "j"
+                },
+                {
+                  "id": "B1_m02_R3_ad_k",
+                  "label": "k"
+                },
+                {
+                  "id": "B1_m02_R3_ad_l",
+                  "label": "l"
+                }
               ],
-              "correctAnswer": "h",
-              "explanation": "Anzeige h) 'Berufliche Neuorientierung mit 40+' bietet genau ein Coaching in Einzelsitzungen an – passend zu Herrn Walkers Wunsch nach persönlicher Begleitung bei beruflicher Neuorientierung."
+              "correctAnswer": "l",
+              "explanation": "Anzeige l) 'Berufliche Neuorientierung 40+' bietet Einzel-Coaching für genau diese Zielgruppe. Anzeige k) (Kfz-Ausbildung) oder b) (Pflegeausbildung) sind konkrete Jobs, nicht Beratungsangebote."
             },
             {
               "id": "B1_m02_R3_q3",
               "type": "matching",
-              "questionText": "3. Studentin Marie sucht einen Nebenjob, den sie vor ihren Vorlesungen am frühen Morgen ausüben kann. Am Nachmittag hat sie keine Zeit.",
+              "questionText": "3. Katrin studiert Grafikdesign im vierten Semester und muss für ihr Studium ein Pflichtpraktikum ableisten. Sie hat noch keinen genauen Starttermin festgelegt.",
               "matchingSources": [
-                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
-                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
-                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
-                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
-                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
-                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+                {
+                  "id": "B1_m02_R3_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R3_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R3_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R3_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R3_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R3_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R3_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R3_ad_h",
+                  "label": "h"
+                },
+                {
+                  "id": "B1_m02_R3_ad_i",
+                  "label": "i"
+                },
+                {
+                  "id": "B1_m02_R3_ad_j",
+                  "label": "j"
+                },
+                {
+                  "id": "B1_m02_R3_ad_k",
+                  "label": "k"
+                },
+                {
+                  "id": "B1_m02_R3_ad_l",
+                  "label": "l"
+                }
               ],
-              "correctAnswer": "c",
-              "explanation": "Anzeige c) sucht Minijobber in der Bäckerei von 5:30 bis 8:30 Uhr – genau die frühen Morgenstunden, in denen Marie arbeiten könnte. Anzeige e) (Babysitter nach der Schule) würde den Nachmittag verlangen und fällt damit weg."
+              "correctAnswer": "d",
+              "explanation": "Anzeige d) bietet ein Praktikum im Grafikdesign, explizit auch als Pflichtpraktikum, mit flexiblem Start. Anzeige g) ist ein Schülerpraktikum für Klasse 9/10, nicht für Hochschulstudierende."
             },
             {
               "id": "B1_m02_R3_q4",
               "type": "matching",
-              "questionText": "4. Herr Balaban führt seit einem Jahr ein kleines Café und möchte vor seiner ersten Steuererklärung mit jemandem sprechen, der sich mit Selbstständigen auskennt.",
+              "questionText": "4. Tom ist 19 und interessiert sich für Autos. Er sucht eine Berufsausbildung im handwerklich-technischen Bereich. Er hat die Mittlere Reife.",
               "matchingSources": [
-                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
-                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
-                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
-                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
-                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
-                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+                {
+                  "id": "B1_m02_R3_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R3_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R3_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R3_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R3_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R3_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R3_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R3_ad_h",
+                  "label": "h"
+                },
+                {
+                  "id": "B1_m02_R3_ad_i",
+                  "label": "i"
+                },
+                {
+                  "id": "B1_m02_R3_ad_j",
+                  "label": "j"
+                },
+                {
+                  "id": "B1_m02_R3_ad_k",
+                  "label": "k"
+                },
+                {
+                  "id": "B1_m02_R3_ad_l",
+                  "label": "l"
+                }
               ],
-              "correctAnswer": "l",
-              "explanation": "Anzeige l) Steuerberater Klausen berät speziell Selbstständige und Kleinunternehmer – genau das, was Herr Balaban für seine erste Steuererklärung braucht."
+              "correctAnswer": "k",
+              "explanation": "Anzeige k) 'Ausbildung Kfz-Mechatroniker' mit Mittlerer Reife als Mindestvorraussetzung passt genau zu Tom. Anzeige b) (Pflege) ist ein anderes Berufsfeld."
             },
             {
               "id": "B1_m02_R3_q5",
               "type": "matching",
-              "questionText": "5. Anja ist ausgebildete Deutschlehrerin und möchte abends nebenberuflich unterrichten, um zusätzliches Geld zu verdienen. Sie unterrichtet seit Jahren B1-Niveau.",
+              "questionText": "5. Vera ist Studentin und sucht einen Nebenjob, bei dem sie nur an Wochenenden arbeitet und direkt bar bezahlt wird.",
               "matchingSources": [
-                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
-                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
-                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
-                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
-                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
-                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+                {
+                  "id": "B1_m02_R3_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R3_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R3_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R3_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R3_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R3_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R3_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R3_ad_h",
+                  "label": "h"
+                },
+                {
+                  "id": "B1_m02_R3_ad_i",
+                  "label": "i"
+                },
+                {
+                  "id": "B1_m02_R3_ad_j",
+                  "label": "j"
+                },
+                {
+                  "id": "B1_m02_R3_ad_k",
+                  "label": "k"
+                },
+                {
+                  "id": "B1_m02_R3_ad_l",
+                  "label": "l"
+                }
               ],
-              "correctAnswer": "j",
-              "explanation": "Anzeige j) sucht eine Honorarkraft für DaF/B1-Kurse am Abend – ideal für Anja als erfahrene Deutschlehrerin mit Wunsch nach Nebenjob am Abend."
+              "correctAnswer": "e",
+              "explanation": "Anzeige e) sucht Servicekraft nur Sa + So mit Barzahlung — genau Veras Anforderungen. Anzeige a) (Werkstudent) verlangt 20 Stunden pro Woche an mehreren Wochentagen."
             },
             {
               "id": "B1_m02_R3_q6",
               "type": "matching",
-              "questionText": "6. Herr Demir ist seit Jahren im Büro tätig und möchte seine Karriere voranbringen. Er sucht eine berufsbegleitende Weiterbildung mit anerkanntem Abschluss im Projektmanagement.",
+              "questionText": "6. Markus ist freiberuflicher Journalist und sucht Schreibaufträge, die er von zu Hause aus erledigen kann.",
               "matchingSources": [
-                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
-                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
-                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
-                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
-                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
-                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+                {
+                  "id": "B1_m02_R3_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R3_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R3_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R3_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R3_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R3_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R3_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R3_ad_h",
+                  "label": "h"
+                },
+                {
+                  "id": "B1_m02_R3_ad_i",
+                  "label": "i"
+                },
+                {
+                  "id": "B1_m02_R3_ad_j",
+                  "label": "j"
+                },
+                {
+                  "id": "B1_m02_R3_ad_k",
+                  "label": "k"
+                },
+                {
+                  "id": "B1_m02_R3_ad_l",
+                  "label": "l"
+                }
               ],
-              "correctAnswer": "d",
-              "explanation": "Anzeige d) 'Weiterbildung Projektmanagement (IHK)' an 8 Wochenenden mit Zertifikat ist die passende berufsbegleitende Option für Herrn Demir."
+              "correctAnswer": "f",
+              "explanation": "Anzeige f) sucht eine freie Textkraft für Schreibaufträge — remote, keine festen Zeiten, perfekt für Markus als freien Journalisten. Anzeige a) erfordert feste Büropräsenz."
             },
             {
               "id": "B1_m02_R3_q7",
               "type": "matching",
-              "questionText": "7. Lisa bewirbt sich in den kommenden Wochen auf mehrere Stellen und möchte ihre alten Bewerbungsbilder durch professionelle Aufnahmen ersetzen.",
+              "questionText": "7. Simon hat die Mittlere Reife und möchte im Gesundheitsbereich arbeiten, am liebsten direkt mit Menschen. Er ist bereit, eine mehrjährige Ausbildung zu machen.",
               "matchingSources": [
-                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
-                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
-                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
-                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
-                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
-                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+                {
+                  "id": "B1_m02_R3_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R3_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R3_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R3_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R3_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R3_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R3_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R3_ad_h",
+                  "label": "h"
+                },
+                {
+                  "id": "B1_m02_R3_ad_i",
+                  "label": "i"
+                },
+                {
+                  "id": "B1_m02_R3_ad_j",
+                  "label": "j"
+                },
+                {
+                  "id": "B1_m02_R3_ad_k",
+                  "label": "k"
+                },
+                {
+                  "id": "B1_m02_R3_ad_l",
+                  "label": "l"
+                }
               ],
-              "correctAnswer": "g",
-              "explanation": "Anzeige g) 'Bewerbungsfoto vom Profi' mit Termin innerhalb einer Woche und mehreren digitalen Aufnahmen passt exakt zu Lisas Bedarf."
+              "correctAnswer": "b",
+              "explanation": "Anzeige b) bietet eine 3-jährige staatlich anerkannte Pflegeausbildung mit Vergütung — Gesundheitsbereich, Menschenkontakt, mehrjährig. Anzeige k) wäre handwerklich-technisch, nicht medizinisch."
             },
             {
               "id": "B1_m02_R3_q8",
               "type": "matching",
-              "questionText": "8. Patrick hat gerade sein Studium abgeschlossen und möchte erste Berufserfahrung im Marketing sammeln, ist aber noch flexibel, wann er startet.",
+              "questionText": "8. Herr Dogan arbeitet selbstständig von zu Hause, findet die Wohnung aber zu ablenkend. Er sucht einen flexiblen, günstigen Arbeitsplatz außerhalb.",
               "matchingSources": [
-                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
-                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
-                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
-                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
-                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
-                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+                {
+                  "id": "B1_m02_R3_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R3_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R3_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R3_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R3_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R3_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R3_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R3_ad_h",
+                  "label": "h"
+                },
+                {
+                  "id": "B1_m02_R3_ad_i",
+                  "label": "i"
+                },
+                {
+                  "id": "B1_m02_R3_ad_j",
+                  "label": "j"
+                },
+                {
+                  "id": "B1_m02_R3_ad_k",
+                  "label": "k"
+                },
+                {
+                  "id": "B1_m02_R3_ad_l",
+                  "label": "l"
+                }
               ],
-              "correctAnswer": "k",
-              "explanation": "Anzeige k) ist ein Praktikum im Marketing, 3 Monate, flexibler Start – genau der Einstieg, den Patrick sucht."
+              "correctAnswer": "j",
+              "explanation": "Anzeige j) 'Coworking-Space Lichtwerk' mit flexiblen Plätzen, Probewoche kostenlos — genau die Lösung für Herrn Dogan. Anzeige f) bietet Auftragsarbeit, keinen physischen Arbeitsplatz."
             },
             {
               "id": "B1_m02_R3_q9",
               "type": "matching",
-              "questionText": "9. Frau Bergmann arbeitet selbstständig als Grafikerin. Zu Hause wird sie ständig abgelenkt und sucht einen bezahlbaren Arbeitsplatz außerhalb der eigenen Wohnung, an dem sie flexibel arbeiten kann.",
+              "questionText": "9. Nele studiert BWL im dritten Semester und sucht eine Stelle neben dem Studium, bei der sie praktische Marketingerfahrung sammeln kann — mit Englisch.",
               "matchingSources": [
-                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
-                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
-                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
-                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
-                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
-                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+                {
+                  "id": "B1_m02_R3_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R3_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R3_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R3_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R3_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R3_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R3_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R3_ad_h",
+                  "label": "h"
+                },
+                {
+                  "id": "B1_m02_R3_ad_i",
+                  "label": "i"
+                },
+                {
+                  "id": "B1_m02_R3_ad_j",
+                  "label": "j"
+                },
+                {
+                  "id": "B1_m02_R3_ad_k",
+                  "label": "k"
+                },
+                {
+                  "id": "B1_m02_R3_ad_l",
+                  "label": "l"
+                }
               ],
-              "correctAnswer": "f",
-              "explanation": "Anzeige f) 'Büro-Coworking Space WerkHalle' bietet flexible Arbeitsplätze ab 180 €/Monat – ideal für Frau Bergmann, die außerhalb der Wohnung arbeiten möchte."
+              "correctAnswer": "a",
+              "explanation": "Anzeige a) 'Werkstudent Marketing' mit 20 Stunden, Englisch und MS Office passt gut zu Neles Studium und Interesse. Anzeige f) wäre Freelance-Schreiben, kein Marketing."
             },
             {
               "id": "B1_m02_R3_q10",
               "type": "matching",
-              "questionText": "10. Ahmed hat eine Ausbildung als Krankenpfleger in seinem Heimatland gemacht, ist gerade in Deutschland angekommen und sucht hier eine Ausbildung, damit sein Abschluss anerkannt wird.",
+              "questionText": "10. Jonas hat im September sechs Wochen frei und möchte dabei Geld verdienen. Er mag Natur und körperliche Arbeit. Eine kostenlose Unterkunft wäre ideal.",
               "matchingSources": [
-                { "id": "B1_m02_R3_ad_a", "label": "a" }, { "id": "B1_m02_R3_ad_b", "label": "b" },
-                { "id": "B1_m02_R3_ad_c", "label": "c" }, { "id": "B1_m02_R3_ad_d", "label": "d" },
-                { "id": "B1_m02_R3_ad_e", "label": "e" }, { "id": "B1_m02_R3_ad_f", "label": "f" },
-                { "id": "B1_m02_R3_ad_g", "label": "g" }, { "id": "B1_m02_R3_ad_h", "label": "h" },
-                { "id": "B1_m02_R3_ad_i", "label": "i" }, { "id": "B1_m02_R3_ad_j", "label": "j" },
-                { "id": "B1_m02_R3_ad_k", "label": "k" }, { "id": "B1_m02_R3_ad_l", "label": "l" }
+                {
+                  "id": "B1_m02_R3_ad_a",
+                  "label": "a"
+                },
+                {
+                  "id": "B1_m02_R3_ad_b",
+                  "label": "b"
+                },
+                {
+                  "id": "B1_m02_R3_ad_c",
+                  "label": "c"
+                },
+                {
+                  "id": "B1_m02_R3_ad_d",
+                  "label": "d"
+                },
+                {
+                  "id": "B1_m02_R3_ad_e",
+                  "label": "e"
+                },
+                {
+                  "id": "B1_m02_R3_ad_f",
+                  "label": "f"
+                },
+                {
+                  "id": "B1_m02_R3_ad_g",
+                  "label": "g"
+                },
+                {
+                  "id": "B1_m02_R3_ad_h",
+                  "label": "h"
+                },
+                {
+                  "id": "B1_m02_R3_ad_i",
+                  "label": "i"
+                },
+                {
+                  "id": "B1_m02_R3_ad_j",
+                  "label": "j"
+                },
+                {
+                  "id": "B1_m02_R3_ad_k",
+                  "label": "k"
+                },
+                {
+                  "id": "B1_m02_R3_ad_l",
+                  "label": "l"
+                }
               ],
-              "correctAnswer": "b",
-              "explanation": "Anzeige b) bietet eine 3-jährige staatlich anerkannte Ausbildung zur Pflegefachkraft mit Vergütung an – genau der Weg, den Ahmed braucht. Anzeige a) (Teamassistenz) und e) (Babysitter) bleiben als Distraktoren übrig."
+              "correctAnswer": "c",
+              "explanation": "Anzeige c) 'Saisonkraft Weinlese' startet im September, 6 Wochen, Unterkunft und Verpflegung inklusive, im Freien — passt exakt zu Jonas. Anzeige h) (Lagerjob) bietet keine Unterkunft. Anzeigen g) und h) bleiben als Distraktoren übrig."
             }
           ]
         }
@@ -599,194 +1264,354 @@
         {
           "partNumber": 1,
           "instructions": "Lesen Sie den folgenden Text und entscheiden Sie, welches Wort (a, b oder c) in die Lücke passt. Es gibt jeweils nur eine richtige Lösung.",
-          "text": "Lieber Jonas,\n\nwie geht es dir? Ich wollte dir schon lange schreiben, aber in den letzten Wochen war richtig viel los. Seit zwei Monaten arbeite ich jetzt __(1)__ einer kleinen Ingenieurfirma im Süden der Stadt, und ich bin wirklich erleichtert, __(2)__ ich nach der langen Bewerbungsphase endlich angekommen bin. Mein Chef, __(3)__ mich damals eingestellt hat, ist ein ruhiger und sehr fairer Mensch. __(4)__ der Anfang nicht einfach war, fühle ich mich heute schon wie ein Teil des Teams.\n\nLetzte Woche haben wir einen großen Auftrag erfolgreich abgeschlossen. Die Präsentation __(5)__ am Donnerstag sogar vom Geschäftsführer selbst gehalten, was uns alle stolz gemacht hat. Wenn ich schon mehr Routine __(6)__, würde ich mich wohl selbst um eigene Kunden bewerben. Aber das dauert wohl noch eine Weile.\n\nAm Wochenende treffe ich mich oft mit Kolleginnen __(7)__ Sport – meistens Laufen im Park. Wir __(8)__ am Samstag zusammen ins Fitnessstudio gegangen, und danach haben wir noch lange geplaudert. Übrigens hoffe ich sehr, dass du mich bald mal besuchen kommst – ich würde mich riesig __(9)__ freuen! Hast du eigentlich schon gehört, dass Tim und Nina geheiratet haben? Nina hat mir erzählt, sie hätten __(10)__ schönsten Tag ihres Lebens gehabt.\n\nIch freue mich auf deine Nachricht.\n\nViele Grüße,\nLina",
+          "text": "Sehr geehrte Damen und Herren,\n\nmein Name ist Clara Hoffmann, und ich wende mich __(1)__ Sie, weil ich auf Ihrer Website ein Angebot für einen Sprachkurs in Barcelona gelesen habe. Ich __(2)__ sehr daran interessiert, im kommenden Sommer an einem vierwöchigen Intensivkurs teilzunehmen.\n\nBevor ich mich jedoch __(3)__ anmelde, hätte ich einige Fragen. Erstens würde ich gern wissen, ob der Kurs __(4)__ für Erwachsene ab 25 Jahren oder auch für Teilnehmerinnen und Teilnehmer im Alter von 18 bis 24 geeignet ist. Zweitens bitte ich Sie __(5)__ eine Auskunft darüber, ob Unterkunft und Mahlzeiten im Kurspreis __(6)__ sind oder separat gebucht werden müssen. Außerdem interessiert mich, __(7)__ viele Stunden Unterricht pro Tag im Kursplan vorgesehen sind.\n\nFalls Sie Informationsbroschüren haben, __(8)__ ich Sie bitten, mir diese per Post zuzusenden? Meine Adresse lautet: Clara Hoffmann, Fichtestraße 12, 60316 Frankfurt am Main.\n\nIch würde mich freuen, __(9)__ Sie mich bei Rückfragen auch telefonisch oder per E-Mail erreichen __(10)__.\n\nMit freundlichen Grüßen\nClara Hoffmann",
           "questions": [
             {
               "blankNumber": 1,
               "type": "mcq",
-              "options": ["a) in", "b) an", "c) bei"],
-              "correctAnswer": "c",
-              "explanation": "Bei Arbeitgebern/Firmen verwendet man 'bei' + Dativ: 'bei einer Firma arbeiten'. 'in' ist möglich bei Stadt oder Gebäude, aber nicht bei Firmennamen. 'an' gehört zu Institutionen wie 'an der Universität'."
+              "options": [
+                "a) an",
+                "b) bei",
+                "c) mit"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Feste Fügung: 'sich an jemanden wenden' (Akkusativ). 'Sich bei jemandem melden' wäre möglich, aber 'wenden' verlangt zwingend 'an'. 'Mit' bildet keine idiomatische Verbindung mit 'wenden' in diesem Kontext."
             },
             {
               "blankNumber": 2,
               "type": "mcq",
-              "options": ["a) weil", "b) dass", "c) wenn"],
-              "correctAnswer": "b",
-              "explanation": "Nach 'erleichtert sein' folgt ein dass-Satz, der den Inhalt der Erleichterung angibt. 'weil' gäbe einen Grund an (hier unpassend, da die Aussage keine Begründung ist). 'wenn' leitet eine Bedingung ein und passt nicht."
+              "options": [
+                "a) bin",
+                "b) wäre",
+                "c) sei"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Im formellen Brief gibt man echte Information über sich: 'Ich bin sehr daran interessiert' (Indikativ). Konjunktiv II ('wäre') klingt zu distanziert-hypothetisch. Konjunktiv I ('sei') steht in indirekter Rede, nicht in eigener Aussage."
             },
             {
               "blankNumber": 3,
               "type": "mcq",
-              "options": ["a) der", "b) den", "c) dem"],
-              "correctAnswer": "a",
-              "explanation": "Relativsatz: 'Mein Chef, der mich eingestellt hat'. Das Relativpronomen bezieht sich auf 'Chef' (Maskulinum) und ist Subjekt im Relativsatz – also Nominativ 'der'. 'den' wäre Akkusativ, 'dem' Dativ."
+              "options": [
+                "a) definitiv",
+                "b) endgültig",
+                "c) verbindlich"
+              ],
+              "correctAnswer": "c",
+              "explanation": "Formelhafte Wendung der Geschäftskommunikation: 'sich verbindlich anmelden' = eine rechtlich bindende Buchung. 'Definitiv' und 'endgültig' sind semantisch ähnlich, aber 'verbindlich' ist der Fachbegriff für Anmeldungen und Buchungen."
             },
             {
               "blankNumber": 4,
               "type": "mcq",
-              "options": ["a) Obwohl", "b) Weil", "c) Trotzdem"],
+              "options": [
+                "a) ausschließlich",
+                "b) besonders",
+                "c) grundsätzlich"
+              ],
               "correctAnswer": "a",
-              "explanation": "Gegensatz zwischen 'nicht einfach' und 'fühle mich wie ein Teil des Teams' → konzessiver Nebensatz mit 'obwohl'. 'weil' gäbe einen Grund an (unlogisch). 'trotzdem' ist ein Adverb (Hauptsatzstellung, Verb auf Position 2), aber hier steht das Verb am Ende – also muss es eine Subjunktion sein."
+              "explanation": "'Ausschließlich' bedeutet 'nur', also ohne andere Gruppe — erzeugt die Frage, ob Jüngere ausgeschlossen sind. 'Besonders' (= vor allem) und 'grundsätzlich' (= in der Regel) passen inhaltlich nicht zur Exklusivitätsfrage."
             },
             {
               "blankNumber": 5,
               "type": "mcq",
-              "options": ["a) hat", "b) wurde", "c) war"],
-              "correctAnswer": "b",
-              "explanation": "Vorgangspassiv Präteritum: 'Die Präsentation wurde gehalten.' 'hat' wäre Aktiv ('hat gehalten'), aber das Subjekt 'Präsentation' führt die Handlung nicht aus. 'war gehalten' wäre Zustandspassiv – grammatisch hier nicht korrekt."
+              "options": [
+                "a) für",
+                "b) nach",
+                "c) um"
+              ],
+              "correctAnswer": "c",
+              "explanation": "Festes Muster: 'jemanden um etwas bitten'. 'Für' gehört zu 'sich bedanken für'; 'nach' zu 'fragen nach'. Hier ist das Verb 'bitten', das 'um' verlangt."
             },
             {
               "blankNumber": 6,
               "type": "mcq",
-              "options": ["a) habe", "b) hätte", "c) hatte"],
-              "correctAnswer": "b",
-              "explanation": "Irreale Bedingung im Konjunktiv II: 'Wenn ich mehr Routine hätte, würde ich ...' Der Hauptsatz mit 'würde' verlangt im Wenn-Satz ebenfalls Konjunktiv II ('hätte'). 'habe' (Indikativ) und 'hatte' (Präteritum) passen nicht."
+              "options": [
+                "a) enthalten",
+                "b) beinhaltet",
+                "c) einbezogen"
+              ],
+              "correctAnswer": "a",
+              "explanation": "'Im Preis enthalten sein' ist die Standardformulierung im Reise- und Kursbereich. 'Beinhaltet' ist ein Verb ('beinhalten'), kein Adjektiv, und passt nicht als Prädikativum. 'Einbezogen' ist in anderen Kontexten üblich, hier aber untypisch."
             },
             {
               "blankNumber": 7,
               "type": "mcq",
-              "options": ["a) zu", "b) auf", "c) zum"],
-              "correctAnswer": "c",
-              "explanation": "Feste Wendung: 'zum Sport gehen' (zu + dem = zum, Dativ). 'zu' allein braucht immer einen Artikel. 'auf Sport gehen' gibt es im Standarddeutsch nicht."
+              "options": [
+                "a) wie",
+                "b) was",
+                "c) wann"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Indirekte W-Frage nach Anzahl: 'wie viele Stunden'. Die Kombination 'wie viele' ist fest. 'Was für Stunden' wäre eine Art-Frage; 'wann' fragt nach Uhrzeit, nicht nach Anzahl."
             },
             {
               "blankNumber": 8,
               "type": "mcq",
-              "options": ["a) haben", "b) sind", "c) waren"],
-              "correctAnswer": "b",
-              "explanation": "Perfekt von 'gehen' mit Hilfsverb 'sein': 'Wir sind ... gegangen.' Bewegungsverben nehmen 'sein'. 'haben' ist falsch. 'waren' wäre Präteritum, passt aber nicht zum Partizip 'gegangen'."
+              "options": [
+                "a) kann",
+                "b) dürfte",
+                "c) würde"
+              ],
+              "correctAnswer": "c",
+              "explanation": "Höfliche Bitte im Geschäftsbrief: 'Würde ich Sie bitten, ...' ist die korrekte Konjunktiv-II-Konstruktion. 'Kann' ist zu direkt. 'Dürfte' fragt nach Erlaubnis, formuliert aber keine Bitte."
             },
             {
               "blankNumber": 9,
               "type": "mcq",
-              "options": ["a) mich", "b) mir", "c) für mich"],
+              "options": [
+                "a) ob",
+                "b) dass",
+                "c) wenn"
+              ],
               "correctAnswer": "a",
-              "explanation": "'sich freuen' ist reflexiv mit Akkusativ: 'Ich freue mich.' 'mir' (Dativ) gehört zu anderen Verben (sich etwas wünschen). 'für mich' ist kein Reflexivpronomen."
+              "explanation": "Indirekter Wunsch mit Fragecharakter: 'Ich würde mich freuen, ob Sie mich erreichen könnten.' 'Ob' leitet eine indirekte Ja/Nein-Frage ein. 'Dass' leitet eine Tatsachenaussage ein; 'wenn' eine Bedingung — beide unpassend."
             },
             {
               "blankNumber": 10,
               "type": "mcq",
-              "options": ["a) der", "b) dem", "c) den"],
-              "correctAnswer": "c",
-              "explanation": "'den schönsten Tag' ist Akkusativobjekt von 'haben' (Maskulinum): 'den'. 'der' wäre Nominativ, 'dem' Dativ. Die starke Adjektivendung '-sten' bestätigt Akkusativ Maskulinum."
+              "options": [
+                "a) könnten",
+                "b) können",
+                "c) konnten"
+              ],
+              "correctAnswer": "a",
+              "explanation": "Der Hauptsatz enthält 'würde' (Konjunktiv II), also muss der Nebensatz ebenfalls im Konjunktiv II stehen: 'könnten'. 'Können' (Indikativ Präsens) und 'konnten' (Präteritum Indikativ) brechen die Konsistenz des Konjunktivs. [Distractor type: verb voice/mood swap]"
             }
           ]
         },
         {
           "partNumber": 2,
           "instructions": "Lesen Sie den folgenden Text. Welches Wort aus der Liste a–o passt in die Lücken? Jedes Wort passt nur einmal. Fünf Wörter bleiben übrig.",
-          "text": "Liebe Nadja,\n\nvielen __(11)__ für deine letzte E-Mail! Ich hatte nicht damit gerechnet, so schnell etwas von dir zu hören. Wie du weißt, habe ich vor einem halben Jahr die Stelle gewechselt. Der Anfang war ziemlich anstrengend, aber __(12)__ habe ich mich gut eingearbeitet.\n\nMein neuer Chef ist sehr freundlich, nur die Deadlines sind manchmal schwer einzuhalten. Wir haben im letzten Monat intensiv darüber __(13)__ und uns auf eine neue Planung geeinigt. Seitdem __(14)__ es deutlich besser. Ich habe weniger Stress und kann meine Aufgaben pünktlich erledigen.\n\nAußerdem bin ich jetzt __(15)__ ein neues Team zuständig, das direkt mit Kunden aus Österreich arbeitet. __(16)__ der letzten Woche habe ich zum ersten Mal allein ein Kundengespräch geführt – es hat gut geklappt, und ich war am Ende richtig stolz auf mich.\n\nNur eines nervt mich gerade: Die Firma hat die Gehälter dieses Jahr leider nicht __(17)__. Ich hatte fest __(18)__ eine kleine Erhöhung gehofft, weil ich viel mehr Verantwortung übernommen habe. Aber der Chef meint, nächstes Jahr sehe die Lage __(19)__ besser aus.\n\nMelde dich bald, ich vermisse dich! __(20)__ können wir uns ja im Frühling mal ein Wochenende in Prag gönnen.\n\nLiebe Grüße,\nSimon",
+          "text": "Lieber Fabian,\n\nstell dir vor — ich habe __(11)__ eine Stelle gefunden! Ab nächstem Monat fange ich als Praktikantin in einem kleinen Architekturbüro an. Ich bin so aufgeregt, ich konnte __(12)__ kaum schlafen.\n\nDer Chef, Herr Vollmer, war beim Gespräch total nett und hat mir alles ausführlich erklärt. Er meinte, ich würde __(13)__ den ersten Wochen vor allem beobachten und mithelfen, aber danach dürfte ich eigene kleine Aufgaben __(14)__. Das klingt für mich nach einem wirklich guten Einstieg!\n\nIch mache das Praktikum __(15)__ meines Pflichtpraktikums im fünften Semester. Die Hochschule hat mir bestätigt, dass ich es mir __(16)__ anrechnen lassen kann. Kein Stress also mit Papieren — das lief zum Glück reibungslos.\n\nDas Büro liegt __(17)__ der Stadtmitte, ungefähr 20 Minuten mit dem Fahrrad. Ich freue mich schon __(18)__ die frische Luft morgens! Und weißt du was — wenn ich Glück habe, __(19)__ das Büro mich sogar nach dem Studium übernehmen. Das wäre natürlich der absolute Traum.\n\nSchreib mir bald, wie es bei dir __(20)__. Ich bin gespannt!\n\nLiebe Grüße,\nMaja",
           "questions": [
             {
               "blankNumber": 11,
               "type": "word_bank",
               "options": [
-                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
-                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
-                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+                "a) endlich",
+                "b) kaum",
+                "c) in",
+                "d) übernehmen",
+                "e) wegen",
+                "f) nahe",
+                "g) auf",
+                "h) könnte",
+                "i) läuft",
+                "j) sogar",
+                "k) vor",
+                "l) danach",
+                "m) damit",
+                "n) auch",
+                "o) die"
               ],
               "correctAnswer": "a",
-              "explanation": "Die feste Briefformel 'Vielen Dank für deine E-Mail' verlangt 'Dank' nach 'vielen'. Distraktor k) 'besten' passt grammatisch ('besten Dank' wäre möglich), aber der Text liefert 'vielen', das direkt zu 'Dank' führt."
+              "explanation": "'Endlich eine Stelle gefunden' — 'endlich' drückt aus, dass es lang erwartet wurde. 'Kaum' würde eine Negation bedeuten. 'Sogar' wäre möglich aber schwächer; 'endlich' trifft den emotionalen Ton des langen Wartens."
             },
             {
               "blankNumber": 12,
               "type": "word_bank",
               "options": [
-                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
-                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
-                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+                "a) endlich",
+                "b) kaum",
+                "c) in",
+                "d) übernehmen",
+                "e) wegen",
+                "f) nahe",
+                "g) auf",
+                "h) könnte",
+                "i) läuft",
+                "j) sogar",
+                "k) vor",
+                "l) danach",
+                "m) damit",
+                "n) auch",
+                "o) die"
               ],
               "correctAnswer": "b",
-              "explanation": "'Der Anfang war anstrengend, aber inzwischen habe ich mich gut eingearbeitet.' 'inzwischen' bedeutet 'mittlerweile' – ein zeitlicher Gegensatz zum Anfang. 'damit' (Zweck) oder 'hoffentlich' (Wunsch) passen hier nicht."
+              "explanation": "'Ich konnte kaum schlafen' — 'kaum' bedeutet 'fast nicht'. Der Satz drückt extreme Aufregung aus. 'Auch' oder 'sogar' würden den Sinn verzerren."
             },
             {
               "blankNumber": 13,
               "type": "word_bank",
               "options": [
-                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
-                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
-                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+                "a) endlich",
+                "b) kaum",
+                "c) in",
+                "d) übernehmen",
+                "e) wegen",
+                "f) nahe",
+                "g) auf",
+                "h) könnte",
+                "i) läuft",
+                "j) sogar",
+                "k) vor",
+                "l) danach",
+                "m) damit",
+                "n) auch",
+                "o) die"
               ],
               "correctAnswer": "c",
-              "explanation": "'Wir haben intensiv darüber gesprochen' – Verb+Präposition 'sprechen über'. Das Partizip II 'gesprochen' schließt das Perfekt ab. 'entschieden' würde 'über etwas entscheiden' erlauben, ist aber inhaltlich schwächer: Gespräch führt zu einer Einigung, nicht stumme Entscheidung."
+              "explanation": "'In den ersten Wochen' — Zeitangabe mit 'in' + Dativ Plural. 'Vor den ersten Wochen' würde 'bevor sie anfangen' bedeuten, was keinen Sinn ergibt in diesem Kontext."
             },
             {
               "blankNumber": 14,
               "type": "word_bank",
               "options": [
-                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
-                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
-                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+                "a) endlich",
+                "b) kaum",
+                "c) in",
+                "d) übernehmen",
+                "e) wegen",
+                "f) nahe",
+                "g) auf",
+                "h) könnte",
+                "i) läuft",
+                "j) sogar",
+                "k) vor",
+                "l) danach",
+                "m) damit",
+                "n) auch",
+                "o) die"
               ],
               "correctAnswer": "d",
-              "explanation": "'Seitdem läuft es deutlich besser' – 'es läuft' ist eine idiomatische Wendung für 'es funktioniert gut, es klappt'. Distraktor m) 'bleibt' passt semantisch nicht (beschreibt keine Verbesserung)."
+              "explanation": "'Eigene Aufgaben übernehmen' — Kollokation: Aufgaben übernehmen. Das Infinitiv 'übernehmen' schließt die Modalverbkonstruktion 'dürfte ... übernehmen' ab. 'Danach' oder 'damit' wären Adverbien, keine Vollverben."
             },
             {
               "blankNumber": 15,
               "type": "word_bank",
               "options": [
-                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
-                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
-                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+                "a) endlich",
+                "b) kaum",
+                "c) in",
+                "d) übernehmen",
+                "e) wegen",
+                "f) nahe",
+                "g) auf",
+                "h) könnte",
+                "i) läuft",
+                "j) sogar",
+                "k) vor",
+                "l) danach",
+                "m) damit",
+                "n) auch",
+                "o) die"
               ],
               "correctAnswer": "e",
-              "explanation": "Feste Kombination 'zuständig sein für + Akkusativ'. 'für' ist obligatorisch. 'auf' oder 'durch' bilden mit 'zuständig' keine Struktur."
+              "explanation": "'Wegen meines Pflichtpraktikums' — kausale Präposition 'wegen' + Genitiv. Das Praktikum wird absolviert, weil es Pflicht ist. 'In' oder 'vor' bilden keine sinnvolle Präpositionalphrase."
             },
             {
               "blankNumber": 16,
               "type": "word_bank",
               "options": [
-                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
-                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
-                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+                "a) endlich",
+                "b) kaum",
+                "c) in",
+                "d) übernehmen",
+                "e) wegen",
+                "f) nahe",
+                "g) auf",
+                "h) könnte",
+                "i) läuft",
+                "j) sogar",
+                "k) vor",
+                "l) danach",
+                "m) damit",
+                "n) auch",
+                "o) die"
               ],
-              "correctAnswer": "f",
-              "explanation": "Zeitangabe am Satzanfang: 'In der letzten Woche ...'. 'in' + Dativ mit Zeitspanne (während). Die Großschreibung ('In') zeigt den Satzanfang."
+              "correctAnswer": "j",
+              "explanation": "'Ich kann es mir sogar anrechnen lassen' — 'sogar' unterstreicht die Überraschung/Freude, dass es reibungslos klappt. Das Reflexivpronomen 'mir' steht bereits im Text; 'sogar' füllt die Lücke vor 'anrechnen'. [Note: the text reads 'dass ich es mir __(16)__ anrechnen lassen kann' — 'sogar' fits as an emphasising adverb.]"
             },
             {
               "blankNumber": 17,
               "type": "word_bank",
               "options": [
-                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
-                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
-                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+                "a) endlich",
+                "b) kaum",
+                "c) in",
+                "d) übernehmen",
+                "e) wegen",
+                "f) nahe",
+                "g) auf",
+                "h) könnte",
+                "i) läuft",
+                "j) sogar",
+                "k) vor",
+                "l) danach",
+                "m) damit",
+                "n) auch",
+                "o) die"
               ],
-              "correctAnswer": "g",
-              "explanation": "'Gehälter erhöhen' ist die Standardkollokation (increase salaries). Partizip II 'erhöht' vervollständigt das Perfekt. 'entschieden' wäre grammatisch möglich ('hat ... entschieden'), aber inhaltlich unpassend."
+              "correctAnswer": "f",
+              "explanation": "'Nahe der Stadtmitte' — Präposition 'nahe' + Genitiv bedeutet 'in der Nähe der Stadtmitte'. Bestätigt durch den Folgesatz: '20 Minuten mit dem Fahrrad' — nah, aber nicht direkt drin."
             },
             {
               "blankNumber": 18,
               "type": "word_bank",
               "options": [
-                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
-                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
-                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+                "a) endlich",
+                "b) kaum",
+                "c) in",
+                "d) übernehmen",
+                "e) wegen",
+                "f) nahe",
+                "g) auf",
+                "h) könnte",
+                "i) läuft",
+                "j) sogar",
+                "k) vor",
+                "l) danach",
+                "m) damit",
+                "n) auch",
+                "o) die"
               ],
-              "correctAnswer": "h",
-              "explanation": "Verb+Präposition: 'hoffen auf + Akkusativ' ('auf eine Erhöhung hoffen'). 'für' würde zu anderen Verben passen ('sich bedanken für'). 'durch' ist hier nicht idiomatisch."
+              "correctAnswer": "g",
+              "explanation": "'Ich freue mich auf' — feste Verbvalenz: sich freuen auf + Akkusativ (für Zukünftiges). 'Sich freuen über' gilt für Vergangenes. 'Für' oder 'mit' bilden keine korrekte Fügung."
             },
             {
               "blankNumber": 19,
               "type": "word_bank",
               "options": [
-                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
-                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
-                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+                "a) endlich",
+                "b) kaum",
+                "c) in",
+                "d) übernehmen",
+                "e) wegen",
+                "f) nahe",
+                "g) auf",
+                "h) könnte",
+                "i) läuft",
+                "j) sogar",
+                "k) vor",
+                "l) danach",
+                "m) damit",
+                "n) auch",
+                "o) die"
               ],
-              "correctAnswer": "i",
-              "explanation": "'Nächstes Jahr sehe die Lage hoffentlich besser aus' – das Adverb 'hoffentlich' drückt Hoffnung aus, passt zum Kontext, dass der Chef die Zukunft positiv darstellt. 'Vielleicht' wäre semantisch ähnlich, aber großgeschrieben und steht meist am Satzanfang; im Satzinneren funktioniert 'hoffentlich' besser."
+              "correctAnswer": "h",
+              "explanation": "'wenn ich Glück habe, könnte das Büro mich übernehmen' — Konjunktiv II 'könnte' drückt eine unsichere Möglichkeit aus, passend zum hypothetischen 'wenn'. 'Kann' (Indikativ) wäre zu sicher; 'sogar' (schon vergeben) ist ein Adverb und kein Vollverb."
             },
             {
               "blankNumber": 20,
               "type": "word_bank",
               "options": [
-                "a) Dank", "b) inzwischen", "c) gesprochen", "d) läuft", "e) für",
-                "f) In", "g) erhöht", "h) auf", "i) hoffentlich", "j) Vielleicht",
-                "k) besten", "l) entschieden", "m) bleibt", "n) durch", "o) damit"
+                "a) endlich",
+                "b) kaum",
+                "c) in",
+                "d) übernehmen",
+                "e) wegen",
+                "f) nahe",
+                "g) auf",
+                "h) könnte",
+                "i) läuft",
+                "j) sogar",
+                "k) vor",
+                "l) danach",
+                "m) damit",
+                "n) auch",
+                "o) die"
               ],
-              "correctAnswer": "j",
-              "explanation": "Satzanfang mit Modaladverb: 'Vielleicht können wir uns ...' Die Großschreibung zeigt Satzanfang. Übrig bleiben k), l), m), n), o) als Distraktoren."
+              "correctAnswer": "i",
+              "explanation": "'Schreib mir, wie es bei dir läuft' — idiomatische Formulierung in informellen Briefen: 'wie es läuft' = wie deine Situation ist. 'Geht' ist nicht in der Liste; 'läuft' ist die passende Alternative. Verbleibende Distraktoren: k), l), m), n), o)."
             }
           ]
         }
@@ -798,34 +1623,34 @@
         {
           "taskNumber": 1,
           "type": "letter",
-          "instructions": "Sie arbeiten seit einem halben Jahr in einer neuen Firma. Ihr Chef hat Ihnen vor Kurzem eine berufliche Weiterbildung vorgeschlagen. Schreiben Sie eine E-Mail an Ihren Chef, Herrn Hoffmann. Gehen Sie auf alle vier Punkte unten ein. Achten Sie auf eine passende Anrede und einen passenden Gruß. Schreiben Sie ca. 150 Wörter.",
-          "instructionsTranslation": "You have been working at a new company for six months. Your boss recently suggested a professional training course. Write an email to your boss, Mr. Hoffmann. Address all four points below. Pay attention to appropriate greeting and closing. Write approximately 150 words.",
-          "prompt": "Situation: Ihr Chef, Herr Hoffmann, hat Ihnen vorgeschlagen, an einer dreitägigen Weiterbildung zum Thema Projektmanagement teilzunehmen. Sie finden das Angebot sehr interessant und möchten gerne mitmachen.\n\nSchreiben Sie eine E-Mail an Herrn Hoffmann. Gehen Sie auf die folgenden vier Punkte ein:\n\n- Dank: Bedanken Sie sich für das Angebot.\n- Begründung: Erklären Sie, warum die Weiterbildung für Ihre Arbeit sinnvoll ist.\n- Frage: Fragen Sie, ob Sie während der drei Tage von Ihren Aufgaben freigestellt werden.\n- Organisation: Schlagen Sie vor, wie Ihre Vertretung während Ihrer Abwesenheit geregelt werden kann.\n\nVergessen Sie nicht Anrede, Einleitung und Grußformel. Schreiben Sie ca. 150 Wörter.",
-          "promptTranslation": "Situation: Your boss, Mr. Hoffmann, has suggested that you attend a three-day training course on project management. You find the offer very interesting and would like to participate.\n\nWrite an email to Mr. Hoffmann. Address these four points:\n\n- Thanks: Thank him for the offer.\n- Reason: Explain why the training is useful for your work.\n- Question: Ask whether you will be released from your duties during the three days.\n- Organization: Suggest how your replacement can be arranged during your absence.\n\nDon't forget greeting, introduction, and closing. Write approximately 150 words.",
+          "instructions": "Ihre Freundin Julia schreibt Ihnen: Sie plant, in Ihre Stadt umzuziehen. Sie kennt die Stadt kaum und fragt Sie um Rat. Schreiben Sie eine Antwort an Julia. Gehen Sie auf alle vier Punkte unten ein. Achten Sie auf eine passende Anrede und einen passenden Gruß. Schreiben Sie ca. 150 Wörter.",
+          "instructionsTranslation": "Your friend Julia writes to you: she is planning to move to your city. She barely knows the city and is asking for your advice. Write a reply to Julia. Address all four points below. Pay attention to appropriate greeting and closing. Write approximately 150 words.",
+          "prompt": "Situation: Ihre Freundin Julia schreibt Ihnen folgende E-Mail:\n\n'Liebe(r) ...,\n\ndu weißt, dass ich schon lange überlege, in deine Stadt zu ziehen. Jetzt habe ich endlich eine gute Stelle dort bekommen! Ich kenne die Stadt aber kaum. Kannst du mir helfen? Ich habe viele Fragen.\n\nLiebe Grüße, Julia'\n\nSchreiben Sie Julia eine Antwort. Gehen Sie auf die folgenden vier Punkte ein:\n\n- Stadtviertel: Welches Viertel empfehlen Sie ihr zum Wohnen und warum?\n- Verkehr: Wie kommt man am besten in der Stadt herum?\n- Kosten: Wie teuer sind Mieten ungefähr?\n- Tipp: Was sollte sie noch vor dem Umzug wissen?\n\nVergessen Sie nicht Anrede, Einleitung und Grußformel. Schreiben Sie ca. 150 Wörter.",
+          "promptTranslation": "Situation: Your friend Julia writes to you:\n\n'Dear ..., you know I've been thinking about moving to your city for a long time. I finally got a good job there! But I barely know the city. Can you help me? I have so many questions. Best wishes, Julia'\n\nWrite a reply to Julia. Address these four points:\n- Neighbourhood: Which district do you recommend for living and why?\n- Transport: How do you best get around?\n- Costs: How expensive are rents roughly?\n- Tip: What else should she know before moving?\n\nDon't forget greeting, introduction, and closing. Write approximately 150 words.",
           "requiredPoints": [
-            "Dank für das Weiterbildungsangebot",
-            "Begründung, warum die Weiterbildung sinnvoll ist",
-            "Frage nach Freistellung während der drei Tage",
-            "Vorschlag zur Vertretung während der Abwesenheit"
+            "Empfehlung eines Stadtviertels mit Begründung",
+            "Hinweis zum Verkehr / zur Mobilität in der Stadt",
+            "Angabe zu Mietkosten",
+            "Praktischer Tipp vor dem Umzug"
           ],
           "wordCountMin": 130,
           "wordCountMax": 170,
-          "sampleAnswer": "Sehr geehrter Herr Hoffmann,\n\nvielen Dank für Ihr Angebot, an der dreitägigen Weiterbildung zum Thema Projektmanagement teilzunehmen. Über Ihren Vorschlag habe ich mich sehr gefreut und möchte die Möglichkeit gerne wahrnehmen.\n\nDa ich in den letzten Monaten immer öfter kleinere Projekte selbstständig betreue, wäre eine strukturierte Einführung in moderne Methoden sehr hilfreich für meine tägliche Arbeit. Ich könnte die neuen Kenntnisse direkt in unserem Team anwenden und würde die Kollegen gern an meinen Erfahrungen teilhaben lassen.\n\nIch hätte allerdings zwei Fragen: Ist es möglich, dass ich während dieser drei Tage komplett von meinen regulären Aufgaben freigestellt werde? Außerdem würde ich gerne mit Ihnen besprechen, wie meine Vertretung geregelt wird. Mein Vorschlag wäre, dass Frau Bruckner meine laufenden Kundenanfragen übernimmt – wir arbeiten ohnehin häufig zusammen.\n\nÜber eine kurze Rückmeldung würde ich mich sehr freuen.\n\nMit freundlichen Grüßen\nAlex Müller",
+          "sampleAnswer": "Liebe Julia,\n\nwas für eine tolle Nachricht — ich freue mich riesig, dass du bald hier wohnst! Lass mich dir ein paar Tipps geben.\n\nFür eine Wohnung würde ich dir das Nordviertel empfehlen. Es ist ruhig, grün und trotzdem gut an die Innenstadt angebunden. Viele junge Leute wohnen dort, und es gibt nette Cafés und einen wöchentlichen Markt.\n\nZum Thema Verkehr: Die Straßenbahn ist hier wirklich prima — mit einer Monatskarte kommst du überall hin. Ein Auto brauchst du eigentlich nicht.\n\nBei den Mieten solltest du mit etwa 800 bis 1.000 Euro für eine Zweizimmerwohnung rechnen. Schau frühzeitig, der Markt ist eng.\n\nEin letzter Tipp: Melde dich rechtzeitig beim Einwohnermeldeamt an — das kann länger dauern, als man denkt.\n\nIch kann's kaum erwarten, dich hier zu sehen!\n\nLiebe Grüße\nKim",
           "scoringCriteria": [
             {
               "criterion": "I. Inhaltliche Vollständigkeit",
               "maxPoints": 15,
-              "description": "Alle vier Leitpunkte (Dank, Begründung, Frage zur Freistellung, Vorschlag zur Vertretung) sind klar behandelt. Wird einer dieser Punkte als nicht bearbeitet bewertet (D), erhält der gesamte Text 0 Punkte."
+              "description": "Alle vier Leitpunkte (Stadtviertel, Verkehr, Mietkosten, Tipp) sind klar und erkennbar behandelt. Fehlt ein Punkt vollständig, erhält der gesamte Text 0 Punkte (D-Bewertung)."
             },
             {
               "criterion": "II. Kommunikative Gestaltung",
               "maxPoints": 15,
-              "description": "Angemessene formelle Anrede ('Sehr geehrter Herr Hoffmann'), klare Einleitung, Verwendung passender Konnektoren (außerdem, allerdings, da), formelle Grußformel, sinnvolle Absatzstruktur."
+              "description": "Angemessene informelle Anrede ('Liebe Julia'), freundlicher Einstieg, logischer Aufbau, Konnektoren (zum Thema, außerdem, ein letzter Tipp), idiomatische Formulierungen ('ich kann's kaum erwarten'), passende Grußformel."
             },
             {
               "criterion": "III. Formale Richtigkeit",
               "maxPoints": 15,
-              "description": "Grammatik, Rechtschreibung und Wortwahl auf B1-Niveau. Verbformen (Perfekt, Konjunktiv II für höfliche Bitten), Satzstellung in Nebensätzen, Kasus nach Präpositionen. Schwerwiegende Grammatikfehler, die das Verständnis blockieren, führen zu D (und damit 0 Punkten für den gesamten Text)."
+              "description": "Grammatik und Rechtschreibung auf B1-Niveau. Konjunktiv II für Empfehlungen ('würde empfehlen', 'solltest'), korrekte Nebensatzkonstruktionen, Kasusregeln. Schwere Verständnisfehler führen zur D-Bewertung."
             }
           ]
         }
@@ -840,50 +1665,44 @@
           "type": "introduce",
           "instructions": "Stellen Sie sich Ihrem Gesprächspartner/Ihrer Gesprächspartnerin vor. Sprechen Sie über sich: Name, Herkunft, Wohnort, Familie, Beruf oder Ausbildung, Hobbys und Sprachen. Stellen Sie anschließend Ihrem Partner/Ihrer Partnerin mindestens zwei Fragen.",
           "instructionsTranslation": "Introduce yourself to your conversation partner. Talk about: name, origin, place of residence, family, work or education, hobbies, and languages. Afterwards ask your partner at least two questions.",
-          "prompt": "Bitte stellen Sie sich Ihrem Partner / Ihrer Partnerin vor. Sprechen Sie u.a. über:\n- Ihren Namen und Ihre Herkunft\n- Ihren aktuellen Wohnort und seit wann Sie dort leben\n- Ihre Familie\n- Ihren Beruf oder Ihr Studium\n- Ihre Hobbys und Interessen\n- Die Sprachen, die Sie sprechen\n\nStellen Sie danach Ihrem Partner / Ihrer Partnerin mindestens zwei Fragen, um mehr über sie/ihn zu erfahren. Vorbereitungszeit: 20 Minuten für die gesamte mündliche Prüfung.",
-          "sampleResponse": "Hallo, mein Name ist Maria Kovac, und ursprünglich komme ich aus Zagreb in Kroatien. Ich lebe seit fünf Jahren in Köln, weil ich hier eine Stelle als Buchhalterin bei einer mittelständischen Baufirma gefunden habe. Meine Familie ist gemischt: Mein Mann ist Deutscher, wir haben eine kleine Tochter, die drei Jahre alt ist und bald in den Kindergarten geht. Meine Eltern leben weiterhin in Zagreb, und ich besuche sie zwei- bis dreimal im Jahr. Beruflich arbeite ich jetzt seit acht Jahren in der Buchhaltung und übernehme seit einem Jahr auch kleinere Projekte in der Personalabteilung – das macht mir richtig Spaß. In meiner Freizeit lese ich gern Krimis und gehe zweimal pro Woche ins Schwimmbad. Außerdem koche ich leidenschaftlich gerne. Sprachlich: Muttersprache Kroatisch, dazu Deutsch, Englisch und etwas Italienisch. Und wie ist das bei dir? Woher kommst du, und was machst du beruflich?",
+          "prompt": "Bitte stellen Sie sich Ihrem Partner / Ihrer Partnerin vor. Sprechen Sie u.a. über:\n- Ihren Namen und Ihre Herkunft\n- Ihren aktuellen Wohnort und seit wann Sie dort leben\n- Ihre Familie\n- Ihren Beruf, Ihr Studium oder Ihre Ausbildung\n- Ihre Hobbys und Interessen\n- Die Sprachen, die Sie sprechen\n\nStellen Sie danach Ihrem Partner / Ihrer Partnerin mindestens zwei Fragen, um mehr über sie/ihn zu erfahren. Vorbereitungszeit: 20 Minuten für die gesamte mündliche Prüfung.",
+          "sampleResponse": "Guten Tag, ich heiße Mia Sander und komme ursprünglich aus Dortmund. Seit fast drei Jahren lebe ich jetzt in Freiburg — ich bin hierhergekommen, weil ich an der Universität Wirtschaft studiere. Das Studium gefällt mir gut, obwohl das vierte Semester wirklich viel Stoff hatte. Meine Familie ist in Dortmund geblieben: Meine Eltern und mein jüngerer Bruder wohnen noch dort, und ich besuche sie in den Semesterferien. In meiner Freizeit fahre ich gerne Mountainbike, das ist hier im Schwarzwald natürlich fantastisch. Außerdem koche ich leidenschaftlich — am liebsten asiatisch. Sprachlich: Deutsch ist meine Muttersprache, dazu Englisch auf C1-Niveau und ein bisschen Spanisch. Und was ist mit dir — studierst du auch, oder bist du schon berufstätig? Und woher kommst du?",
           "evaluationTips": [
-            "Strukturieren Sie Ihre Vorstellung – beginnen Sie nicht mit Hobbys, sondern mit Name und Herkunft",
-            "Verwenden Sie Nebensätze mit 'weil', 'wo', 'der/die' – das zeigt B1-Niveau",
-            "Sprechen Sie in Absätzen: ein Gedanke pro Thema, nicht alles in einem langen Satz",
-            "Stellen Sie echte Fragen – keine Ja/Nein-Fragen, sondern W-Fragen, die zu einem Gespräch einladen",
-            "Nennen Sie konkrete Details (Stadt, Jahre, Beruf), keine abstrakten Angaben",
-            "Reagieren Sie auf die Antworten Ihres Partners: 'Das finde ich interessant – erzähl mehr.'"
+            "Strukturieren Sie die Vorstellung von allgemein zu spezifisch — erst Herkunft, dann aktuelle Situation",
+            "Verwenden Sie Relativsätze und Kausalsätze: 'weil', 'obwohl', 'der/die', 'wo'",
+            "Nennen Sie konkrete Details: Stadt, Fach, Dauer, Hobbynamen",
+            "Stellen Sie echte offene Fragen, die ein Gespräch einladen",
+            "Reagieren Sie auf die Antworten des Partners"
           ],
           "keyPhrases": [
-            "Mein Name ist ... und ich komme aus ...",
-            "Seit ... Jahren lebe ich in ...",
-            "Beruflich bin ich ... / Ich arbeite als ...",
-            "In meiner Freizeit ... / Ich interessiere mich besonders für ...",
-            "Neben Deutsch spreche ich ...",
-            "Und du – woher kommst du?",
-            "Was machst du eigentlich beruflich?"
+            "Ich komme ursprünglich aus ... / Ich lebe seit ... Jahren in ...",
+            "Ich studiere ... / Ich mache eine Ausbildung als ...",
+            "In meiner Freizeit ... / Besonders mag ich ...",
+            "Neben Deutsch spreche ich außerdem ...",
+            "Und du — was machst du gerade?"
           ]
         },
         {
           "partNumber": 2,
           "type": "discussion",
-          "instructions": "Sie erhalten einen kurzen Text zum Thema. Fassen Sie den Inhalt für Ihren Partner zusammen, beantworten Sie die drei Leitfragen, und tauschen Sie Ihre Meinung mit dem Partner aus.",
-          "instructionsTranslation": "You receive a short text on the topic. Summarize the content for your partner, answer the three guiding questions, and exchange your opinions with your partner.",
-          "prompt": "Thema: Weiterbildung im Beruf\n\nLesen Sie den folgenden kurzen Text:\n\n'Immer mehr Arbeitnehmer in Deutschland nehmen an Weiterbildungen teil. Eine aktuelle Studie zeigt: Fast die Hälfte aller Beschäftigten besucht mindestens einmal pro Jahr einen beruflichen Kurs oder ein Seminar. Viele machen das in ihrer Freizeit, andere werden vom Arbeitgeber freigestellt. Experten sind sich einig: Wer heute beruflich erfolgreich sein will, muss lebenslang lernen.'\n\nLeitfragen:\n1. Fassen Sie kurz den Inhalt des Textes zusammen (in 2–3 Sätzen).\n2. Haben Sie schon einmal an einer beruflichen Weiterbildung teilgenommen? Wenn ja, welche – und was hat Ihnen besonders gefallen oder gefehlt?\n3. Sollte Weiterbildung in der Arbeitszeit stattfinden oder in der Freizeit der Mitarbeiter? Begründen Sie Ihre Meinung.\n\nSprechen Sie mit Ihrem Partner/Ihrer Partnerin über das Thema – fragen Sie auch nach seiner/ihrer Meinung.",
-          "sampleResponse": "Im Text steht, dass fast jeder zweite Arbeitnehmer in Deutschland einmal pro Jahr eine Weiterbildung macht. Manche nutzen ihre Freizeit dafür, andere werden von der Firma freigestellt. Die Experten meinen, dass lebenslanges Lernen heute wichtig ist.\n\nIch habe letztes Jahr an einem Kurs 'Excel für Fortgeschrittene' teilgenommen. Das war ein zweitägiges Seminar bei einem externen Anbieter – mein Chef hat mich freigestellt und die Kosten übernommen. Der Kurs war sehr praktisch, ich kann heute meine Tabellen viel schneller erstellen. Gefehlt hat mir allerdings etwas: Es gab kaum Zeit, eigene Fragen zu besprechen.\n\nMeiner Meinung nach sollte Weiterbildung in der Arbeitszeit stattfinden. Es handelt sich ja um eine Investition, von der die Firma direkt profitiert. Wer sich in der Freizeit weiterbildet, opfert Zeit mit Familie oder Hobbys. Natürlich können kleine Online-Kurse auch abends funktionieren, aber längere Seminare gehören aus meiner Sicht in den Arbeitsalltag. Wie siehst du das – findest du es fair, wenn Kollegen am Wochenende für den Beruf lernen?",
+          "instructions": "Sie erhalten Informationen zum Thema. Fassen Sie den Inhalt für Ihren Partner zusammen, beantworten Sie die Leitfragen und tauschen Sie Ihre Meinung aus.",
+          "instructionsTranslation": "You receive information on the topic. Summarize the content for your partner, answer the guiding questions, and exchange opinions.",
+          "prompt": "Thema: Sport — Warum bewegen sich Deutsche?\n\nBetrachten Sie die folgenden Informationen:\n\nViele Erwachsene in Deutschland treiben Sport. Die häufigsten Gründe:\n- Abnehmen / Gewicht halten\n- Gesund bleiben / Stress abbauen\n- Spaß und Geselligkeit\n\nLaut einer Umfrage treiben 62 % der Deutschen mindestens einmal pro Woche Sport.\n\nLeitfragen:\n1. Fassen Sie die Informationen kurz zusammen (2–3 Sätze).\n2. Warum treiben Sie selbst Sport — oder warum nicht?\n3. Glauben Sie, dass man eher allein oder in der Gruppe Sport treiben sollte? Begründen Sie Ihre Meinung.\n\nSprechen Sie mit Ihrem Partner über das Thema — fragen Sie nach seiner/ihrer Meinung.",
+          "sampleResponse": "Die Statistik zeigt, dass über die Hälfte der Deutschen mindestens einmal pro Woche Sport macht. Die wichtigsten Gründe sind Gesundheit, Stressabbau und der Spaßfaktor.\n\nIch selbst fahre zweimal pro Woche Rad — nicht wegen des Aussehens, ehrlich gesagt, sondern weil ich nach einem langen Unitag einfach den Kopf freibekomme. Das ist für mich Erholung auf zwei Rädern.\n\nOb man lieber allein oder in der Gruppe Sport treibt, hängt meiner Meinung nach sehr vom Typ ab. Ich persönlich laufe lieber allein, weil ich dann das Tempo selbst bestimmen kann. Aber ich verstehe, dass viele Leute die Gruppe brauchen, um überhaupt aufzustehen — da ist der soziale Druck manchmal wirklich hilfreich. Wie ist das bei dir — bist du eher ein Einzelsportler oder magst du den Mannschaftsgeist?",
           "evaluationTips": [
-            "Beginnen Sie mit einer klaren Zusammenfassung, bevor Sie Ihre Meinung nennen",
-            "Nennen Sie konkrete Beispiele aus Ihrem eigenen Arbeitsalltag, keine allgemeinen Aussagen",
-            "Verwenden Sie Meinungsformulierungen: 'Meiner Meinung nach ...', 'Ich finde, dass ...', 'Aus meiner Sicht ...'",
-            "Gliedern Sie Vor- und Nachteile klar: 'Einerseits ..., andererseits ...'",
-            "Stellen Sie dem Partner mindestens eine inhaltliche Rückfrage",
-            "Benutzen Sie Konnektoren wie 'allerdings', 'außerdem', 'trotzdem', 'deshalb' – das wertet die Antwort auf"
+            "Beginnen Sie mit einer klaren, kurzen Zusammenfassung der Daten",
+            "Sprechen Sie in der ersten Person und mit konkreten Beispielen",
+            "Formulieren Sie Meinungen: 'Meiner Meinung nach', 'Ich glaube, dass', 'Für mich persönlich'",
+            "Stellen Sie dem Partner mindestens eine inhaltliche Gegenfrage",
+            "Benutzen Sie Konnektoren: 'weil', 'obwohl', 'einerseits ... andererseits', 'außerdem'"
           ],
           "keyPhrases": [
-            "Im Text geht es um ...",
-            "Der Text berichtet, dass ...",
-            "Meiner Meinung nach ...",
-            "Ich finde es wichtig, dass ...",
-            "Ein Vorteil/Nachteil ist, dass ...",
-            "Einerseits ... andererseits ...",
-            "Wie siehst du das?",
-            "Hast du ähnliche Erfahrungen gemacht?"
+            "Laut der Statistik / Den Daten zufolge ...",
+            "Der wichtigste Grund scheint ... zu sein",
+            "Ich persönlich ... weil ...",
+            "Das hängt meiner Meinung nach davon ab, ob ...",
+            "Einerseits ..., andererseits ...",
+            "Wie siehst du das?"
           ]
         },
         {
@@ -891,27 +1710,23 @@
           "type": "planning",
           "instructions": "Sie sollen mit Ihrem Partner gemeinsam etwas planen. Machen Sie Vorschläge, reagieren Sie auf die Ideen Ihres Partners und einigen Sie sich am Ende auf eine gemeinsame Lösung.",
           "instructionsTranslation": "You are going to plan something together with your partner. Make suggestions, respond to your partner's ideas, and agree on a joint solution at the end.",
-          "prompt": "Ihre Kollegin Frau Bergmann verlässt nach fünfzehn Jahren die Firma und wechselt zu einem anderen Arbeitgeber. Sie möchten mit Ihrem Partner/Ihrer Partnerin gemeinsam eine Abschiedsfeier für sie im Büro organisieren.\n\nBesprechen Sie bitte folgende Punkte und kommen Sie zu einer gemeinsamen Entscheidung:\n\n- Wann und wo soll die Feier stattfinden (letzter Arbeitstag, Mittagspause, nach Feierabend)?\n- Wen laden Sie aus dem Kollegenkreis ein?\n- Was soll es zu essen und zu trinken geben? Wer kümmert sich um den Einkauf?\n- Welches gemeinsame Abschiedsgeschenk schlagen Sie vor?\n- Wer hält eine kleine Rede, und wer kümmert sich um die Dekoration?\n\nMachen Sie Vorschläge, gehen Sie auf die Vorschläge Ihres Partners ein und einigen Sie sich am Ende.",
-          "sampleResponse": "Also, ich würde vorschlagen, dass wir die Feier am Freitag, den 30. Mai, nach Feierabend organisieren – das ist ihr letzter Arbeitstag, und viele Kollegen haben am Wochenende dann frei. Was hältst du davon, im großen Besprechungsraum zu feiern? Der ist gemütlich und groß genug.\n\nIch denke, wir sollten das komplette Team plus ein paar enge Kollegen aus anderen Abteilungen einladen, insgesamt vielleicht 18 bis 20 Personen. Außerdem würde ich ihren früheren Chef dazunehmen – sie haben lange zusammengearbeitet.\n\nFür das Essen schlage ich ein kleines Buffet vor: belegte Brötchen, Salate und Obst. Ich könnte beim Catering-Service um die Ecke bestellen – macht das für dich Sinn? Und bei den Getränken teilen wir uns: Du übernimmst Wasser und Säfte, ich besorge einen guten Sekt für den Anstoß.\n\nAls Geschenk würde ich einen Gutschein für ein Wellness-Wochenende vorschlagen, alle Kollegen können dafür etwas in einen Umschlag legen. Ich hätte auch eine Karte bestellt, die jeder unterschreiben kann.\n\nLetzter Punkt: Hältst du die Rede? Du kennst sie ja am längsten. Ich würde dann die Dekoration übernehmen – ein paar Blumen und eine Fotowand mit Bildern aus ihrer Zeit hier. Einverstanden?",
+          "prompt": "Sie möchten mit Ihrem Freund / Ihrer Freundin einen gemeinsamen Tagesausflug am kommenden Wochenende machen. Ihr Budget ist begrenzt: maximal 30 Euro pro Person.\n\nBesprechen Sie folgende Punkte und einigen Sie sich auf einen Plan:\n\n- Ziel: Wohin soll der Ausflug gehen? (Naturpark, Sehenswürdigkeit, Nachbarstadt, See ...)\n- Anreise: Wie fahrt ihr hin? (Zug, Bus, Fahrrad, Auto?)\n- Programm: Was wollt ihr dort unternehmen?\n- Essen und Trinken: Wo und was esst ihr? (Picknick, Restaurant, Imbiss?)\n- Kosten: Wie bleibt ihr im Budget von 30 Euro?\n\nMachen Sie Vorschläge, gehen Sie auf die Ideen Ihres Partners ein und einigen Sie sich am Ende.",
+          "sampleResponse": "Also, ich hätte eine Idee: Was hältst du davon, wenn wir mit dem Zug in die Rhön fahren? Das dauert etwa eine Stunde und kostet mit dem Deutschlandticket schon 29 Euro — damit sind Hin- und Rückfahrt drin, und für das Ziel zahlen wir nichts.\n\nFür das Programm würde ich einen Wanderweg vorschlagen — es gibt da eine schöne Route zum Schwarzen Moor, ungefähr zwei Stunden. Das kostet nichts, und die Aussicht soll fantastisch sein. Wenn dir das zu weit ist, könnten wir auch nur zum Aussichtsturm laufen — das ist kürzer.\n\nBeim Essen schlage ich ein Picknick vor, das ist eindeutig günstiger als ein Restaurant. Ich mache Sandwiches und Obst, du kannst Getränke mitbringen. Ein heißer Kaffee aus der Thermoskanne macht den Tag auch gemütlicher.\n\nDamit bleiben wir klar unter 30 Euro. Vielleicht gönnen wir uns noch ein Eis vor Ort — das ist ja erlaubt. Klingt das gut, oder hast du einen anderen Vorschlag für das Ziel?",
           "evaluationTips": [
-            "Sprechen Sie nicht nur, sondern hören Sie auch aktiv zu – reagieren Sie auf die Vorschläge Ihres Partners",
-            "Machen Sie Vorschläge mit Konjunktiv II ('Ich würde vorschlagen ...', 'Wir könnten ...') – das wirkt höflich",
-            "Begründen Sie Ihre Vorschläge kurz: 'weil', 'damit', 'denn'",
-            "Einigen Sie sich am Ende wirklich – ein 'Das machen wir so, einverstanden?' zeigt Abschluss",
-            "Vermeiden Sie Monologe – lassen Sie dem Partner Raum für eigene Ideen",
-            "Verwenden Sie Modalverben: 'sollten wir', 'können wir', 'müssen wir' – das zeigt Planungssprache",
-            "Fassen Sie am Ende die wichtigsten Entscheidungen kurz zusammen"
+            "Planen Sie alle fünf genannten Punkte durch — das zeigt strukturiertes Sprechen",
+            "Machen Sie konkrete Vorschläge mit Konjunktiv II: 'Ich würde vorschlagen', 'Wir könnten'",
+            "Achten Sie auf das Budget: Argumentieren Sie, warum Ihre Ideen im Rahmen bleiben",
+            "Hören Sie aktiv zu und reagieren Sie auf die Vorschläge des Partners",
+            "Einigen Sie sich am Ende: 'Dann machen wir das so, einverstanden?'"
           ],
           "keyPhrases": [
-            "Ich würde vorschlagen, dass ...",
-            "Was hältst du davon, wenn ...?",
-            "Wir könnten ... machen.",
-            "Das ist eine gute Idee, aber ...",
-            "Alternativ könnten wir auch ...",
-            "Wer übernimmt ...?",
-            "Ich kann ... / Du bringst ... mit, okay?",
-            "Einverstanden!",
-            "Dann halten wir fest: ..."
+            "Was hältst du davon, wenn wir ... ?",
+            "Ich würde vorschlagen, dass wir ...",
+            "Das würde ungefähr ... Euro kosten.",
+            "Wir könnten auch alternativ ...",
+            "Ich finde deinen Vorschlag gut, aber ...",
+            "Dann halten wir fest: ...",
+            "Einverstanden!"
           ]
         }
       ]

--- a/packages/content/src/catalog.ts
+++ b/packages/content/src/catalog.ts
@@ -25,7 +25,7 @@ function generateEntries(level: Level, count: number): MockExamEntry[] {
       'Arbeit', 'Freizeit', 'Gesundheit', 'Reisen', 'Einkaufen',
     ],
     B1: [
-      'Alltag', 'Beruf', 'Bildung', 'Medien', 'Umwelt',
+      'Alltag', 'Berufseinstieg', 'Bildung', 'Medien', 'Umwelt',
       'Gesellschaft', 'Kultur', 'Gesundheit', 'Reisen', 'Konsum',
     ],
     B2: [


### PR DESCRIPTION
## Summary

Rewrites `apps/mobile/assets/content/B1/mock_02.json` (version 1 → 2) to Hueber-rigour standard as part of B1 Wave 1. Closes #151.

- **SB register split — profile B (inverse):** SB1 is now a formal `Sehr geehrte` service inquiry (Spanish language-course enquiry); SB2 remains `du`-form private letter (Maja writing to Fabian about her new Praktikum).
- **Listening T3:** Five distinct stem styles — `Aus welchem Grund`, `Wie plant X`, `Was hat X hauptsächlich gemacht`, `Worüber sind sich X einig`, `Was sagt X über` — zero templated triplet stems.
- **Sprechen T3:** Trip/Ausflug archetype — weekend Tagesausflug planning with 30 €/person budget, transport, programme, food logistics.
- **Reading T2:** Klinikclowns article (~500 words, paraphrased), 7 of 9 distractor types across R2 + L3 MCQs (causal reversal, subject-swap, generalisation, false-inference, lexical false-friend, numerical near-miss, time-frame trap).
- **Reading T3:** Jobs + Praktika ad cluster — 12 ads covering Stelle, Ausbildung, Werkstudent, Aushilfe, Saisonkraft, Freelance, duales Studium, Coworking across varied fields.
- **Schreiben:** Private penpal reply — respond to friend planning to move to your city (Viertel, Verkehr, Mietkosten, Umzugstipp). 130–170 words.
- **Catalog:** `packages/content/src/catalog.ts` B1 title array updated to convergent end-state (M02 = Berufseinstieg).

## Quality Gates

| Gate | Result |
|------|--------|
| Typecheck | PASS — clean |
| Web tests (379) | PASS — all green |
| Layer A structural | PASS — 5/5/10 reading, 10+10 SB blanks, 5+10+5 listening, playCount 1/1/2, 130–170 writing |
| SB register split | PASS — SB1 `Sehr geehrte` formal, SB2 `Lieber Fabian` informal |
| Distractor types | PASS — 7/9 types documented across R2+L3 |
| Idiom budget | PASS — 1–2 per content section |
| L3 stem diversity | PASS — 0 templated triplet stems |
| SP3 archetype | PASS — Tagesausflug trip planning |
| R3 cluster theme | PASS — jobs + Praktika, 12 ads |
| Mobile test failure | Pre-existing ESM infrastructure issue, not related to this PR |

## Test plan

- [ ] Load B1 mock 02 in the web app and verify all sections render
- [ ] Confirm SB1 shows formal register (`Sehr geehrte Damen und Herren`)
- [ ] Confirm SB2 shows informal register (`Lieber Fabian`)
- [ ] Confirm Sprechen Teil 3 prompt references Tagesausflug / Ausflug
- [ ] Confirm Reading Teil 3 ads are about jobs/Praktika/Ausbildung
- [ ] Run `pnpm test` — 379 web tests pass