### PR TITLE
content(B1-grammar): add Pronominaladverbien topic (darauf/daran/wofür/woran)

### DIFF
--- a/apps/mobile/src/data/grammar/B1_grammar.json
+++ b/apps/mobile/src/data/grammar/B1_grammar.json
@@ -1417,5 +1417,82 @@
       }
     ],
     "orderIndex": 24
+  },
+  {
+    "id": 25,
+    "level": "B1",
+    "topic": "Pronominaladverbien — darauf, daran, dafür, davon, dazu / worauf, woran, wofür, wovon, wozu",
+    "explanation": "Pronominaladverbien ersetzen Präposition + Pronomen, wenn sich der Bezug auf eine Sache oder einen abstrakten Begriff bezieht (nicht auf Personen). Bildung: da(r) + Präposition. Vor Präpositionen, die mit Vokal beginnen, wird ein -r- eingefügt: darüber, daran, darauf, darum. Kein -r-: damit, dabei, dazu, dafür, davon, dadurch. Bei Personen steht Präposition + Pronomen: Ich warte auf ihn (nicht: darauf). Für Fragen nach Sachen und Abstrakta: wo(r) + Präposition → worauf, woran, wofür, wovon, wozu. 'Worauf wartest du?' ist korrekt, 'Auf was wartest du?' gilt als umgangssprachlich. Feste Präpositionsverben bestimmen die Form: sich freuen auf → darauf; denken an → daran; warten auf → darauf; sich interessieren für → dafür; Angst haben vor → davor.",
+    "examples": [
+      "Ich freue mich darauf.",
+      "Worauf wartest du?",
+      "Sie denkt oft daran.",
+      "Ich habe Angst davor.",
+      "Damit kann ich nichts anfangen.",
+      "Wofür interessierst du dich?",
+      "Wir reden gerade darüber.",
+      "Kannst du dich daran erinnern?"
+    ],
+    "exercises": [
+      {
+        "type": "fill_blank",
+        "prompt": "Er wartet auf die Antwort. → Er wartet ___ .",
+        "correctAnswer": "darauf",
+        "explanation": "warten auf + Sache → Pronominaladverb: da + r + auf = darauf. Das -r- wird eingefügt, weil 'auf' mit Vokal beginnt."
+      },
+      {
+        "type": "fill_blank",
+        "prompt": "Sie interessiert sich für das Thema. → Sie interessiert sich ___ .",
+        "correctAnswer": "dafür",
+        "explanation": "sich interessieren für + Sache → dafür. Kein -r- nötig, da 'für' mit Konsonant beginnt."
+      },
+      {
+        "type": "fill_blank",
+        "prompt": "Ich denke an den Plan. → Ich denke ___ .",
+        "correctAnswer": "daran",
+        "explanation": "denken an + Sache → daran. -r- vor vokalisch anlautender Präposition 'an'."
+      },
+      {
+        "type": "fill_blank",
+        "prompt": "Wir freuen uns auf das Konzert. → Wir freuen uns ___ .",
+        "correctAnswer": "darauf",
+        "explanation": "sich freuen auf + Sache → darauf. Präposition 'auf' beginnt mit Vokal, daher da-r-auf."
+      },
+      {
+        "type": "fill_blank",
+        "prompt": "___ denkst du gerade? — An den Urlaub.",
+        "correctAnswer": "Woran",
+        "explanation": "Frage nach Sache/Abstraktum mit 'denken an': wo + r + an = Woran. Nicht 'An was' (umgangssprachlich)."
+      },
+      {
+        "type": "fill_blank",
+        "prompt": "___ wartet sie so lange? — Auf die Prüfungsergebnisse.",
+        "correctAnswer": "Worauf",
+        "explanation": "Frage nach Sache mit 'warten auf': wo + r + auf = Worauf. Das -r- erscheint, weil 'auf' mit Vokal beginnt."
+      },
+      {
+        "type": "multiple_choice",
+        "prompt": "Die Klasse freut sich ___ den Ausflug.",
+        "correctAnswer": "darauf",
+        "options": [
+          "darauf",
+          "auf ihn",
+          "auf es"
+        ],
+        "explanation": "'Ausflug' ist eine Sache, kein Mensch → Pronominaladverb darauf. 'auf ihn' wäre für eine Person; 'auf es' ist kein gültiges Pronominaladverb."
+      },
+      {
+        "type": "multiple_choice",
+        "prompt": "___ hast du so lange gespart? — Auf eine neue Kamera.",
+        "correctAnswer": "Wofür",
+        "options": [
+          "Wofür",
+          "Für was",
+          "Womit"
+        ],
+        "explanation": "'sparen für' + Sache → Frage mit wofür. 'Für was' gilt als umgangssprachlich; 'Womit' passt nicht zur Präposition 'für'."
+      }
+    ],
+    "orderIndex": 25
   }
 ]

--- a/apps/web/src/__tests__/grammar/GrammarLevelPage.test.tsx
+++ b/apps/web/src/__tests__/grammar/GrammarLevelPage.test.tsx
@@ -93,11 +93,11 @@ describe('GrammarLevelPage — static data, no fs at request time', () => {
     expect(cards.length).toBe(20);
   });
 
-  it('B1 renders topic grid with 24 cards', async () => {
+  it('B1 renders topic grid with 25 cards', async () => {
     await renderPage('B1');
     const grid = screen.getByTestId('topic-grid');
     const cards = grid.querySelectorAll('[data-testid^="topic-card-"]');
-    expect(cards.length).toBe(24);
+    expect(cards.length).toBe(25);
   });
 
   it('B2 renders topic grid with 27 cards', async () => {
@@ -115,7 +115,7 @@ describe('GrammarLevelPage — static data, no fs at request time', () => {
   });
 
   it('topic count subtitle matches the actual JSON count', async () => {
-    for (const [level, expected] of [['A1', 14], ['A2', 20], ['B1', 24], ['B2', 27], ['C1', 33]] as const) {
+    for (const [level, expected] of [['A1', 14], ['A2', 20], ['B1', 25], ['B2', 27], ['C1', 33]] as const) {
       const { unmount } = await renderPage(level);
       const countEl = screen.getByTestId('topic-count');
       expect(countEl.textContent).toBe(`${expected} topics`);

--- a/apps/web/src/__tests__/grammar/GrammarLevelTopicPage.test.tsx
+++ b/apps/web/src/__tests__/grammar/GrammarLevelTopicPage.test.tsx
@@ -147,10 +147,10 @@ describe('GrammarLevelTopicPage — static data, no fs at request time', () => {
     await expect(resolveGrammarTopicPage('D2', '1')).rejects.toThrow('NEXT_NOT_FOUND');
   });
 
-  it('B1/1 renders with correct total count of 24', async () => {
+  it('B1/1 renders with correct total count of 25', async () => {
     await renderPage('B1', '1');
     const counter = screen.getByTestId('topic-counter');
-    expect(counter.textContent).toBe('1 / 24');
+    expect(counter.textContent).toBe('1 / 25');
   });
 
   it('generateStaticParams includes all level+topic combinations', () => {
@@ -159,8 +159,8 @@ describe('GrammarLevelTopicPage — static data, no fs at request time', () => {
       const topics = getGrammarTopics(level);
       return topics.map((t) => ({ level, topicId: String(t.orderIndex) }));
     });
-    // A1(14) + A2(20) + B1(24) + B2(27) + C1(33) = 118
-    expect(params.length).toBe(118);
+    // A1(14) + A2(20) + B1(25) + B2(27) + C1(33) = 119
+    expect(params.length).toBe(119);
     // C1 contributes 33 entries
     const c1Entries = params.filter((p) => p.level === 'C1');
     expect(c1Entries.length).toBe(33);

--- a/apps/web/src/__tests__/grammar/loadGrammar.test.ts
+++ b/apps/web/src/__tests__/grammar/loadGrammar.test.ts
@@ -26,9 +26,9 @@ describe('loadGrammar shim — no fs, static data only', () => {
     }
   });
 
-  it('B1 returns 24 topics sorted by orderIndex', () => {
+  it('B1 returns 25 topics sorted by orderIndex', () => {
     const topics = loadGrammar('B1');
-    expect(topics).toHaveLength(24);
+    expect(topics).toHaveLength(25);
     for (let i = 0; i < topics.length - 1; i++) {
       expect(topics[i].orderIndex).toBeLessThan(topics[i + 1].orderIndex);
     }


### PR DESCRIPTION
## Summary

- Appends topic id=25 `Pronominaladverbien` to `B1_grammar.json` (24→25 topics)
- Covers: `da(r)+Präposition` formation rule, `-r-` insertion before vowel-initial prepositions, `wo-` question forms, fixed prepositional verb coverage (`darauf`, `daran`, `dafür`, `davor`, `worauf`, `woran`, `wofür`, `wozu`)
- 8 examples, 8 exercises: 4 fill_blank (form correct pronominaladverb), 2 fill_blank (question word), 2 multiple_choice with Hueber-style distractors (thing vs person, formal vs colloquial)

## Quality Gates

| Gate | Status |
|------|--------|
| typecheck | PASS — clean |
| web tests | PASS — 382/382 |
| mobile tests | n/a — pre-existing expo-modules-core ESM issue unrelated to this change |

## Test plan

- [ ] `pnpm typecheck` — clean
- [ ] `pnpm vitest run` in `apps/web` — 382 tests pass including all 5 grammar test files
- [ ] Verify B1 grammar page at `/grammar/B1` shows 25 topics
- [ ] Verify topic 25 renders at `/grammar/B1/25` with Pronominaladverbien content

Closes #194