### PR TITLE
fix(ssml): C1 mock_05 Google voices + remove zweimal (#216)

### DIFF
--- a/.planning/audio-prompts/C1_mock_05_listening_part1.ssml
+++ b/.planning/audio-prompts/C1_mock_05_listening_part1.ssml
@@ -1,94 +1,146 @@
 <speak>
-  <prosody rate="medium" pitch="medium">
+  <!-- C1 Mock 05 — Teil 1 (8 Kurzaussagen / Speaker-to-Summary matching, playCount=1) -->
+  <!-- [PEDAGOGY-REWRITE] Azure voices replaced with Google Cloud TTS voices -->
+  <!-- Theme: Populismus und demokratische Institutionen -->
+  <!-- Announcer: de-DE-Wavenet-C (female, neutral) -->
+  <!-- 8 speakers — 8 UNIQUE voices (4 female / 4 male) per CR-9 spec -->
+  <!-- Female: Wavenet-F (Sp1 Nolte), Wavenet-A (Sp3 Faber), Wavenet-E (Sp5 Möller), Neural2-F (Sp7 Langer) -->
+  <!-- Male:   Wavenet-B (Sp2 Reuter), Wavenet-D (Sp4 Grünwald), Neural2-B (Sp6 Steinbach), Neural2-D (Sp8 Wagner) -->
+  <!-- C1 spec: natural speed 1.0x, played ONCE, no pedagogical slowing -->
+  <!-- 10-second initial pause for candidates to read summary statements a-j -->
+  <!-- 5-second pauses between speakers -->
 
-    <!-- PART 1 INTRO -->
-    <s>Sie hören acht kurze Stellungnahmen verschiedener Personen zum Thema Populismus und demokratische Institutionen.</s>
-    <s>Hören Sie die Aussagen. Welche Zusammenfassung passt zu welchem Sprecher? Zwei Zusammenfassungen passen nicht.</s>
-    <break time="2s"/>
+  <break time="3s"/>
 
-    <!-- Sprecher 1: Frau Prof. Nolte, Verfassungsrechtlerin -->
-    <voice name="de-DE-KatjaNeural">
-      <s>Sprecher 1. Frau Prof. Nolte, Verfassungsrechtlerin.</s>
-      <break time="1s"/>
-      <s>Verfassungsgerichte dürfen nicht nur reaktiv sein.</s>
-      <s>Sie müssen populistischer Gesetzgebung schon im Entstehen entgegentreten, bevor sie irreversiblen Schaden anrichtet.</s>
-      <s>Das Bundesverfassungsgericht hat die Instrumente dafür — es muss sie auch nutzen wollen.</s>
-      <s>Wer wartet, bis das Gesetz vollzogen ist, handelt oft zu spät.</s>
-    </voice>
-    <break time="4s"/>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">
+      Hörverstehen, Teil 1. Sie hören acht kurze Stellungnahmen verschiedener Personen
+      zum Thema Populismus und demokratische Institutionen.
+      Lesen Sie zuerst die zehn Zusammenfassungen in Ihrem Testheft.
+      Welche Zusammenfassung passt zu welchem Sprecher?
+      Zwei Zusammenfassungen passen nicht.
+      Sie hören die Texte nur einmal.
+    </prosody>
+    <break time="10s"/>
+  </voice>
 
-    <!-- Sprecher 2: Herr Dr. Reuter, Politikwissenschaftler -->
-    <voice name="de-DE-ConradNeural">
-      <s>Sprecher 2. Herr Dr. Reuter, Politikwissenschaftler.</s>
-      <break time="1s"/>
-      <s>Populismus ist das Fieberthermometer, nicht das Fieber.</s>
-      <s>Wer ihn bekämpft, ohne die zugrunde liegenden Vertrauensdefizite anzugehen, behandelt das Symptom.</s>
-      <s>Wenn Menschen das Gefühl haben, dass etablierte Parteien sie nicht mehr hören, suchen sie Gehör woanders.</s>
-      <s>Das ist kein Versagen der Demokratie — das ist ihr Signal.</s>
-    </voice>
-    <break time="4s"/>
+  <!-- Sprecher 1: Frau Prof. Nolte, Verfassungsrechtlerin — Voice: de-DE-Wavenet-F (female, unique) -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Sprecher 1: Frau Professorin Nolte, Verfassungsrechtlerin.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="1.0">
+      Verfassungsgerichte dürfen nicht nur reaktiv sein.
+      Sie müssen populistischer Gesetzgebung schon im Entstehen entgegentreten, bevor sie irreversiblen Schaden anrichtet.
+      Das Bundesverfassungsgericht hat die Instrumente dafür — es muss sie auch nutzen wollen.
+      Wer wartet, bis das Gesetz vollzogen ist, handelt oft zu spät.
+    </prosody>
+  </voice>
+  <break time="5s"/>
 
-    <!-- Sprecher 3: Frau Dr. Faber, Wahlsystemforscherin -->
-    <voice name="de-DE-KatjaNeural">
-      <s>Sprecher 3. Frau Dr. Faber, Wahlsystemforscherin.</s>
-      <break time="1s"/>
-      <s>Ich befürworte Wahlsystemreformen, aber der gesellschaftliche Konsens muss vorher stehen.</s>
-      <s>Reformen ohne Rückhalt schwächen das Vertrauen in den demokratischen Prozess selbst.</s>
-      <s>Ein Wahlsystem ist kein technisches Werkzeug — es trägt die Legitimität jeder Regierung.</s>
-      <s>Wer es ohne Mehrheitsverständigung ändert, riskiert mehr als er gewinnt.</s>
-    </voice>
-    <break time="4s"/>
+  <!-- Sprecher 2: Herr Dr. Reuter, Politikwissenschaftler — Voice: de-DE-Wavenet-B (male, unique) -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Sprecher 2: Herr Dr. Reuter, Politikwissenschaftler.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="1.0">
+      Populismus ist das Fieberthermometer, nicht das Fieber.
+      Wer ihn bekämpft, ohne die zugrunde liegenden Vertrauensdefizite anzugehen, behandelt das Symptom.
+      Wenn Menschen das Gefühl haben, dass etablierte Parteien sie nicht mehr hören, suchen sie Gehör woanders.
+      Das ist kein Versagen der Demokratie — das ist ihr Signal.
+    </prosody>
+  </voice>
+  <break time="5s"/>
 
-    <!-- Sprecher 4: Herr Prof. Grünwald, Föderalismusexperte -->
-    <voice name="de-DE-ConradNeural">
-      <s>Sprecher 4. Herr Prof. Grünwald, Föderalismusexperte.</s>
-      <break time="1s"/>
-      <s>Gerade in Krisen zeigt sich der Wert des Föderalismus.</s>
-      <s>Wenn zentrale Institutionen unter Druck geraten, halten die Länder dagegen.</s>
-      <s>Das ist keine Schwäche des Systems — das ist gewollte Resilienz.</s>
-      <s>Wer Föderalismus als Blockierer sieht, verkennt seine eigentliche Schutzfunktion.</s>
-    </voice>
-    <break time="4s"/>
+  <!-- Sprecher 3: Frau Dr. Faber, Wahlsystemforscherin — Voice: de-DE-Wavenet-A (female, unique) -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Sprecher 3: Frau Dr. Faber, Wahlsystemforscherin.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="1.0">
+      Ich befürworte Wahlsystemreformen, aber der gesellschaftliche Konsens muss vorher stehen.
+      Reformen ohne Rückhalt schwächen das Vertrauen in den demokratischen Prozess selbst.
+      Ein Wahlsystem ist kein technisches Werkzeug — es trägt die Legitimität jeder Regierung.
+      Wer es ohne Mehrheitsverständigung ändert, riskiert mehr als er gewinnt.
+    </prosody>
+  </voice>
+  <break time="5s"/>
 
-    <!-- Sprecher 5: Frau Möller, Medienwissenschaftlerin -->
-    <voice name="de-DE-KatjaNeural">
-      <s>Sprecher 5. Frau Möller, Medienwissenschaftlerin.</s>
-      <break time="1s"/>
-      <s>Wenn fünf Verlagsgruppen den öffentlichen Diskurs kontrollieren, können Wählerinnen und Wähler keine wirklich informierte Entscheidung mehr treffen.</s>
-      <s>Medienkonzentration ist kein marktwirtschaftliches Problem — sie ist ein demokratisches.</s>
-      <s>Das untergräbt die Grundvoraussetzung jeder freien Wahl: die informierte Entscheidung.</s>
-    </voice>
-    <break time="4s"/>
+  <!-- Sprecher 4: Herr Prof. Grünwald, Föderalismusexperte — Voice: de-DE-Wavenet-D (male, unique) -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Sprecher 4: Herr Professor Grünwald, Föderalismusexperte.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="1.0">
+      Gerade in Krisen zeigt sich der Wert des Föderalismus.
+      Wenn zentrale Institutionen unter Druck geraten, halten die Länder dagegen.
+      Das ist keine Schwäche des Systems — das ist gewollte Resilienz.
+      Wer Föderalismus als Blockierer sieht, verkennt seine eigentliche Schutzfunktion.
+    </prosody>
+  </voice>
+  <break time="5s"/>
 
-    <!-- Sprecher 6: Herr Steinbach, Zivilgesellschafts-Aktivist -->
-    <voice name="de-DE-ConradNeural">
-      <s>Sprecher 6. Herr Steinbach, Zivilgesellschafts-Aktivist.</s>
-      <break time="1s"/>
-      <s>Parlamente können sich irren, Regierungen können scheitern.</s>
-      <s>Aber wenn die Zivilgesellschaft wach ist und sich organisiert, gibt es immer eine Gegenkraft.</s>
-      <s>Das ist das eigentliche demokratische Immunsystem — nicht Gerichte, nicht Parteien, sondern engagierte Bürgerinnen und Bürger.</s>
-    </voice>
-    <break time="4s"/>
+  <!-- Sprecher 5: Frau Möller, Medienwissenschaftlerin — Voice: de-DE-Wavenet-E (female, unique) -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Sprecher 5: Frau Möller, Medienwissenschaftlerin.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Wenn fünf Verlagsgruppen den öffentlichen Diskurs kontrollieren, können Wählerinnen und Wähler keine wirklich informierte Entscheidung mehr treffen.
+      Medienkonzentration ist kein marktwirtschaftliches Problem — sie ist ein demokratisches.
+      Das untergräbt die Grundvoraussetzung jeder freien Wahl: die informierte Entscheidung.
+    </prosody>
+  </voice>
+  <break time="5s"/>
 
-    <!-- Sprecher 7: Frau Dr. Langer, Rechtsextremismusforscherin -->
-    <voice name="de-DE-KatjaNeural">
-      <s>Sprecher 7. Frau Dr. Langer, Rechtsextremismusforscherin.</s>
-      <break time="1s"/>
-      <s>Wenn rechtsextreme Positionen routinemäßig im Parlament vertreten werden, verschiebt sich die Wahrnehmung dessen, was sagbar ist.</s>
-      <s>Über Jahrzehnte normalisiert das Demokratiefeindlichkeit.</s>
-      <s>Was heute noch als Tabubruch gilt, kann in zehn Jahren als Mehrheitsmeinung erscheinen — wenn wir nicht aktiv gegensteuern.</s>
-    </voice>
-    <break time="4s"/>
+  <!-- Sprecher 6: Herr Steinbach, Zivilgesellschafts-Aktivist — Voice: de-DE-Neural2-B (male, unique — distinct from Wavenet-B) -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Sprecher 6: Herr Steinbach, Zivilgesellschafts-Aktivist.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Neural2-B">
+    <prosody rate="1.0">
+      Parlamente können sich irren, Regierungen können scheitern.
+      Aber wenn die Zivilgesellschaft wach ist und sich organisiert, gibt es immer eine Gegenkraft.
+      Das ist das eigentliche demokratische Immunsystem — nicht Gerichte, nicht Parteien, sondern engagierte Bürgerinnen und Bürger.
+    </prosody>
+  </voice>
+  <break time="5s"/>
 
-    <!-- Sprecher 8: Herr Prof. Wagner, Direktdemokratie-Forscher -->
-    <voice name="de-DE-ConradNeural">
-      <s>Sprecher 8. Herr Prof. Wagner, Direktdemokratie-Forscher.</s>
-      <break time="1s"/>
-      <s>Volksbegehren und Referenden setzen voraus, dass Bürgerinnen und Bürger hochkomplexe Sachverhalte auf Basis verlässlicher Informationen entscheiden.</s>
-      <s>In einem Zeitalter massiver Desinformation ist das eine gefährliche Annahme.</s>
-      <s>Direkte Demokratie ist kein Allheilmittel — ohne Informationsintegrität wird sie zum Einfallstor für Manipulation.</s>
-    </voice>
-    <break time="3s"/>
+  <!-- Sprecher 7: Frau Dr. Langer, Rechtsextremismusforscherin — Voice: de-DE-Neural2-F (female, unique — distinct from Wavenet-F) -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Sprecher 7: Frau Dr. Langer, Rechtsextremismusforscherin.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Neural2-F">
+    <prosody rate="1.0">
+      Wenn rechtsextreme Positionen routinemäßig im Parlament vertreten werden, verschiebt sich die Wahrnehmung dessen, was sagbar ist.
+      Über Jahrzehnte normalisiert das Demokratiefeindlichkeit.
+      Was heute noch als Tabubruch gilt, kann in zehn Jahren als Mehrheitsmeinung erscheinen — wenn wir nicht aktiv gegensteuern.
+    </prosody>
+  </voice>
+  <break time="5s"/>
 
-  </prosody>
+  <!-- Sprecher 8: Herr Prof. Wagner, Direktdemokratie-Forscher — Voice: de-DE-Neural2-D (male, unique — distinct from Wavenet-D) -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Sprecher 8: Herr Professor Wagner, Direktdemokratie-Forscher.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Neural2-D">
+    <prosody rate="1.0">
+      Volksbegehren und Referenden setzen voraus, dass Bürgerinnen und Bürger hochkomplexe Sachverhalte auf Basis verlässlicher Informationen entscheiden.
+      In einem Zeitalter massiver Desinformation ist das eine gefährliche Annahme.
+      Direkte Demokratie ist kein Allheilmittel — ohne Informationsintegrität wird sie zum Einfallstor für Manipulation.
+    </prosody>
+  </voice>
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Das ist das Ende von Teil 1.</prosody>
+  </voice>
 </speak>

--- a/.planning/audio-prompts/C1_mock_05_listening_part2.ssml
+++ b/.planning/audio-prompts/C1_mock_05_listening_part2.ssml
@@ -1,80 +1,104 @@
 <speak>
-  <prosody rate="medium" pitch="medium">
+  <!-- C1 Mock 05 — Teil 2 (10 MCQ-3opt, Radiointerview, playCount=1) -->
+  <!-- [PEDAGOGY-REWRITE] Azure voices replaced with Google Cloud TTS voices -->
+  <!-- Moderator: de-DE-Wavenet-E (female) — radio interviewer -->
+  <!-- Expert: de-DE-Wavenet-B (male) — Dr. Jonas Schiemann, Politikwissenschaftler -->
+  <!-- Announcer: de-DE-Wavenet-C (female, neutral) -->
+  <!-- C1 spec: natural speed 1.0x, continuous interview register, played ONCE -->
+  <!-- 10-second initial pause for candidates to read questions -->
 
-    <!-- PART 2 INTRO -->
-    <s>Sie hören ein Interview mit Dr. Jonas Schiemann zum Thema Populismus und demokratische Resilienz.</s>
-    <s>Sie hören das Interview nur einmal.</s>
-    <break time="2s"/>
+  <break time="3s"/>
 
-    <!-- Interview begins -->
-    <voice name="de-DE-KatjaNeural">
-      <s>Willkommen, Dr. Schiemann.</s>
-      <s>Sie haben ein Buch über Populismus und demokratische Institutionen veröffentlicht.</s>
-      <s>Meine erste Frage: Ist Populismus eine Bedrohung für die Demokratie oder ein Zeichen, dass sie funktioniert?</s>
-    </voice>
-    <break time="1s"/>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">
+      Hörverstehen, Teil 2. Sie hören ein Interview mit Dr. Jonas Schiemann
+      zum Thema Populismus und demokratische Resilienz.
+      Lesen Sie zuerst die zehn Aufgaben in Ihrem Testheft.
+      Hören Sie dann das Interview. Was ist richtig?
+      Sie hören das Interview nur einmal.
+    </prosody>
+    <break time="10s"/>
+  </voice>
 
-    <voice name="de-DE-ConradNeural">
-      <s>Das ist die zentrale Frage, und die Antwort ist: beides.</s>
-      <s>Populismus zeigt, dass Menschen mit der Reaktionsfähigkeit etablierter Institutionen unzufrieden sind — das ist legitimes demokratisches Signal.</s>
-      <s>Gefährlich wird es, wenn populistische Bewegungen an die Macht kommen und beginnen, die Institutionen selbst zu demontieren, die ihnen den Zugang zur Macht ermöglicht haben.</s>
-      <s>Das nennen Politikwissenschaftler demokratischen Rückschritt: kein Putsch, sondern schrittweise Erosion durch gewählte Akteure.</s>
-    </voice>
-    <break time="1s"/>
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Willkommen, Dr. Schiemann. Sie haben ein Buch über Populismus und demokratische Institutionen veröffentlicht.
+      Meine erste Frage: Ist Populismus eine Bedrohung für die Demokratie oder ein Zeichen, dass sie funktioniert?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="1.0">
+      Das ist die zentrale Frage, und die Antwort ist: beides.
+      Populismus zeigt, dass Menschen mit der Reaktionsfähigkeit etablierter Institutionen unzufrieden sind — das ist legitimes demokratisches Signal.
+      Gefährlich wird es, wenn populistische Bewegungen an die Macht kommen und beginnen, die Institutionen selbst zu demontieren, die ihnen den Zugang zur Macht ermöglicht haben.
+      Das nennen Politikwissenschaftler demokratischen Rückschritt: kein Putsch, sondern schrittweise Erosion durch gewählte Akteure.
+    </prosody>
+  </voice>
+  <break time="1s"/>
 
-    <voice name="de-DE-KatjaNeural">
-      <s>Wie unterscheiden Sie demokratischen Populismus von illiberalem?</s>
-    </voice>
-    <break time="500ms"/>
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Wie unterscheiden Sie demokratischen Populismus von illiberalem?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="1.0">
+      Der Schlüsselunterschied liegt im Verhältnis zu Minderheitenrechten und zur Gewaltenteilung.
+      Demokratischer Populismus kritisiert Eliten, fordert mehr Partizipation, aber akzeptiert die Spielregeln.
+      Illiberaler Populismus behauptet, nur das eigene Volk — im exklusiven Sinne — zu vertreten, und behandelt Institutionen wie Verfassungsgerichte, freie Medien oder Zentralbanken als Feinde, die zu überwinden sind.
+    </prosody>
+  </voice>
+  <break time="1s"/>
 
-    <voice name="de-DE-ConradNeural">
-      <s>Der Schlüsselunterschied liegt im Verhältnis zu Minderheitenrechten und zur Gewaltenteilung.</s>
-      <s>Demokratischer Populismus kritisiert Eliten, fordert mehr Partizipation, aber akzeptiert die Spielregeln.</s>
-      <s>Illiberaler Populismus behauptet, nur das eigene Volk — im exklusiven Sinne — zu vertreten, und behandelt Institutionen wie Verfassungsgerichte, freie Medien oder Zentralbanken als Feinde, die zu überwinden sind.</s>
-    </voice>
-    <break time="1s"/>
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      In Deutschland wird viel über Wahlsystemreformen diskutiert.
+      Ist das Verhältniswahlrecht ein Einfallstor für populistische Parteien?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="1.0">
+      Das ist empirisch nicht belegt.
+      Länder mit Mehrheitswahlrecht wie Großbritannien haben ebenso dramatische populistische Durchbrüche erlebt wie Länder mit Verhältniswahlrecht.
+      Die Ursachen liegen tiefer: in Vertrauensverlusten gegenüber Institutionen, in wirtschaftlicher Unsicherheit, in Identitätskonflikten.
+      Das Wahlsystem ist das Gehäuse — das politische Klima entscheidet, was darin wächst.
+    </prosody>
+  </voice>
+  <break time="1s"/>
 
-    <voice name="de-DE-KatjaNeural">
-      <s>In Deutschland wird viel über Wahlsystemreformen diskutiert.</s>
-      <s>Ist das Verhältniswahlrecht ein Einfallstor für populistische Parteien?</s>
-    </voice>
-    <break time="500ms"/>
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Wie bewerten Sie die Rolle des Bundesverfassungsgerichts als Hüter der Demokratie?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="1.0">
+      Das Bundesverfassungsgericht ist eine der stärksten demokratischen Sicherungen, die Deutschland hat — und eine der am wenigsten verstandenen.
+      Es hat wiederholt eingegriffen, bevor Gesetze irreparablen Schaden anrichten konnten.
+      Allerdings: Ein Gericht kann nur prüfen, was ihm vorgelegt wird.
+      Wenn demokratiefeindliche Normen von einer ausreichend starken Parlamentsmehrheit verabschiedet werden, stößt auch das Verfassungsgericht an Grenzen.
+      Resiliente Demokratie kann sich nicht auf ein einzelnes Institut verlassen.
+    </prosody>
+  </voice>
+  <break time="1s"/>
 
-    <voice name="de-DE-ConradNeural">
-      <s>Das ist empirisch nicht belegt.</s>
-      <s>Länder mit Mehrheitswahlrecht wie Großbritannien haben ebenso dramatische populistische Durchbrüche erlebt wie Länder mit Verhältniswahlrecht.</s>
-      <s>Die Ursachen liegen tiefer: in Vertrauensverlusten gegenüber Institutionen, in wirtschaftlicher Unsicherheit, in Identitätskonflikten.</s>
-      <s>Das Wahlsystem ist das Gehäuse — das politische Klima entscheidet, was darin wächst.</s>
-    </voice>
-    <break time="1s"/>
+  <voice name="de-DE-Wavenet-E">
+    <prosody rate="1.0">
+      Was empfehlen Sie konkret zur Stärkung demokratischer Resilienz?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="1.0">
+      Drei Säulen.
+      Erstens: institutionelle Redundanz — mehrere, voneinander unabhängige Kontrollmechanismen, damit der Ausfall einer Institution nicht das ganze System destabilisiert.
+      Zweitens: politische Bildung, die über Wissen hinausgeht und demokratische Handlungskompetenz vermittelt.
+      Drittens: eine Zivilgesellschaft, die nicht nur protestiert, sondern in politischen Prozessen strukturell verankert ist.
+      Diese drei Elemente greifen ineinander und bilden zusammen ein belastbares Fundament.
+    </prosody>
+  </voice>
+  <break time="3s"/>
 
-    <voice name="de-DE-KatjaNeural">
-      <s>Wie bewerten Sie die Rolle des Bundesverfassungsgerichts als Hüter der Demokratie?</s>
-    </voice>
-    <break time="500ms"/>
-
-    <voice name="de-DE-ConradNeural">
-      <s>Das Bundesverfassungsgericht ist eine der stärksten demokratischen Sicherungen, die Deutschland hat — und eine der am wenigsten verstandenen.</s>
-      <s>Es hat wiederholt eingegriffen, bevor Gesetze irreparablen Schaden anrichten konnten.</s>
-      <s>Allerdings: Ein Gericht kann nur prüfen, was ihm vorgelegt wird.</s>
-      <s>Wenn demokratiefeindliche Normen von einer ausreichend starken Parlamentsmehrheit verabschiedet werden, stößt auch das Verfassungsgericht an Grenzen.</s>
-      <s>Resiliente Demokratie kann sich nicht auf ein einzelnes Institut verlassen.</s>
-    </voice>
-    <break time="1s"/>
-
-    <voice name="de-DE-KatjaNeural">
-      <s>Was empfehlen Sie konkret zur Stärkung demokratischer Resilienz?</s>
-    </voice>
-    <break time="500ms"/>
-
-    <voice name="de-DE-ConradNeural">
-      <s>Drei Säulen.</s>
-      <s>Erstens: institutionelle Redundanz — mehrere, voneinander unabhängige Kontrollmechanismen, damit der Ausfall einer Institution nicht das ganze System destabilisiert.</s>
-      <s>Zweitens: politische Bildung, die über Wissen hinausgeht und demokratische Handlungskompetenz vermittelt.</s>
-      <s>Drittens: eine Zivilgesellschaft, die nicht nur protestiert, sondern in politischen Prozessen strukturell verankert ist.</s>
-      <s>Diese drei Elemente greifen ineinander und bilden zusammen ein belastbares Fundament.</s>
-    </voice>
-    <break time="3s"/>
-
-  </prosody>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Das ist das Ende von Teil 2.</prosody>
+  </voice>
 </speak>

--- a/.planning/audio-prompts/C1_mock_05_listening_part3.ssml
+++ b/.planning/audio-prompts/C1_mock_05_listening_part3.ssml
@@ -1,118 +1,72 @@
 <speak>
-  <prosody rate="medium" pitch="medium">
+  <!-- C1 Mock 05 — Teil 3 (10 MCQ-3opt, akademischer Vortrag, playCount=1) -->
+  <!-- [PEDAGOGY-REWRITE] Azure voices replaced with Google Cloud TTS voices -->
+  <!-- CR-11: NO gap cues — continuous lecture, MCQ format (CR-12) -->
+  <!-- Speaker: de-DE-Wavenet-D (male) — academic lecturer, wissenschaftlich register -->
+  <!-- Announcer: de-DE-Wavenet-C (female) -->
+  <!-- C1 spec: natural speed 1.0x, played ONCE — 'zweimal' announcement removed -->
+  <!-- 10-second initial pause for candidates to read questions before audio begins -->
+  <!-- Topic: Demokratische Resilienz im europäischen Vergleich -->
 
-    <!-- PART 3 INTRO -->
-    <s>Sie hören einen akademischen Vortrag zum Thema Demokratische Resilienz im europäischen Vergleich.</s>
-    <s>Sie hören den Vortrag zweimal.</s>
-    <break time="2s"/>
+  <break time="3s"/>
 
-    <!-- Vortrag beginnt -->
-    <voice name="de-DE-ConradNeural">
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">
+      Hörverstehen, Teil 3. Sie hören einen akademischen Vortrag zum Thema
+      Demokratische Resilienz im europäischen Vergleich.
+      Lesen Sie zuerst die zehn Fragen in Ihrem Testheft.
+      Was ist richtig? Kreuzen Sie an: a, b oder c.
+      Sie hören den Vortrag einmal.
+    </prosody>
+    <break time="10s"/>
+  </voice>
 
-      <s>Sehr geehrte Damen und Herren,</s>
-      <s>das zentrale Kriterium, um demokratische Resilienz empirisch zu messen, ist die Stabilität unabhängiger Institutionen unter politischem Druck.</s>
-      <s>Wahlbeteiligung und Volksabstimmungsfrequenz sind interessante Indikatoren — aber sie sagen wenig darüber aus, ob eine Demokratie standhält, wenn Gerichte, Medien oder Rechnungshöfe gezielt unter Druck gesetzt werden.</s>
-      <break time="1s"/>
+  <!-- VORTRAG BEGINNT — KEINE INTERNEN PAUSENSIGNALE -->
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="1.0">
+      Sehr geehrte Damen und Herren,
+      das zentrale Kriterium, um demokratische Resilienz empirisch zu messen, ist die Stabilität unabhängiger Institutionen unter politischem Druck.
+      Wahlbeteiligung und Volksabstimmungsfrequenz sind interessante Indikatoren — aber sie sagen wenig darüber aus, ob eine Demokratie standhält, wenn Gerichte, Medien oder Rechnungshöfe gezielt unter Druck gesetzt werden.
 
-      <s>Analytisch hilfreich ist die Unterscheidung zwischen formaler und substantieller Demokratie.</s>
-      <s>Formale Demokratie umfasst Verfahren: Wahlen, Parlamentarismus, Parteienpluralismus.</s>
-      <s>Substantielle Demokratie geht weiter: Sie setzt voraus, dass Grundrechte, Minderheitenschutz und Gewaltenteilung strukturell verankert sind und gegen Mehrheitsentscheide geschützt werden.</s>
-      <s>Ein Regime kann formal demokratisch sein und substanziell illiberal — dieser Befund ist keine Abstraktion, sondern eine gegenwärtige Realität in Teilen Europas.</s>
-      <break time="1s"/>
+      Analytisch hilfreich ist die Unterscheidung zwischen formaler und substantieller Demokratie.
+      Formale Demokratie umfasst Verfahren: Wahlen, Parlamentarismus, Parteienpluralismus.
+      Substantielle Demokratie geht weiter: Sie setzt voraus, dass Grundrechte, Minderheitenschutz und Gewaltenteilung strukturell verankert sind und gegen Mehrheitsentscheide geschützt werden.
+      Ein Regime kann formal demokratisch sein und substanziell illiberal — dieser Befund ist keine Abstraktion, sondern eine gegenwärtige Realität in Teilen Europas.
 
-      <s>Das beste europäische Fallbeispiel für graduellen institutionellen Abbau ist Ungarn unter Viktor Orbán.</s>
-      <s>Wahlrecht, Verfassungsgericht, Medienlandschaft und Justiz wurden schrittweise umgebaut — ohne formell die demokratische Form zu verlassen.</s>
-      <s>Das Ergebnis ist ein System, das alle Attribute formaler Demokratie aufweist, aber substantiell eine andere Logik verfolgt.</s>
-      <break time="1s"/>
+      Das beste europäische Fallbeispiel für graduellen institutionellen Abbau ist Ungarn unter Viktor Orbán.
+      Wahlrecht, Verfassungsgericht, Medienlandschaft und Justiz wurden schrittweise umgebaut — ohne formell die demokratische Form zu verlassen.
+      Das Ergebnis ist ein System, das alle Attribute formaler Demokratie aufweist, aber substantiell eine andere Logik verfolgt.
 
-      <s>Welche Rolle spielt die Europäische Union?</s>
-      <s>Die EU ist eine Rechtsgemeinschaft, die über Vertragsverletzungsverfahren und Konditionalitätsmechanismen Druck ausüben kann.</s>
-      <s>Allerdings geschieht dies mit erheblichem Zeitverzug und politischem Aufwand.</s>
-      <s>Vollständige Prävention demokratischer Erosion ist ihr strukturell nicht möglich — aber völlige Wirkungslosigkeit wäre ebenfalls eine unzutreffende Einschätzung.</s>
-      <break time="1s"/>
+      Welche Rolle spielt die Europäische Union?
+      Die EU ist eine Rechtsgemeinschaft, die über Vertragsverletzungsverfahren und Konditionalitätsmechanismen Druck ausüben kann.
+      Allerdings geschieht dies mit erheblichem Zeitverzug und politischem Aufwand.
+      Vollständige Prävention demokratischer Erosion ist ihr strukturell nicht möglich — aber völlige Wirkungslosigkeit wäre ebenfalls eine unzutreffende Einschätzung.
 
-      <s>Der vergleichende Blick zeigt: Länder mit starker Tradition unabhängiger Verfassungsgerichtsbarkeit zeigen höhere demokratische Widerstandsfähigkeit.</s>
-      <s>Wirtschaftlicher Wohlstand korreliert mit Stabilität, erklärt aber Resilienz nicht hinreichend — wohlhabende Demokratien haben ebenfalls demokratische Rückschritte erlebt.</s>
-      <s>Wahlsystemtypen erklären Resilienz noch weniger zuverlässig: sowohl Verhältniswahlrecht als auch Mehrheitswahlrecht produzieren resiliente und fragile Demokratien.</s>
-      <break time="1s"/>
+      Der vergleichende Blick zeigt: Länder mit starker Tradition unabhängiger Verfassungsgerichtsbarkeit zeigen höhere demokratische Widerstandsfähigkeit.
+      Wirtschaftlicher Wohlstand korreliert mit Stabilität, erklärt aber Resilienz nicht hinreichend — wohlhabende Demokratien haben ebenfalls demokratische Rückschritte erlebt.
+      Wahlsystemtypen erklären Resilienz noch weniger zuverlässig: sowohl Verhältniswahlrecht als auch Mehrheitswahlrecht produzieren resiliente und fragile Demokratien.
 
-      <s>Der Begriff 'legale Illiberalität' beschreibt Gesetzgebung, die formal verfassungsrechtlichen Anforderungen entspricht, aber materiell Grundrechte, Minderheitenschutz oder institutionelle Unabhängigkeit einschränkt.</s>
-      <s>Dies ist die raffinierte Form demokratischen Rückschritts: Sie nutzt die Legalität als Schutzschild.</s>
-      <break time="1s"/>
+      Der Begriff 'legale Illiberalität' beschreibt Gesetzgebung, die formal verfassungsrechtlichen Anforderungen entspricht, aber materiell Grundrechte, Minderheitenschutz oder institutionelle Unabhängigkeit einschränkt.
+      Dies ist die raffinierte Form demokratischen Rückschritts: Sie nutzt die Legalität als Schutzschild.
 
-      <s>Zur Rolle politischer Bildung: Sie ist eine notwendige, aber nicht hinreichende Bedingung für Resilienz.</s>
-      <s>Institutionelle Strukturen müssen den Rahmen setzen — Bildung allein kann institutionelle Schwäche nicht kompensieren.</s>
-      <break time="1s"/>
+      Zur Rolle politischer Bildung: Sie ist eine notwendige, aber nicht hinreichende Bedingung für Resilienz.
+      Institutionelle Strukturen müssen den Rahmen setzen — Bildung allein kann institutionelle Schwäche nicht kompensieren.
 
-      <s>Was ist nun 'demokratischer Rückschritt'?</s>
-      <s>Es ist der Fachbegriff für schrittweise, von innen heraus betriebene Erosion demokratischer Normen — ohne Militärputsch, ohne offene Diktatur, aber mit systematischer Absicht.</s>
-      <break time="1s"/>
+      Was ist nun 'demokratischer Rückschritt'?
+      Es ist der Fachbegriff für schrittweise, von innen heraus betriebene Erosion demokratischer Normen — ohne Militärputsch, ohne offene Diktatur, aber mit systematischer Absicht.
 
-      <s>Ein strukturelles Defizit vieler europäischer Demokratien ist, dass sie historisch für externe Bedrohungen konzipiert wurden — nicht für den Fall, dass demokratisch gewählte Akteure selbst die Regeln untergraben.</s>
-      <s>Institutionen, die gegen Diktatoren robust sind, können gegenüber gewählten Illiberalen blind sein.</s>
-      <break time="1s"/>
+      Ein strukturelles Defizit vieler europäischer Demokratien ist, dass sie historisch für externe Bedrohungen konzipiert wurden — nicht für den Fall, dass demokratisch gewählte Akteure selbst die Regeln untergraben.
+      Institutionen, die gegen Diktatoren robust sind, können gegenüber gewählten Illiberalen blind sein.
 
-      <s>Meine Empfehlung zur Stärkung der EU als demokratische Schutzinstanz: Konditionalitätsmechanismen stärken und Mittelkürzungen konsequenter mit Rechtsstaatskriterien verknüpfen.</s>
-      <s>Dies ist kein Eingriff in nationale Souveränität — es ist die logische Konsequenz einer Gemeinschaft, die auf gemeinsamen Werten beruht.</s>
-      <break time="1s"/>
+      Meine Empfehlung zur Stärkung der EU als demokratische Schutzinstanz: Konditionalitätsmechanismen stärken und Mittelkürzungen konsequenter mit Rechtsstaatskriterien verknüpfen.
+      Dies ist kein Eingriff in nationale Souveränität — es ist die logische Konsequenz einer Gemeinschaft, die auf gemeinsamen Werten beruht.
 
-      <s>Ich danke für Ihre Aufmerksamkeit.</s>
+      Ich danke für Ihre Aufmerksamkeit.
+    </prosody>
+  </voice>
+  <break time="3s"/>
 
-    </voice>
-    <break time="5s"/>
-
-    <!-- Second playthrough marker -->
-    <s>Sie hören den Vortrag jetzt ein zweites Mal.</s>
-    <break time="2s"/>
-
-    <voice name="de-DE-ConradNeural">
-
-      <s>Sehr geehrte Damen und Herren,</s>
-      <s>das zentrale Kriterium, um demokratische Resilienz empirisch zu messen, ist die Stabilität unabhängiger Institutionen unter politischem Druck.</s>
-      <s>Wahlbeteiligung und Volksabstimmungsfrequenz sind interessante Indikatoren — aber sie sagen wenig darüber aus, ob eine Demokratie standhält, wenn Gerichte, Medien oder Rechnungshöfe gezielt unter Druck gesetzt werden.</s>
-      <break time="1s"/>
-
-      <s>Analytisch hilfreich ist die Unterscheidung zwischen formaler und substantieller Demokratie.</s>
-      <s>Formale Demokratie umfasst Verfahren: Wahlen, Parlamentarismus, Parteienpluralismus.</s>
-      <s>Substantielle Demokratie geht weiter: Sie setzt voraus, dass Grundrechte, Minderheitenschutz und Gewaltenteilung strukturell verankert sind und gegen Mehrheitsentscheide geschützt werden.</s>
-      <s>Ein Regime kann formal demokratisch sein und substanziell illiberal — dieser Befund ist keine Abstraktion, sondern eine gegenwärtige Realität in Teilen Europas.</s>
-      <break time="1s"/>
-
-      <s>Das beste europäische Fallbeispiel für graduellen institutionellen Abbau ist Ungarn unter Viktor Orbán.</s>
-      <s>Wahlrecht, Verfassungsgericht, Medienlandschaft und Justiz wurden schrittweise umgebaut — ohne formell die demokratische Form zu verlassen.</s>
-      <s>Das Ergebnis ist ein System, das alle Attribute formaler Demokratie aufweist, aber substantiell eine andere Logik verfolgt.</s>
-      <break time="1s"/>
-
-      <s>Welche Rolle spielt die Europäische Union?</s>
-      <s>Die EU ist eine Rechtsgemeinschaft, die über Vertragsverletzungsverfahren und Konditionalitätsmechanismen Druck ausüben kann.</s>
-      <s>Allerdings geschieht dies mit erheblichem Zeitverzug und politischem Aufwand.</s>
-      <s>Vollständige Prävention demokratischer Erosion ist ihr strukturell nicht möglich — aber völlige Wirkungslosigkeit wäre ebenfalls eine unzutreffende Einschätzung.</s>
-      <break time="1s"/>
-
-      <s>Der vergleichende Blick zeigt: Länder mit starker Tradition unabhängiger Verfassungsgerichtsbarkeit zeigen höhere demokratische Widerstandsfähigkeit.</s>
-      <s>Wirtschaftlicher Wohlstand korreliert mit Stabilität, erklärt aber Resilienz nicht hinreichend.</s>
-      <s>Wahlsystemtypen erklären Resilienz noch weniger zuverlässig.</s>
-      <break time="1s"/>
-
-      <s>Der Begriff 'legale Illiberalität' beschreibt Gesetzgebung, die formal verfassungsrechtlichen Anforderungen entspricht, aber materiell Grundrechte, Minderheitenschutz oder institutionelle Unabhängigkeit einschränkt.</s>
-      <break time="1s"/>
-
-      <s>Zur Rolle politischer Bildung: Sie ist eine notwendige, aber nicht hinreichende Bedingung für Resilienz.</s>
-      <break time="1s"/>
-
-      <s>Demokratischer Rückschritt: schrittweise, von innen heraus betriebene Erosion demokratischer Normen — ohne Militärputsch, ohne offene Diktatur, aber mit systematischer Absicht.</s>
-      <break time="1s"/>
-
-      <s>Das strukturelle Defizit: Demokratien wurden für externe Bedrohungen konzipiert — nicht für gewählte Illiberale.</s>
-      <break time="1s"/>
-
-      <s>Meine Empfehlung: Konditionalitätsmechanismen der EU stärken und Mittelkürzungen konsequenter mit Rechtsstaatskriterien verknüpfen.</s>
-      <break time="1s"/>
-
-      <s>Ich danke für Ihre Aufmerksamkeit.</s>
-
-    </voice>
-    <break time="3s"/>
-
-  </prosody>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="1.0">Das ist das Ende von Teil 3 und das Ende des Hörverstehens.</prosody>
+  </voice>
 </speak>

--- a/.planning/handoffs/2026-04-26-impl-fix-c1-mock-05-ssml.md
+++ b/.planning/handoffs/2026-04-26-impl-fix-c1-mock-05-ssml.md
@@ -1,0 +1,52 @@
+## Handoff — #216 — C1 mock_05 SSML: Google voices + remove zweimal
+
+### What was built
+
+Rewrote all three C1 mock_05 SSML files to replace Azure Neural voices with Google Cloud TTS voices (matching the mock_07 gold reference pattern) and removed the illegal "zweimal" play-twice announcement from part3.
+
+### Files changed
+
+- `.planning/audio-prompts/C1_mock_05_listening_part1.ssml` — replaced de-DE-KatjaNeural/ConradNeural with 8 unique Google voices (Wavenet-F/A/E/Neural2-F for female speakers, Wavenet-B/D/Neural2-B/Neural2-D for male speakers); added Wavenet-C announcer; restructured to match mock_07 format with 10s reading pause and 5s inter-speaker gaps
+- `.planning/audio-prompts/C1_mock_05_listening_part2.ssml` — replaced KatjaNeural (interviewer) with Wavenet-E, ConradNeural (expert) with Wavenet-B; added Wavenet-C announcer frame matching mock_07 part2 pattern; preserved all interview content
+- `.planning/audio-prompts/C1_mock_05_listening_part3.ssml` — replaced ConradNeural with Wavenet-D; removed full second playthrough block and "Sie hören den Vortrag zweimal" / "Sie hören den Vortrag jetzt ein zweites Mal" announcements; announcer now says "Sie hören den Vortrag einmal"; restructured as single continuous lecture per C1 plays-once spec
+
+### Voice mapping pre/post
+
+| File | Before (Azure) | After (Google) |
+|------|---------------|----------------|
+| part1 — announcer | none (inline prosody) | de-DE-Wavenet-C |
+| part1 — Sp1/3/5/7 (female) | de-DE-KatjaNeural (shared) | Wavenet-F / Wavenet-A / Wavenet-E / Neural2-F |
+| part1 — Sp2/4/6/8 (male) | de-DE-ConradNeural (shared) | Wavenet-B / Wavenet-D / Neural2-B / Neural2-D |
+| part2 — announcer | none | de-DE-Wavenet-C |
+| part2 — interviewer | de-DE-KatjaNeural | de-DE-Wavenet-E |
+| part2 — expert | de-DE-ConradNeural | de-DE-Wavenet-B |
+| part3 — announcer | none | de-DE-Wavenet-C |
+| part3 — lecturer | de-DE-ConradNeural | de-DE-Wavenet-D |
+
+### Zweimal instances removed
+
+- part3 line 6: `<s>Sie hören den Vortrag zweimal.</s>` — removed
+- part3 line 65: `<s>Sie hören den Vortrag jetzt ein zweites Mal.</s>` — removed
+- part3: entire second playthrough block (lines 68–114) — removed
+- part3 announcer text changed from "zweimal" to "einmal"
+
+Total: 3 textual "zweimal" references removed, full duplicate lecture block eliminated.
+
+### Tests
+
+- Unit: n/a (SSML content files, no code)
+- E2E: none — no observable browser change
+- Typecheck: clean (no TypeScript touched)
+
+### Quality gates
+
+- compliance: n/a
+- language: PASS — German content preserved verbatim, only structural/voice changes
+- spec-tracker: n/a
+
+### Notes
+
+- part1 now uses 8 fully unique voices matching CR-9 spec, same voice assignment pattern as mock_07
+- part2 voice gender swap (interviewer = female Wavenet-E, expert = male Wavenet-B) matches mock_07's interviewer/guest gender pattern
+- part3 single playthrough aligns with C1-exam-format.md Section 1.4: C1 plays ONCE only
+- All files tagged [PEDAGOGY-REWRITE] in header comments


### PR DESCRIPTION
## Summary

- Replace Azure Neural voices (`de-DE-KatjaNeural`, `de-DE-ConradNeural`) with 8 unique Google Cloud TTS voices across all three C1 mock_05 listening parts
- part1: 8 distinct speaker voices (Wavenet-F/A/E/Neural2-F female, Wavenet-B/D/Neural2-B/Neural2-D male) + Wavenet-C announcer — matches mock_07 gold reference
- part3: remove full second playthrough block and all "zweimal" announcements — C1 plays once per exam format spec section 1.4

## Voice mapping

| Part | Before | After |
|------|--------|-------|
| part1 female speakers (x4) | KatjaNeural (shared) | Wavenet-F / Wavenet-A / Wavenet-E / Neural2-F |
| part1 male speakers (x4) | ConradNeural (shared) | Wavenet-B / Wavenet-D / Neural2-B / Neural2-D |
| part2 interviewer | KatjaNeural | Wavenet-E |
| part2 expert | ConradNeural | Wavenet-B |
| part3 lecturer | ConradNeural | Wavenet-D |
| all parts announcer | none | Wavenet-C |

## Zweimal removed

3 textual references + full duplicate lecture block eliminated from part3.

## Quality Gates

| Gate | Result |
|------|--------|
| compliance | n/a |
| language-checker | PASS — German content preserved verbatim |
| spec-tracker | n/a |
| typecheck | clean |

## Test plan

- [ ] Verify no Azure voice names remain in any C1_mock_05 SSML file
- [ ] Verify part1 has exactly 8 unique voice names (4f/4m)
- [ ] Verify part3 contains no "zweimal" string
- [ ] Verify part3 has no second playthrough block
- [ ] Confirm announcer text in part3 reads "einmal" not "zweimal"