### PR TITLE
audio(B1): SSML scripts for new mocks 11-15

### DIFF
--- a/.planning/audio-prompts/B1_M11-M15_manifest.md
+++ b/.planning/audio-prompts/B1_M11-M15_manifest.md
@@ -1,0 +1,114 @@
+# B1 Mock 11–15 Audio SSML Manifest
+
+Generated: 2026-05-01
+Branch: b1-upgrade/audio-ssml-m11-m15
+
+## Voice Assignments (B1 — rate=0.95 target)
+
+All prosody rates in the scripts use SSML named rates (`slow` = ~0.85, `medium` = ~0.95) rather than
+numeric values, consistent with the M01–M10 convention in this repo.
+
+| Voice | Role |
+|-------|------|
+| de-DE-Wavenet-B | Narrator / Announcer — instructions, task labels |
+| de-DE-Wavenet-C | Female speaker (primary) — main female character in dialogues |
+| de-DE-Wavenet-D | Male speaker (primary) — main male character in dialogues |
+| de-DE-Wavenet-A | Female speaker (secondary) — used for interview guests where distinct voice needed |
+| de-DE-Wavenet-F | Male speaker (secondary) — statistics/data voice, older male characters |
+
+---
+
+## File Inventory
+
+### Mock 11 — Topic: Arbeit und Beruf (job ads, homeoffice, workplace)
+
+| File | Part | Questions | Voices Used | Play Count | Transcript Source | Est. Duration |
+|------|------|-----------|-------------|------------|-------------------|---------------|
+| B1_mock11_listening_part1.ssml | Teil 1 | 5 T/F | B (narrator), C (female), D (male) | 1x | Full — derived from JSON explanations | ~2.5 min |
+| B1_mock11_listening_part2.ssml | Teil 2 | 10 T/F | B (narrator), C (moderatorin), D (Dr. Mertens) | 1x | Full — derived from JSON explanations | ~5 min |
+| B1_mock11_listening_part3.ssml | Teil 3 | 5 MCQ | B (narrator), C (female), D (male) | 2x each | PLACEHOLDER — see note below | ~4 min |
+
+**Mock 11 Part 3 note:** The mock_11.json on branch `b1-upgrade/mock-11-new` does not contain a
+`parts[2]` (Teil 3) entry — the JSON ends after Teil 2. Dialogues in Part 3 were constructed from
+the interview and workplace context of Mock 11. A content reviewer should verify the 5 dialogues
+align with the intended questions before audio generation.
+
+---
+
+### Mock 12 — Topic: Gesundheit und Ernährung (Arztpraxis, Fitnessstudio, Frau Koch interview)
+
+| File | Part | Questions | Voices Used | Play Count | Transcript Source | Est. Duration |
+|------|------|-----------|-------------|------------|-------------------|---------------|
+| B1_mock12_listening_part1.ssml | Teil 1 | 5 T/F | B (narrator), C (female), D (male) | 1x | Full — derived from JSON explanations | ~2.5 min |
+| B1_mock12_listening_part2.ssml | Teil 2 | 10 T/F | B (narrator), C (moderatorin), A (Frau Koch) | 1x | Full — derived from JSON explanations | ~5 min |
+| B1_mock12_listening_part3.ssml | Teil 3 | 5 MCQ | B (narrator), C (female), D (male) | 2x each | PLACEHOLDER — see note below | ~4 min |
+
+**Mock 12 Part 3 note:** No Teil 3 data in `mock_12.json` on branch `b1-upgrade/mock-12-new`.
+Dialogues constructed to match the health/nutrition theme of Mock 12. Content reviewer should
+confirm dialogue topics before production. Suggested topics used: Arzt empfiehlt Bewegung,
+Intervallfasten, Magenschmerzen Kind, Supermarkt laktosefrei, Kochkurs.
+
+---
+
+### Mock 13 — Topic: Reisen und Verkehr (sustainable travel, Nachtzüge, Fahrrad)
+
+| File | Part | Questions | Voices Used | Play Count | Transcript Source | Est. Duration |
+|------|------|-----------|-------------|------------|-------------------|---------------|
+| B1_mock13_listening_part1.ssml | Teil 1 | 5 T/F | B (narrator), C (female), D (male) | 1x | Full — sourced directly from JSON explanations | ~2.5 min |
+| B1_mock13_listening_part2.ssml | Teil 2 | 10 T/F | B (narrator), D (moderator), C (Frau Steiner), F (data) | 1x | Full — sourced directly from JSON explanations | ~5 min |
+| B1_mock13_listening_part3.ssml | Teil 3 | 5 MCQ | B (narrator), C (female), D (male) | 2x each | Full — sourced directly from JSON explanations | ~4 min |
+
+Mock 13 has the most complete JSON source — all three parts have full question explanations with
+verbatim quotes. No placeholders needed.
+
+---
+
+### Mock 14 — Topic: Familie und Gesellschaft (Patchwork-Familien, Elternzeit, Lena + Opa)
+
+| File | Part | Questions | Voices Used | Play Count | Transcript Source | Est. Duration |
+|------|------|-----------|-------------|------------|-------------------|---------------|
+| B1_mock14_listening_part1.ssml | Teil 1 | 5 T/F | B (narrator), C (female), D (male) | 1x | Full — sourced directly from JSON explanations | ~2.5 min |
+| B1_mock14_listening_part2.ssml | Teil 2 | 10 T/F | B (narrator), C (moderatorin), A (Dr. Wendland), F (data) | 2x | Full — sourced directly from JSON explanations | ~10 min (×2) |
+| B1_mock14_listening_part3.ssml | Teil 3 | 5 MCQ | B (narrator), C (Lena), F (Heinrich/Großvater) | 2x | Full — sourced directly from JSON explanations | ~5 min (×2) |
+
+**Mock 14 Part 2 note:** The JSON specifies `playCount: 2` for Teil 2. This is unusual for B1 but
+has been honoured — the SSML includes a full repeat with the "Sie hören den Text jetzt noch einmal"
+marker and a 5-second gap, consistent with the A1 convention.
+
+---
+
+### Mock 15 — Topic: Digitale Medien (Medienkonsum, Doom-Scrolling, Social Media, Digital Detox)
+
+| File | Part | Questions | Voices Used | Play Count | Transcript Source | Est. Duration |
+|------|------|-----------|-------------|------------|-------------------|---------------|
+| B1_mock15_listening_part1.ssml | Teil 1 | 5 T/F | B (narrator), C (female), D (male) | 1x | Full — sourced directly from JSON explanations | ~2.5 min |
+| B1_mock15_listening_part2.ssml | Teil 2 | 10 T/F | B (narrator), C (moderatorin), D (Dr. Kern), F (data) | 1x | Full — sourced directly from JSON explanations | ~5 min |
+| B1_mock15_listening_part3.ssml | Teil 3 | 5 MCQ | B (narrator), C (female), D (male) | 2x each | Full — sourced directly from JSON explanations | ~4 min |
+
+---
+
+## Summary
+
+| Mock | Part 1 | Part 2 | Part 3 | Placeholders |
+|------|--------|--------|--------|--------------|
+| mock_11 | ready | ready | PLACEHOLDER | Part 3 dialogues |
+| mock_12 | ready | ready | PLACEHOLDER | Part 3 dialogues |
+| mock_13 | ready | ready | ready | none |
+| mock_14 | ready | ready | ready | none |
+| mock_15 | ready | ready | ready | none |
+
+Total files: 15 SSML scripts
+Files requiring content review before audio generation: 2 (mock11 part3, mock12 part3)
+
+## Audio Generation
+
+To generate MP3 files from these scripts, use the `generate-audio` mode with `mock_id` set to
+each mock (e.g. `mock_id=B1_mock_11`). The standard curl template is documented in the agent
+system prompt. GCP credentials must be configured (`gcloud auth print-access-token`).
+
+Output paths:
+- `apps/mobile/assets/audio/B1/mock11/listening_part{1,2,3}.mp3`
+- `apps/mobile/assets/audio/B1/mock12/listening_part{1,2,3}.mp3`
+- `apps/mobile/assets/audio/B1/mock13/listening_part{1,2,3}.mp3`
+- `apps/mobile/assets/audio/B1/mock14/listening_part{1,2,3}.mp3`
+- `apps/mobile/assets/audio/B1/mock15/listening_part{1,2,3}.mp3`

--- a/.planning/audio-prompts/B1_mock11_listening_part1.ssml
+++ b/.planning/audio-prompts/B1_mock11_listening_part1.ssml
@@ -1,0 +1,95 @@
+<speak>
+  <!-- B1 Mock 11 — Teil 1 (5 True/False, short audio clips, playCount=1) -->
+  <!-- Narrator/Announcer: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions, task labels -->
+  <!-- Female speaker: de-DE-Wavenet-C (female, clear) rate="medium" — voicemail, female roles -->
+  <!-- Male speaker: de-DE-Wavenet-D (male, warm) rate="medium" — announcements, male roles -->
+  <!-- No repeat — Teil 1 plays ONCE at B1 -->
+  <!-- Topic: Stellenanzeigen, Arbeitskommunikation (job ads, workplace calls) -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 1. Sie hören fünf kurze Texte. Entscheiden Sie bei jedem Text:
+      Ist die Aussage richtig oder falsch? Sie hören jeden Text nur einmal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Aufgabe 1: Stellenanzeige — mindestens fünf Jahre Erfahrung im Vertrieb -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 1.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Wir suchen zum nächstmöglichen Zeitpunkt eine engagierte Vertriebspersönlichkeit
+      für unser Team in Frankfurt. Voraussetzung ist eine abgeschlossene kaufmännische Ausbildung
+      sowie mindestens fünf Jahre Erfahrung im Vertrieb. Wir freuen uns auf Ihre Bewerbung.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 2: Voicemail Herr Kaya — Bericht bis Montag überprüfen -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 2.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Hallo Sandra, hier ist Can Kaya. Ich wollte kurz fragen:
+      Könntest du dir den Quartalsbericht bis Montag noch mal anschauen?
+      Ich möchte ihn dienstags abgeben, da wäre es gut, wenn du vorher drübergeschaut hast.
+      Danke schön, bis dann!
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 3: Sekretärin — Bewerbungsgespräch Mittwoch 10:30 Uhr -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 3.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Guten Tag, hier ist Petra Lange von der Firma Meißner und Partner.
+      Ich rufe an, um Ihren Termin für das Bewerbungsgespräch zu bestätigen.
+      Wir freuen uns, Sie am Mittwoch um 10 Uhr 30 bei uns begrüßen zu dürfen.
+      Bitte melden Sie sich an der Rezeption.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 4: Personalleiter — Dienstwagen und Laptop zur Stelle -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 4.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Die ausgeschriebene Stelle im Außendienst bietet ein attraktives Gehaltspaket.
+      Zur Stelle gehören außerdem ein Dienstwagen und ein Laptop,
+      die Sie auch privat nutzen dürfen.
+      Urlaubsanspruch beträgt 30 Tage im Jahr.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 5: Sprecherin — wurde entlassen, hat nicht selbst gekündigt -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 5.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Also, ich bin seit drei Monaten auf Jobsuche. Die Firma hat leider Stellen abgebaut —
+      meine Stelle wurde einfach gestrichen. Das war ein Schock, aber jetzt bin ich aktiv
+      dabei, mich neu zu orientieren. Ich bewerbe mich hauptsächlich im Bereich Marketing.
+    </prosody>
+  </voice>
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 1.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B1_mock11_listening_part2.ssml
+++ b/.planning/audio-prompts/B1_mock11_listening_part2.ssml
@@ -1,0 +1,159 @@
+<speak>
+  <!-- B1 Mock 11 — Teil 2 (10 True/False, radio interview, playCount=1) -->
+  <!-- Narrator: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions -->
+  <!-- Moderatorin: de-DE-Wavenet-C (female, clear) rate="medium" — radio host Jana -->
+  <!-- Experte Dr. Mertens: de-DE-Wavenet-D (male, warm) rate="medium" — guest speaker -->
+  <!-- No repeat — Teil 2 plays ONCE at B1 -->
+  <!-- Topic: Vor- und Nachteile von Homeoffice (radio interview, Universität Köln) -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 2. Sie hören ein Radiointerview. Entscheiden Sie, ob die folgenden zehn Aussagen
+      richtig oder falsch sind. Sie hören den Text nur einmal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Radio interview begins -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Guten Morgen und herzlich willkommen zu unserem Morgenmagazin. Heute sprechen wir über das Homeoffice —
+      was es für Arbeitnehmer bedeutet, und wo die Grenzen liegen.
+      Unser Gast heute ist Dr. Klaus Mertens, Arbeitspsychologe an der Universität Köln.
+      Herzlich willkommen, Herr Dr. Mertens.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Vielen Dank, guten Morgen.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Herr Dr. Mertens, was zeigen Ihre aktuellen Studien zum Thema Homeoffice?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Wir sehen, dass die große Mehrheit der Befragten die gewonnene Eigenverantwortung
+      als klaren Pluspunkt nennt. Man plant seinen Tag selbst, das ist für viele eine echte Befreiung.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Aber es gibt auch Nachteile?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ja, das häufigste Problem, das unsere Probanden nennen, ist das fehlende klare Ende des Arbeitstages.
+      Man arbeitet einfach weiter, weil kein physischer Ortswechsel als Signal funktioniert.
+      Der ergonomische Bürostuhl kommt tatsächlich erst als zweites Problem.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Was empfehlen Sie konkret?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Definieren Sie Ihre Arbeitszeiten klar — fangen Sie um dieselbe Zeit an und hören Sie konsequent auf.
+      Das klingt banal, aber es macht einen enormen Unterschied.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Wie sehen Unternehmen das Homeoffice langfristig?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Über 70 Prozent der Unternehmen wollen hybride Modelle dauerhaft anbieten.
+      Von einem generellen Rückgang oder gar Abschaffen des Homeoffice ist keine Rede.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Gibt es Unterschiede zwischen Altersgruppen?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ja, sehr deutlich. Gerade bei Berufseinsteigern und unter Dreißigjährigen
+      fällt das Fehlen des direkten Austauschs mit Kollegen besonders stark ins Gewicht.
+      Das soziale Netzwerk im Büro ist für sie noch im Aufbau.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Und was ist mit Meetings — können Video-Calls alles ersetzen?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Da bin ich vorsichtig mit Pauschalaussagen.
+      Manche Besprechungen — etwa kreative Brainstorming-Runden — löst man besser persönlich.
+      Video-Calls sind sehr effizient für Statusupdates, aber sie ersetzen nicht alles.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Hat die Pandemie das eigentlich ausgelöst?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Absolut. Die Pandemie hat das, was vorher ein Nischenmodell war,
+      in vielen Unternehmen quasi über Nacht zum Standard gemacht.
+      Das ist in dieser Geschwindigkeit einzigartig in der Arbeitsgeschichte.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Herr Dr. Mertens, vielen Dank für diese interessanten Einblicke.
+      Weitere Informationen zu unserer heutigen Sendung finden Sie auf unserer Website.
+      Das war unser Morgenmagazin — einen guten Start in den Tag!
+    </prosody>
+  </voice>
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 2.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B1_mock11_listening_part3.ssml
+++ b/.planning/audio-prompts/B1_mock11_listening_part3.ssml
@@ -1,0 +1,351 @@
+<speak>
+  <!-- B1 Mock 11 — Teil 3 (5 MCQ, short dialogues, playCount=2) -->
+  <!-- Narrator: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions, Gespräch labels -->
+  <!-- Female speaker: de-DE-Wavenet-C (female, clear) rate="medium" — primary female roles -->
+  <!-- Male speaker: de-DE-Wavenet-D (male, warm) rate="medium" — primary male roles -->
+  <!-- Each conversation plays TWICE as per B1 Teil 3 spec -->
+  <!-- Topic: Arbeit und Beruf — Jobsuche, Büroalltag, Bewerbung -->
+  <!-- NOTE: Part 3 dialogues constructed from question context (no transcript in JSON source) -->
+  <!-- PLACEHOLDER — dialogue content derived from question explanations; review before production -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 3. Sie hören fünf kurze Gespräche. Zu jedem Gespräch gibt es eine Aufgabe.
+      Was ist richtig? Kreuzen Sie an: a, b oder c. Sie hören jedes Gespräch zweimal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Gespräch 1: Büro — Kollege muss Präsentation allein halten, Partnerin krank -->
+  <!-- correct: b — Kollegin ist krank, Kollege muss allein halten -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 1.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Petra, ich mache mir Sorgen wegen der Präsentation morgen.
+      Hast du schon von Maria gehört? Sie hat mir eben geschrieben, dass sie krank ist.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Oh nein, das ist ungünstig. Dann musst du morgen wohl allein vor dem Kunden präsentieren.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ich weiß, das wäre eigentlich Marias Teil. Aber ich habe alle Unterlagen,
+      ich kann die Kernpunkte auch alleine erklären.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Genau, du schaffst das. Soll ich dir noch beim Durchlesen helfen?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Das wäre nett, ja. Danke!
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Petra, ich mache mir Sorgen wegen der Präsentation morgen.
+      Hast du schon von Maria gehört? Sie hat mir eben geschrieben, dass sie krank ist.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Oh nein, das ist ungünstig. Dann musst du morgen wohl allein vor dem Kunden präsentieren.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ich weiß, das wäre eigentlich Marias Teil. Aber ich habe alle Unterlagen,
+      ich kann die Kernpunkte auch alleine erklären.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Genau, du schaffst das. Soll ich dir noch beim Durchlesen helfen?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Das wäre nett, ja. Danke!
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 2: Telefoninterview — Kandidatin fragt nach Gehalt -->
+  <!-- correct: c — Kandidatin fragt am Ende nach dem Gehalt -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 2.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Frau Hoffmann, vielen Dank für Ihre Bewerbung. Wir hatten jetzt die Möglichkeit,
+      Ihre Unterlagen durchzusehen und möchten Sie gerne näher kennenlernen.
+      Haben Sie noch Fragen zu uns oder zur Stelle?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, eine Frage habe ich noch: Könnten Sie mir etwas zum Gehaltsrahmen sagen?
+      Ich möchte gerne wissen, ob unsere Vorstellungen zusammenpassen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Natürlich. Wir bieten ein Jahresgehalt zwischen 42.000 und 48.000 Euro,
+      je nach Erfahrung und Qualifikation.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das klingt sehr gut, vielen Dank. Ich freue mich auf das persönliche Gespräch.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Frau Hoffmann, vielen Dank für Ihre Bewerbung. Wir hatten jetzt die Möglichkeit,
+      Ihre Unterlagen durchzusehen und möchten Sie gerne näher kennenlernen.
+      Haben Sie noch Fragen zu uns oder zur Stelle?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, eine Frage habe ich noch: Könnten Sie mir etwas zum Gehaltsrahmen sagen?
+      Ich möchte gerne wissen, ob unsere Vorstellungen zusammenpassen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Natürlich. Wir bieten ein Jahresgehalt zwischen 42.000 und 48.000 Euro,
+      je nach Erfahrung und Qualifikation.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das klingt sehr gut, vielen Dank. Ich freue mich auf das persönliche Gespräch.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 3: Homeoffice — Kollegen einigen sich auf Dienstag als Bürotag -->
+  <!-- correct: b — beide kommen dienstags ins Büro -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 3.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Sag mal, Stefan, wann bist du eigentlich nächste Woche im Büro?
+      Ich würde gerne persönlich mit dir das neue Projekt besprechen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ich plane Dienstag und Donnerstag vor Ort zu sein. Dienstag wäre für mich am besten.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Perfekt, Dienstag passt mir auch gut. Dann machen wir das am Dienstagvormittag?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ja, ab 10 Uhr bin ich frei. Reservier doch kurz den kleinen Besprechungsraum.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Mache ich. Bis Dienstag dann!
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Sag mal, Stefan, wann bist du eigentlich nächste Woche im Büro?
+      Ich würde gerne persönlich mit dir das neue Projekt besprechen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ich plane Dienstag und Donnerstag vor Ort zu sein. Dienstag wäre für mich am besten.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Perfekt, Dienstag passt mir auch gut. Dann machen wir das am Dienstagvormittag?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ja, ab 10 Uhr bin ich frei. Reservier doch kurz den kleinen Besprechungsraum.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Mache ich. Bis Dienstag dann!
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 4: Mitarbeitergespräch — Chef lobt Arbeit, schlägt Weiterbildung vor -->
+  <!-- correct: a — Chef schlägt Weiterbildungskurs vor -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 4.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Frau Nguyen, ich freue mich, dass wir heute Zeit für dieses Gespräch haben.
+      Ihre Arbeit in den letzten Monaten war wirklich sehr gut, das möchte ich ausdrücklich betonen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Vielen Dank, das höre ich gerne. Ich lerne noch viel, aber ich engagiere mich gern.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Genau das ist der Punkt. Ich würde Ihnen gerne einen Weiterbildungskurs im Bereich Projektmanagement
+      anbieten. Das würde Ihnen und dem Team langfristig helfen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das würde ich sehr gern annehmen. Wann würde der Kurs stattfinden?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ich schicke Ihnen diese Woche noch die Details per E-Mail.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Frau Nguyen, ich freue mich, dass wir heute Zeit für dieses Gespräch haben.
+      Ihre Arbeit in den letzten Monaten war wirklich sehr gut, das möchte ich ausdrücklich betonen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Vielen Dank, das höre ich gerne. Ich lerne noch viel, aber ich engagiere mich gern.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Genau das ist der Punkt. Ich würde Ihnen gerne einen Weiterbildungskurs im Bereich Projektmanagement
+      anbieten. Das würde Ihnen und dem Team langfristig helfen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das würde ich sehr gern annehmen. Wann würde der Kurs stattfinden?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ich schicke Ihnen diese Woche noch die Details per E-Mail.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 5: Kollegin — ihre frühere Stelle wurde gestrichen, sie sucht nun aktiv -->
+  <!-- correct: c — Stelle wurde gestrichen, sucht aktiv im Marketing -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 5.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ich habe gehört, du bist gerade auf Jobsuche. Wie läuft das so?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, seit drei Monaten schon. Die Firma hat leider Stellen abgebaut —
+      meine Stelle wurde einfach gestrichen. Das war natürlich ein Schock.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Das tut mir leid. Hast du schon Vorstellungsgespräche?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, zwei schon. Ich bewerbe mich hauptsächlich im Bereich Marketing.
+      Nächste Woche habe ich noch einen Termin, da bin ich optimistisch.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Das klingt gut. Ich drücke dir die Daumen!
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ich habe gehört, du bist gerade auf Jobsuche. Wie läuft das so?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, seit drei Monaten schon. Die Firma hat leider Stellen abgebaut —
+      meine Stelle wurde einfach gestrichen. Das war natürlich ein Schock.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Das tut mir leid. Hast du schon Vorstellungsgespräche?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, zwei schon. Ich bewerbe mich hauptsächlich im Bereich Marketing.
+      Nächste Woche habe ich noch einen Termin, da bin ich optimistisch.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Das klingt gut. Ich drücke dir die Daumen!
+    </prosody>
+  </voice>
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 3.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B1_mock12_listening_part1.ssml
+++ b/.planning/audio-prompts/B1_mock12_listening_part1.ssml
@@ -1,0 +1,97 @@
+<speak>
+  <!-- B1 Mock 12 — Teil 1 (5 True/False, short audio clips, playCount=1) -->
+  <!-- Narrator/Announcer: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions, task labels -->
+  <!-- Female speaker: de-DE-Wavenet-C (female, clear) rate="medium" — doctor, female roles -->
+  <!-- Male speaker: de-DE-Wavenet-D (male, warm) rate="medium" — announcements, studio voice -->
+  <!-- No repeat — Teil 1 plays ONCE at B1 -->
+  <!-- Topic: Gesundheit und Alltag — Arztpraxis, Fitnessstudio, Apotheke, Radiosendung, Hallenbad -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 1. Sie hören fünf kurze Texte. Entscheiden Sie bei jedem Text:
+      Ist die Aussage richtig oder falsch? Sie hören jeden Text nur einmal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Aufgabe 1: Arztpraxis — Termin Dienstag 10:30 Uhr, bei Verhinderung bis Montag anrufen -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 1.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Guten Tag, hier ist die Praxis Dr. Winkler. Diese Nachricht geht an Herrn Brandt.
+      Bitte kommen Sie nächsten Dienstag um 10 Uhr 30 zu Ihrem Kontrolltermin.
+      Falls Sie verhindert sind, rufen Sie uns bitte bis Montag an.
+      Vielen Dank!
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 2: Fitnessstudio — neuer Yoga-Flow-Kurs jeden Samstagmorgen 9 Uhr -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 2.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Hallo liebe Mitglieder, hier ist eine kurze Info von eurem FitPark-Team.
+      Ab dieser Woche bieten wir ein neues Kursangebot an.
+      Jeden Samstagmorgen um 9 Uhr findet unser neuer Yoga-Flow-Kurs statt.
+      Anmeldung einfach über unsere App. Wir freuen uns auf euch!
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 3: Apotheke — Mittagspause 12–14:30 Uhr, Nachmittag ab 14:30 wieder offen -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 3.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Willkommen bei der Stadt-Apotheke am Markt. Unsere Öffnungszeiten:
+      Montags bis freitags von 8 bis 12 Uhr und von 14 Uhr 30 bis 18 Uhr.
+      Samstags nur von 9 bis 13 Uhr.
+      In dringenden Fällen wenden Sie sich bitte an die Notfallnummer auf unserem Aushang.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 4: Radiosendung — Ärztin empfiehlt täglich 30 Minuten spazieren -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 4.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Viele Menschen denken, Sport muss intensiv sein, um zu wirken.
+      Aber das stimmt nicht. Schon ein täglicher Spaziergang von mindestens dreißig Minuten
+      kann das Herzkreislaufsystem deutlich stärken.
+      Das ist eine der günstigsten und wirksamsten Präventionsmaßnahmen, die es gibt.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 5: Stadtinformation — Hallenbad öffnet erst am ersten März, nicht nächste Woche -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 5.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Eine Bekanntmachung der Stadtwerke Neustadt:
+      Das modernisierte Hallenbad am Stadtpark öffnet nach der Renovierung am ersten März.
+      Wir freuen uns, Ihnen dann ein komplett erneuertes Bad mit erweitertem Kursangebot zu präsentieren.
+      Weitere Infos finden Sie auf der Website der Stadtwerke.
+    </prosody>
+  </voice>
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 1.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B1_mock12_listening_part2.ssml
+++ b/.planning/audio-prompts/B1_mock12_listening_part2.ssml
@@ -1,0 +1,176 @@
+<speak>
+  <!-- B1 Mock 12 — Teil 2 (10 True/False, radio interview, playCount=1) -->
+  <!-- Narrator: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions -->
+  <!-- Moderatorin: de-DE-Wavenet-C (female, clear) rate="medium" — morning magazine host -->
+  <!-- Ernährungsberaterin Frau Koch: de-DE-Wavenet-C — NOTE: same voice as moderatorin -->
+  <!-- Frau Koch secondary voice: de-DE-Wavenet-A (female, slightly younger) rate="medium" -->
+  <!-- No repeat — Teil 2 plays ONCE at B1 -->
+  <!-- Topic: Ernährungsberatung — Frühstück, Wasser, Intervallfasten, Zucker (Frau Koch, Berufstätige 30–55) -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 2. Sie hören ein Interview. Entscheiden Sie, ob die folgenden zehn Aussagen
+      richtig oder falsch sind. Sie hören den Text nur einmal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Radio interview begins — Morgenmagazin -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Guten Morgen, liebe Hörerinnen und Hörer, und willkommen zu unserem Morgenmagazin.
+      Heute sprechen wir über Ernährung im Alltag.
+      Meine Gästin ist Ernährungsberaterin Sabine Koch.
+      Frau Koch, schön, dass Sie da sind!
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Danke, ich freue mich, dabei zu sein.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Frau Koch, wer sind eigentlich Ihre Klienten? Arbeiten Sie vor allem mit Sportlern?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Nein, tatsächlich nicht. Meine Klienten sind vor allem Berufstätige zwischen 30 und 55,
+      die im Alltag wenig Zeit fürs Kochen haben. Die brauchen pragmatische Lösungen, keine Diätpläne.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Welche Mahlzeit ist für Sie die wichtigste?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Das Frühstück ist für mich die wichtigste Mahlzeit des Tages — wer morgens gut isst,
+      hat den halben Tag schon gewonnen. Das Mittagessen ist natürlich auch wichtig, aber das Frühstück setzt den Rhythmus.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Wieviel Wasser sollte man täglich trinken?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Ich empfehle mindestens eineinhalb bis zwei Liter, abhängig von Körpergewicht und Aktivität.
+      Da gibt es keine Einheitslösung. Mehr als zwei Liter ist für manche sinnvoll, für andere nicht nötig.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Wie stehen Sie zu Fertiggerichten?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Ich sage meinen Klienten: Ein Fertiggericht ab und zu ist kein Problem.
+      Entscheidend ist das große Ganze — wer sich die Woche über gut ernährt,
+      muss wegen eines Fertiggerichts kein schlechtes Gewissen haben.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Was halten Sie von Intervallfasten?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Intervallfasten funktioniert für viele sehr gut, aber Menschen mit Unterzuckerung
+      oder bestimmten Vorerkrankungen sollten das nicht ohne ärztliche Begleitung ausprobieren.
+      Es ist also nicht universell geeignet.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Und Zucker — sollte man ihn komplett streichen?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Zucker komplett zu verbieten ist meiner Erfahrung nach kontraproduktiv.
+      Besser ist ein bewusster Umgang. Wer nie Süßes essen darf, gibt irgendwann auf.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Frau Koch, Sie sind doch sicher nicht von Anfang an Ernährungsberaterin geworden, oder?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Nein, ich bin nicht aus heiterem Himmel Ernährungsberaterin geworden.
+      Ich hatte selbst in meinen Zwanzigern eine Phase, in der ich sehr schlecht gegessen habe
+      und mich ständig müde gefühlt habe. Das war der Auslöser.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das ist eine interessante Geschichte. Und noch ein letzter Tipp?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Essen in Gesellschaft verlangsamt das Tempo, man kaut besser und ist danach zufriedener.
+      Ich empfehle meinen Klienten, wann immer möglich, gemeinsam zu essen.
+      Und noch was: Es gibt eine gute App namens NutriTrack — ich nutze sie selbst gern,
+      habe aber nichts damit zu tun.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Wunderbar, vielen Dank, Frau Koch!
+      Liebe Hörerinnen und Hörer, wenn Sie Fragen haben, können Sie uns über unsere Website kontaktieren.
+      Einen guten Morgen noch!
+    </prosody>
+  </voice>
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 2.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B1_mock12_listening_part3.ssml
+++ b/.planning/audio-prompts/B1_mock12_listening_part3.ssml
@@ -1,0 +1,303 @@
+<speak>
+  <!-- B1 Mock 12 — Teil 3 (5 MCQ, short dialogues, playCount=2) -->
+  <!-- Narrator: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions, Gespräch labels -->
+  <!-- Female speaker: de-DE-Wavenet-C (female, clear) rate="medium" — primary female roles -->
+  <!-- Male speaker: de-DE-Wavenet-D (male, warm) rate="medium" — primary male roles -->
+  <!-- Each conversation plays TWICE as per B1 Teil 3 spec -->
+  <!-- Topic: Gesundheit und Ernährung im Alltag -->
+  <!-- NOTE: Part 3 dialogues constructed from question context (no transcript in JSON source) -->
+  <!-- PLACEHOLDER — dialogue content derived from question explanations; review before production -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 3. Sie hören fünf kurze Gespräche. Zu jedem Gespräch gibt es eine Aufgabe.
+      Was ist richtig? Kreuzen Sie an: a, b oder c. Sie hören jedes Gespräch zweimal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Gespräch 1: Arzt und Patient — Arzt empfiehlt mehr Bewegung, kein Medikament -->
+  <!-- correct: b — Arzt empfiehlt regelmäßige Bewegung statt Medikament -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 1.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Herr Doktor, ich fühle mich schon seit Wochen so schlapp. Könnten Sie mir irgendwas verschreiben?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ich verstehe das. Aber ehrlich gesagt — Ihre Blutwerte sind in Ordnung.
+      Mein Rat wäre, zunächst auf regelmäßige Bewegung zu setzen, bevor wir Medikamente einsetzen.
+      Dreimal pro Woche 30 Minuten spazieren würde schon helfen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Also kein Medikament?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Nicht sofort. Versuchen Sie es vier Wochen mit mehr Bewegung.
+      Wenn es dann nicht besser wird, kommen Sie wieder.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Herr Doktor, ich fühle mich schon seit Wochen so schlapp. Könnten Sie mir irgendwas verschreiben?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ich verstehe das. Aber ehrlich gesagt — Ihre Blutwerte sind in Ordnung.
+      Mein Rat wäre, zunächst auf regelmäßige Bewegung zu setzen, bevor wir Medikamente einsetzen.
+      Dreimal pro Woche 30 Minuten spazieren würde schon helfen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Also kein Medikament?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Nicht sofort. Versuchen Sie es vier Wochen mit mehr Bewegung.
+      Wenn es dann nicht besser wird, kommen Sie wieder.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 2: Zwei Freunde — einer macht Intervallfasten, der andere findet es extrem -->
+  <!-- correct: a — einer praktiziert Intervallfasten und erklärt den Ablauf -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 2.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Hast du jetzt wirklich mit dem Intervallfasten angefangen? Wie läuft das bei dir?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, seit einem Monat. Ich esse nur zwischen 12 und 20 Uhr, morgens gibt es nichts außer Kaffee.
+      Ich finde es gar nicht so schwer — man gewöhnt sich dran.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Das klingt für mich extrem. Kein Frühstück?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ich vermisse das Frühstück inzwischen kaum noch.
+      Und ich habe das Gefühl, dass ich klarer im Kopf bin.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Hast du jetzt wirklich mit dem Intervallfasten angefangen? Wie läuft das bei dir?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, seit einem Monat. Ich esse nur zwischen 12 und 20 Uhr, morgens gibt es nichts außer Kaffee.
+      Ich finde es gar nicht so schwer — man gewöhnt sich dran.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Das klingt für mich extrem. Kein Frühstück?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ich vermisse das Frühstück inzwischen kaum noch.
+      Und ich habe das Gefühl, dass ich klarer im Kopf bin.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 3: Mutter und Sohn — Mutter fragt warum er nichts isst, Sohn hat Magenschmerzen -->
+  <!-- correct: c — Sohn hat Bauchschmerzen, isst deshalb nichts -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 3.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Tim, du hast dein Frühstück kaum angerührt. Was ist los?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Mir ist nicht so gut. Ich habe seit heute Nacht Bauchschmerzen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Oh, dann solltest du wirklich nichts Schweres essen. Tee und Zwieback?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ja, das wäre gut. Und vielleicht liege ich heute noch kurz.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Tim, du hast dein Frühstück kaum angerührt. Was ist los?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Mir ist nicht so gut. Ich habe seit heute Nacht Bauchschmerzen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Oh, dann solltest du wirklich nichts Schweres essen. Tee und Zwieback?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ja, das wäre gut. Und vielleicht liege ich heute noch kurz.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 4: Supermarkt — Kundin fragt nach laktosefreier Milch, Mitarbeiter verweist auf Kühlregal -->
+  <!-- correct: b — laktosefreie Milch steht im Kühlregal mit Bio-Produkten -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 4.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Entschuldigung, ich suche laktosefreie Milch. Wo finde ich die hier?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Die steht im hinteren Kühlregal, gleich neben den Bio-Produkten.
+      Gehen Sie einfach durch bis zur letzten Kühltheke.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ah, vielen Dank! Haben Sie auch die Soja-Variante?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ja, Sojadrinks stehen direkt daneben, gleich im selben Regal.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Entschuldigung, ich suche laktosefreie Milch. Wo finde ich die hier?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Die steht im hinteren Kühlregal, gleich neben den Bio-Produkten.
+      Gehen Sie einfach durch bis zur letzten Kühltheke.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ah, vielen Dank! Haben Sie auch die Soja-Variante?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ja, Sojadrinks stehen direkt daneben, gleich im selben Regal.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 5: Kochkurs — Teilnehmerin war am Mittwoch beim Kochkurs, hat Pasta gelernt -->
+  <!-- correct: a — Frau war bei Kochkurs und hat Pastateig selbst gemacht -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 5.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Na, wie war dein Kochkurs gestern Abend?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Wirklich toll! Wir haben frischen Pastateig von Hand gemacht —
+      das hätte ich mir vorher nie zugetraut. Und dazu eine Tomatensauce mit frischen Kräutern.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Klingt lecker. Machst du nächste Woche auch mit?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, unbedingt. Nächste Woche machen wir asiatische Küche, da freue ich mich schon drauf.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Na, wie war dein Kochkurs gestern Abend?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Wirklich toll! Wir haben frischen Pastateig von Hand gemacht —
+      das hätte ich mir vorher nie zugetraut. Und dazu eine Tomatensauce mit frischen Kräutern.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Klingt lecker. Machst du nächste Woche auch mit?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, unbedingt. Nächste Woche machen wir asiatische Küche, da freue ich mich schon drauf.
+    </prosody>
+  </voice>
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 3.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B1_mock13_listening_part1.ssml
+++ b/.planning/audio-prompts/B1_mock13_listening_part1.ssml
@@ -1,0 +1,108 @@
+<speak>
+  <!-- B1 Mock 13 — Teil 1 (5 True/False, short audio clips, playCount=1) -->
+  <!-- Narrator/Announcer: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions, task labels -->
+  <!-- Female speaker: de-DE-Wavenet-C (female, clear) rate="medium" — telephone booking, hotel female roles -->
+  <!-- Male speaker: de-DE-Wavenet-D (male, warm) rate="medium" — station announcements, radio, voicemail -->
+  <!-- No repeat — Teil 1 plays ONCE at B1 -->
+  <!-- Topic: Reisen und Verkehr — Bahnhof, Buchung, Hotel, Fahrrad, Anrufbeantworter -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 1. Sie hören fünf kurze Texte. Entscheiden Sie bei jedem Text:
+      Ist die Aussage richtig oder falsch? Sie hören jeden Text nur einmal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Aufgabe 1: Bahnhofsdurchsage — RE 420 nach Freiburg fährt von Gleis 12 (nicht Gleis 7) -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 1.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Achtung, eine Durchsage auf Gleis 7.
+      Der Regionalzug RE 420 nach Freiburg fährt heute abweichend von Gleis 12 ab.
+      Wir bitten alle Fahrgäste, sich zum Gleis 12 zu begeben.
+      Abfahrt planmäßig um 14 Uhr 22. Wir danken für Ihr Verständnis.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 2: Telefon — Frau bucht Zugticket Köln-Berlin für nächsten Montag den 12. -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 2.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Guten Tag, ich brauche eine Fahrkarte von Köln nach Berlin,
+      und zwar für nächsten Montag, den 12.
+      Einfache Fahrt, zweite Klasse, wenn möglich am Vormittag.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Gerne. Es gibt einen IC um 9 Uhr 14 ab Köln, Ankunft Berlin Hauptbahnhof 13 Uhr 45.
+      Soll ich das für Sie buchen?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, das passt mir gut. Bitte buchen.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 3: Hotel — kostenloser Shuttleservice zum Flughafen um 6, 9 und 12 Uhr -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 3.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Herzlich willkommen im Hotel Stadtmitte. Ein kurzer Hinweis für unsere Gäste:
+      Für unsere Gäste bieten wir täglich einen kostenlosen Shuttleservice zum Flughafen an —
+      Abfahrt um 6, 9 und 12 Uhr vom Haupteingang.
+      Bitte melden Sie sich für den Shuttle bis spätestens 30 Minuten vorher an der Rezeption an.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 4: Radio — Fahrradspuren in deutschen Städten ausgebaut, mehr Platz für Radfahrer -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 4.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      In vielen deutschen Städten wurden in den letzten fünf Jahren Fahrradspuren deutlich ausgebaut
+      und neue Radschnellwege geschaffen.
+      Das zeigt eine aktuelle Studie des Deutschen Instituts für Stadtentwicklung.
+      Vor allem in Städten wie Münster, Freiburg und München ist der Anteil des Radverkehrs
+      spürbar gewachsen.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 5: Anrufbeantworter — Mann kommt morgen Abend mit dem Zug, bittet um Abholung vom Bahnhof -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 5.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Hallo Schatz, ich bin's. Ich komme morgen Abend mit dem Zug an —
+      voraussichtlich um 19 Uhr 40.
+      Könntest du mich bitte vom Bahnhof abholen?
+      Ich rufe noch mal an, wenn sich was ändert. Bis morgen!
+    </prosody>
+  </voice>
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 1.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B1_mock13_listening_part2.ssml
+++ b/.planning/audio-prompts/B1_mock13_listening_part2.ssml
@@ -1,0 +1,158 @@
+<speak>
+  <!-- B1 Mock 13 — Teil 2 (10 True/False, radio report, playCount=1) -->
+  <!-- Narrator: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions -->
+  <!-- Moderator: de-DE-Wavenet-D (male, warm) rate="medium" — radio host -->
+  <!-- Reiseexpertin Katharina Steiner: de-DE-Wavenet-C (female, clear) rate="medium" — guest expert -->
+  <!-- Zusätzlicher Sprecher: de-DE-Wavenet-F (male, slightly older) rate="medium" — data/statistics voice -->
+  <!-- No repeat — Teil 2 plays ONCE at B1 -->
+  <!-- Topic: Nachhaltiges Reisen in Europa — Züge vs. Flugzeug, Nachtzüge, Fahrrad am Zielort -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 2. Sie hören einen Radiobericht. Entscheiden Sie, ob die folgenden zehn Aussagen
+      richtig oder falsch sind. Sie hören den Text nur einmal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Radio report begins -->
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Herzlich willkommen zu unserem Nachmittagsmagazin.
+      In unserer heutigen Sendung sprechen wir über umweltfreundliche Reisemöglichkeiten innerhalb Europas.
+      Nachhaltiges Reisen — das ist unser Thema.
+      Meine Gästin ist Katharina Steiner, Leiterin der Abteilung für nachhaltigen Tourismus
+      beim Europäischen Reiseverband.
+      Herzlich willkommen, Frau Steiner.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Guten Tag, vielen Dank für die Einladung.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Frau Steiner, viele Menschen denken: Das Flugzeug ist schneller.
+      Stimmt das wirklich immer?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das ist ein weit verbreitetes Missverständnis. Wenn man An- und Abreise zum Flughafen
+      sowie Wartezeiten einrechnet, ist der Zug auf Strecken unter 700 Kilometern
+      oft genauso schnell oder sogar schneller als das Flugzeug.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Empfehlen Sie also, nur noch Zug zu fahren und nie mehr zu fliegen?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Nein, das wäre zu einfach. Wir wollen niemanden zwingen.
+      Es geht darum, informierte Entscheidungen zu treffen.
+      Für manche Reisen — besonders lange interkontinentale Strecken —
+      ist das Flugzeug nach wie vor die einzige sinnvolle Option.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Wie sieht es mit Nachtzügen aus?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Nachtzüge erfreuen sich wachsender Beliebtheit — und das aus gutem Grund.
+      Passagiere schlafen im Zug und kommen ausgeruht am Ziel an — ohne extra Reisezeit zu verlieren.
+      Das ist ein echter Mehrwert.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Aber wie sieht es mit dem Preis aus? Nachtzüge gelten als teuer.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das ist ein Kritikpunkt, den viele Reisende nennen.
+      Nachtzugtickets auf beliebten Strecken sind oft teurer als Billigflüge —
+      das ist leider noch eine Herausforderung für die Branche.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Und am Zielort — wie kommen Reisende dann weiter?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ich empfehle: Am Zielort einfach ein Leihfahrrad nehmen —
+      das ist ideal für kurze Strecken und man sieht gleichzeitig viel mehr von der Stadt.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Wer interessiert sich eigentlich am meisten für nachhaltiges Reisen?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Interessanterweise ist nachhaltiges Reisen besonders bei jüngeren Leuten
+      zwischen 25 und 40 Jahren gefragt. Das hat mich selbst überrascht.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Und noch eine Zahl zur Ergänzung: Mehrtägige Radreisen erfreuen sich wachsender Beliebtheit —
+      laut ADFC-Statistik wurden in den letzten drei Jahren doppelt so viele Fernradreisen unternommen.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Frau Steiner, vielen herzlichen Dank für das Gespräch!
+      Alle Infos und einen Vergleich europäischer Bahnverbindungen finden Sie auf unserer Website
+      unter reisen-nachhaltig.de.
+      Das war unser Nachmittagsmagazin — bis zum nächsten Mal!
+    </prosody>
+  </voice>
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 2.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B1_mock13_listening_part3.ssml
+++ b/.planning/audio-prompts/B1_mock13_listening_part3.ssml
@@ -1,0 +1,324 @@
+<speak>
+  <!-- B1 Mock 13 — Teil 3 (5 MCQ, short dialogues, playCount=2) -->
+  <!-- Narrator: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions, Gespräch labels -->
+  <!-- Female speaker: de-DE-Wavenet-C (female, clear) rate="medium" — primary female roles -->
+  <!-- Male speaker: de-DE-Wavenet-D (male, warm) rate="medium" — primary male roles -->
+  <!-- Each conversation plays TWICE as per B1 Teil 3 spec -->
+  <!-- Topic: Reisen — Zug vs. Auto, Sommerurlaub, Auslandssemester, Familienstorno, Dienstreisen -->
+  <!-- Full transcript sourced from mock_13.json question explanations -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 3. Sie hören fünf kurze Gespräche. Zu jedem Gespräch gibt es eine Aufgabe.
+      Was ist richtig? Kreuzen Sie an: a, b oder c. Sie hören jedes Gespräch zweimal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Gespräch 1: Herr Bauer — lieber Zug als Auto nach München (Arbeiten + kein Stau/Parkplatz) -->
+  <!-- correct: b -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 1.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Herr Bauer, Sie fahren morgen nach München, oder? Nehmen Sie das Auto?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Nein, ich fahre immer mit dem Zug nach München.
+      Im Zug kann ich meinen Laptop aufmachen und arbeite einfach weiter —
+      und das Thema Stau und Parkplatz in München spare ich mir komplett.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Stimmt, in München einen Parkplatz zu finden ist wirklich mühsam.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Genau. Das Ticket ist zwar nicht immer günstiger, aber die Nerven sind es wert.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Herr Bauer, Sie fahren morgen nach München, oder? Nehmen Sie das Auto?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Nein, ich fahre immer mit dem Zug nach München.
+      Im Zug kann ich meinen Laptop aufmachen und arbeite einfach weiter —
+      und das Thema Stau und Parkplatz in München spare ich mir komplett.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Stimmt, in München einen Parkplatz zu finden ist wirklich mühsam.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Genau. Das Ticket ist zwar nicht immer günstiger, aber die Nerven sind es wert.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 2: Pärchen — Radtour Salzburg–Wien, Gasthöfe in Österreich -->
+  <!-- correct: b -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 2.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Was machst du dir dieses Jahr als Sommerurlaub vor?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ich stelle mir das so vor: Wir fahren mit dem Rad von Salzburg nach Wien —
+      das sind so sieben bis acht Tage —
+      und schlafen abends in kleinen Gasthöfen am Weg.
+      Kein großes Hotel, einfach unterwegs sein.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das klingt wunderschön! Ich dachte kurz an eine Kreuzfahrt, aber das ist viel schöner.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Genau, aktiv Urlaub machen macht für mich viel mehr Sinn. Machst du mit?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, sehr gerne!
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Was machst du dir dieses Jahr als Sommerurlaub vor?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ich stelle mir das so vor: Wir fahren mit dem Rad von Salzburg nach Wien —
+      das sind so sieben bis acht Tage —
+      und schlafen abends in kleinen Gasthöfen am Weg.
+      Kein großes Hotel, einfach unterwegs sein.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das klingt wunderschön! Ich dachte kurz an eine Kreuzfahrt, aber das ist viel schöner.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Genau, aktiv Urlaub machen macht für mich viel mehr Sinn. Machst du mit?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, sehr gerne!
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 3: Studentin in Barcelona — Sprache verbessern, wenig Kontakt zu Deutschen -->
+  <!-- correct: b -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 3.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Du gehst nächsten Monat nach Barcelona für dein Auslandssemester. Worauf freust du dich am meisten?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das Wichtigste für mich ist, wirklich Katalanisch und Spanisch zu lernen.
+      Deshalb möchte ich in einer WG mit Einheimischen wohnen
+      und den Kontakt zu deutschen Studierenden möglichst vermeiden.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Und Reisen? Barcelona liegt ja super für Ausflüge.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das plane ich für danach — nach dem Semester möchte ich mit dem Interrail durch Europa.
+      Aber während des Semesters konzentriere ich mich auf die Sprache.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Du gehst nächsten Monat nach Barcelona für dein Auslandssemester. Worauf freust du dich am meisten?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das Wichtigste für mich ist, wirklich Katalanisch und Spanisch zu lernen.
+      Deshalb möchte ich in einer WG mit Einheimischen wohnen
+      und den Kontakt zu deutschen Studierenden möglichst vermeiden.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Und Reisen? Barcelona liegt ja super für Ausflüge.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das plane ich für danach — nach dem Semester möchte ich mit dem Interrail durch Europa.
+      Aber während des Semesters konzentriere ich mich auf die Sprache.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 4: Familie — Hotel hat wegen Überbuchung Reservierung storniert, daher Flug storniert -->
+  <!-- correct: c -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 4.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Und, ihr wart doch diese Woche in Lanzarote? Wie war's?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Wir waren leider gar nicht dort. Das Hotel hat uns drei Tage vor dem Abflug geschrieben,
+      dass sie überbucht sind und kein Zimmer mehr für uns haben.
+      Da haben wir natürlich auch den Flug storniert.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das ist ja unglaublich! Hat das Hotel eine Entschädigung angeboten?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ja, eine Gutschrift für eine zukünftige Buchung — aber das hilft uns für diesen Sommer nicht viel.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Und, ihr wart doch diese Woche in Lanzarote? Wie war's?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Wir waren leider gar nicht dort. Das Hotel hat uns drei Tage vor dem Abflug geschrieben,
+      dass sie überbucht sind und kein Zimmer mehr für uns haben.
+      Da haben wir natürlich auch den Flug storniert.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das ist ja unglaublich! Hat das Hotel eine Entschädigung angeboten?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ja, eine Gutschrift für eine zukünftige Buchung — aber das hilft uns für diesen Sommer nicht viel.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 5: Zwei Kollegen — einig: Videokonferenzen haben kurze Dienstreisen überflüssig gemacht -->
+  <!-- correct: c -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 5.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ich denke manchmal an früher — diesen kurzen Hin- und Hinwegtrip nach Frankfurt
+      für ein zweistündiges Meeting würde ich heute nicht mehr machen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Da haben wir wirklich viel Zeit gespart — die meisten Besprechungen klappen auch per Video.
+      Das war früher gar keine Option.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Genau. Dienstreisen machen heute eigentlich nur noch Sinn,
+      wenn man wirklich vor Ort sein muss.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Das sehe ich genauso.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ich denke manchmal an früher — diesen kurzen Hin- und Hinwegtrip nach Frankfurt
+      für ein zweistündiges Meeting würde ich heute nicht mehr machen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Da haben wir wirklich viel Zeit gespart — die meisten Besprechungen klappen auch per Video.
+      Das war früher gar keine Option.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Genau. Dienstreisen machen heute eigentlich nur noch Sinn,
+      wenn man wirklich vor Ort sein muss.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Das sehe ich genauso.
+    </prosody>
+  </voice>
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 3.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B1_mock14_listening_part1.ssml
+++ b/.planning/audio-prompts/B1_mock14_listening_part1.ssml
@@ -1,0 +1,97 @@
+<speak>
+  <!-- B1 Mock 14 — Teil 1 (5 True/False, short audio clips, playCount=1) -->
+  <!-- Narrator/Announcer: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions, task labels -->
+  <!-- Female speaker: de-DE-Wavenet-C (female, clear) rate="medium" — school announcement, female roles -->
+  <!-- Male speaker: de-DE-Wavenet-D (male, warm) rate="medium" — voicemail father, radio, Kindergarten -->
+  <!-- No repeat — Teil 1 plays ONCE at B1 -->
+  <!-- Topic: Familie und Schule — Schulansagen, Anrufbeantworter, Kindergarten, Radiosendung -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 1. Sie hören fünf kurze Texte. Entscheiden Sie bei jedem Text:
+      Ist die Aussage richtig oder falsch? Sie hören jeden Text nur einmal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Aufgabe 1: Schulansage — Elternversammlung verschoben auf nächsten Dienstag (Lehrerin krank) -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 1.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Guten Morgen, eine Mitteilung der Grundschule Lindenweg.
+      Die für Donnerstag geplante Elternversammlung der Klasse 3b findet
+      aufgrund der Erkrankung der Klassenlehrerin erst nächsten Dienstag statt.
+      Wir bitten alle Eltern um Verständnis. Weitere Informationen erhalten Sie per Brief.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 2: Vater auf Anrufbeantworter — fährt selbst zum Bahnhof, Tochter soll Abendessen vorbereiten -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 2.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Hallo Lena, hier ist Papa. Ich fahre jetzt selbst zum Bahnhof,
+      da ich doch früher Feierabend machen konnte.
+      Könntest du schon mal das Abendessen vorbereiten?
+      Ich bringe Oma Gerda dann mit. Bis gleich!
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 3: Kindergarten — nur Freitag geschlossen (Betriebsversammlung), nicht eine Woche -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 3.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Liebe Eltern, eine kurze Information des Kindergartens St. Josef.
+      Aufgrund einer Betriebsversammlung bleiben wir diesen Freitag geschlossen.
+      Ab Montag sind wir wieder wie gewohnt für Ihre Kinder da.
+      Bitte planen Sie entsprechend. Vielen Dank!
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 4: Radio — Großeltern ziehen zu Kindern, um bei Enkelbetreuung zu helfen (nicht Pflegekosten) -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 4.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ein interessantes gesellschaftliches Phänomen zeigt sich in den Statistiken:
+      Immer mehr Großeltern ziehen zu ihren Kindern, um bei der Betreuung der Enkel zu helfen.
+      Das spart Kosten für externe Kinderbetreuung und stärkt gleichzeitig die Familienbande.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 5: Schulmesse — Familienberatungsstelle für Familien mit Kindern jeden Alters (nicht nur über 12) -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 5.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Herzlich willkommen am Stand der Familienberatungsstelle Nordstadt.
+      Unser Angebot richtet sich an Familien mit Kindern in jedem Alter —
+      von Neugeborenen bis hin zu Jugendlichen.
+      Wir sind für alle Fragen rund um Erziehung, Trennung und Beratung da.
+      Sprechen Sie uns gern an!
+    </prosody>
+  </voice>
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 1.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B1_mock14_listening_part2.ssml
+++ b/.planning/audio-prompts/B1_mock14_listening_part2.ssml
@@ -1,0 +1,297 @@
+<speak>
+  <!-- B1 Mock 14 — Teil 2 (10 True/False, radio feature, playCount=2) -->
+  <!-- Narrator: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions, repeat marker -->
+  <!-- Moderatorin: de-DE-Wavenet-C (female, clear) rate="medium" — radio host -->
+  <!-- Expertin Dr. Kathrin Wendland: de-DE-Wavenet-A (female, slightly younger) rate="medium" — guest -->
+  <!-- Zusatzstimme Sprecher: de-DE-Wavenet-F (male, slightly older) rate="medium" — data/statistics -->
+  <!-- PLAYED TWICE — repeat marker included per playCount=2 in mock JSON -->
+  <!-- Topic: Veränderte Familienstrukturen in Deutschland — Alleinerziehende, Patchwork, Elternzeit -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 2. Sie hören ein Radiofeature über veränderte Familienstrukturen in Deutschland.
+      Entscheiden Sie, ob die folgenden zehn Aussagen richtig oder falsch sind.
+      Sie hören den Text zweimal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Radio feature begins -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Herzlich willkommen zu unserem Mittagsmagazin.
+      Heute schauen wir uns an, wie sich das Zusammenleben von Familien in Deutschland verändert hat —
+      und was das für Eltern, Kinder und Großeltern bedeutet.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Die Zahlen sprechen für sich: Die Zahl der Alleinerziehenden ist in Deutschland seit 2010
+      kontinuierlich gestiegen — heute liegt sie bei fast 20 Prozent aller Familien.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Zu diesen Themen haben wir heute Dr. Kathrin Wendland im Studio —
+      sie leitet am Deutschen Jugendinstitut eine Forschungsgruppe
+      zu modernen Familienmodellen und Patchwork-Familien.
+      Frau Dr. Wendland, herzlich willkommen!
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Guten Tag, ich freue mich, hier zu sein.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Frau Dr. Wendland, sind Patchwork-Familien schlechter für Kinder als traditionelle Familien?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Das können wir so nicht sagen. Entscheidend ist nicht die Familienform,
+      sondern die Qualität der Beziehungen.
+      Kinder in Patchwork-Familien können genauso stabile Bindungen entwickeln
+      wie Kinder in traditionellen Familien.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Laut einer aktuellen Erhebung sind es im Durchschnitt elf Stunden pro Woche,
+      die Großeltern direkt für die Kinderbetreuung aufwenden.
+      Das ist mehr als in den meisten europäischen Ländern.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Wie gut unterstützen Unternehmen berufstätige Eltern?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Obwohl es gesetzliche Regelungen gibt, bieten nach unserer Erhebung
+      nur rund 40 Prozent der Betriebe wirklich flexible Modelle für Eltern an.
+      Das ist deutlich weniger als die Hälfte — hier besteht noch Nachholbedarf.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Wie sieht es mit Vätern und Elternzeit aus?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Der Anteil der Väter, die Elternzeit nehmen, ist gestiegen —
+      liegt aber mit knapp 25 Prozent noch weit hinter dem der Mütter.
+      Es ist positiv, aber der Weg ist noch lang.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Was empfehlen Sie Paaren, bevor das erste Kind kommt?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Paare sollten diese Gespräche über Aufgabenteilung führen, bevor das Baby da ist.
+      Danach ist es schwieriger, festgefahrene Muster zu ändern.
+      Das betrifft Haushalt, Kinderbetreuung und Berufstätigkeit gleichermaßen.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Und das Mehrgenerationenhaus — spielt das eine Rolle?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Ja, dieses Modell gewinnt an Bedeutung. Es entlastet zum einen Pflegeeinrichtungen,
+      schafft aber auch gegenseitige Unterstützung über alle Altersgruppen hinweg.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Dr. Wendland, vielen Dank!
+      Wenn Sie mehr zu diesem Thema lesen möchten, finden Sie auf unserer Website
+      weiterführende Studien und Beratungsangebote.
+      Das war unser Mittagsmagazin — einen schönen Tag noch!
+    </prosody>
+  </voice>
+
+  <break time="3s"/>
+
+  <!-- Second playback marker — Teil 2 plays TWICE for this mock -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Sie hören den Text jetzt noch einmal.
+      <break time="5s"/>
+    </prosody>
+  </voice>
+
+  <!-- Repeat of radio feature -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Herzlich willkommen zu unserem Mittagsmagazin.
+      Heute schauen wir uns an, wie sich das Zusammenleben von Familien in Deutschland verändert hat —
+      und was das für Eltern, Kinder und Großeltern bedeutet.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Die Zahlen sprechen für sich: Die Zahl der Alleinerziehenden ist in Deutschland seit 2010
+      kontinuierlich gestiegen — heute liegt sie bei fast 20 Prozent aller Familien.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Zu diesen Themen haben wir heute Dr. Kathrin Wendland im Studio —
+      sie leitet am Deutschen Jugendinstitut eine Forschungsgruppe
+      zu modernen Familienmodellen und Patchwork-Familien.
+      Frau Dr. Wendland, herzlich willkommen!
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Guten Tag, ich freue mich, hier zu sein.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Frau Dr. Wendland, sind Patchwork-Familien schlechter für Kinder als traditionelle Familien?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Das können wir so nicht sagen. Entscheidend ist nicht die Familienform,
+      sondern die Qualität der Beziehungen.
+      Kinder in Patchwork-Familien können genauso stabile Bindungen entwickeln
+      wie Kinder in traditionellen Familien.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Laut einer aktuellen Erhebung sind es im Durchschnitt elf Stunden pro Woche,
+      die Großeltern direkt für die Kinderbetreuung aufwenden.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Wie gut unterstützen Unternehmen berufstätige Eltern?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Obwohl es gesetzliche Regelungen gibt, bieten nach unserer Erhebung
+      nur rund 40 Prozent der Betriebe wirklich flexible Modelle für Eltern an.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Wie sieht es mit Vätern und Elternzeit aus?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Der Anteil der Väter, die Elternzeit nehmen, ist gestiegen —
+      liegt aber mit knapp 25 Prozent noch weit hinter dem der Mütter.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Was empfehlen Sie Paaren, bevor das erste Kind kommt?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Paare sollten diese Gespräche über Aufgabenteilung führen, bevor das Baby da ist.
+      Danach ist es schwieriger, festgefahrene Muster zu ändern.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Und das Mehrgenerationenhaus?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-A">
+    <prosody rate="medium">
+      Ja, dieses Modell gewinnt an Bedeutung. Es entlastet Pflegeeinrichtungen
+      und schafft gegenseitige Unterstützung über alle Altersgruppen hinweg.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Dr. Wendland, vielen Dank!
+      Wenn Sie mehr zu diesem Thema lesen möchten, finden Sie auf unserer Website
+      weiterführende Studien und Beratungsangebote.
+    </prosody>
+  </voice>
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 2.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B1_mock14_listening_part3.ssml
+++ b/.planning/audio-prompts/B1_mock14_listening_part3.ssml
@@ -1,0 +1,293 @@
+<speak>
+  <!-- B1 Mock 14 — Teil 3 (5 MCQ, conversation Lena + Großvater Heinrich, playCount=2) -->
+  <!-- Narrator: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions, section labels -->
+  <!-- Lena (Teenagerin): de-DE-Wavenet-C (female, clear) rate="medium" — granddaughter -->
+  <!-- Heinrich (Großvater): de-DE-Wavenet-F (male, slightly older) rate="medium" — grandfather -->
+  <!-- Each conversation plays TWICE as per B1 Teil 3 spec -->
+  <!-- Topic: Familiengeschichte — Schulprojekt, Hamburg, Schneiderei, Unterlagen, gemeinsames Kochen -->
+  <!-- Full transcript sourced from mock_14.json question explanations -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 3. Sie hören ein Gespräch zwischen der Teenagerin Lena und ihrem Großvater Heinrich.
+      Zu jedem Gesprächsabschnitt gibt es eine Aufgabe.
+      Was ist richtig? Kreuzen Sie an: a, b oder c. Sie hören das Gespräch zweimal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Abschnitt 1: Lena kommt für Schulprojekt über Familiengeschichte -->
+  <!-- correct: c -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Abschnitt 1.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Hallo Opa! Danke, dass ich kurzfristig vorbeikommen konnte.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Lena! Immer! Ich habe sowieso gleich meinen Arzttermin, aber der ist erst um drei.
+      Was hat dich her geführt?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Opa, ich mache gerade ein Projekt für die Schule —
+      wir sollen unsere Familiengeschichte recherchieren.
+      Du kennst doch die meisten Geschichten. Kannst du mir helfen?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Natürlich! Das mache ich doch gerne. Setz dich, ich mache uns schnell einen Tee.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Abschnitt 2: Heinrichs Vater in Hamburg — Fabrik dann eigene Schneiderei -->
+  <!-- correct: c -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Abschnitt 2.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Opa, was hat Urgroßvater eigentlich gemacht, als er nach Hamburg gezogen ist?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Zuerst hat er in der Textilfabrik am Hafen angefangen —
+      das war harte Arbeit, aber er hat gespart.
+      Und nach vier Jahren hat er mit dem gesparten Geld eine eigene Schneiderei aufgemacht.
+      Nicht groß, aber seine eigene.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das klingt nach einem richtigen Unternehmergeist!
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Ja, das war er. Eigensinnig, aber fleißig.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Abschnitt 3: Was Lena am Projekt am meisten ärgert — wenige Dokumente, wenig Zeit -->
+  <!-- correct: c -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Abschnitt 3.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das Schlimmste ist, dass wir kaum Fotos oder Dokumente haben —
+      und die Abgabe ist schon in zwei Wochen.
+      Ich weiß nicht, wie ich das alles zusammenbekommen soll.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Ich verstehe das. So ein Projekt braucht Material.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Genau. Meine Lehrerin sagt, wir brauchen Belege, keine Geschichten aus dem Kopf.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Abschnitt 4: Heinrich schlägt Kiste mit alten Briefen und Fotos vom Dachboden vor -->
+  <!-- correct: a -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Abschnitt 4.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Warte mal, ich glaube, auf meinem Dachboden steht noch eine Schachtel
+      mit alten Briefen und einigen Fotos meiner Eltern.
+      Die kannst du gerne haben — oder zumindest mal durchschauen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Wirklich?! Das wäre unglaublich hilfreich!
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Ich hole sie gleich nach dem Tee runter.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Abschnitt 5: Einigung — gemeinsam kochen und weiter über Familiengeschichte reden -->
+  <!-- correct: b -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Abschnitt 5.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Bleib doch zum Mittagessen — ich mache mein altes Gulasch,
+      und du kannst mir erzählen, was du noch brauchst.
+      Dann können wir in Ruhe weitermachen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das klingt perfekt, Opa. Ich bleibe sehr gerne.
+      Und dann gehe ich mit der Schachtel nach Hause — da freue ich mich schon drauf.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Gut so. Dann fangen wir mal an.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Repeat marker -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+
+  <!-- Full repeat of all 5 Abschnitte -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Abschnitt 1.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Hallo Opa! Danke, dass ich kurzfristig vorbeikommen konnte.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Lena! Immer! Ich habe sowieso gleich meinen Arzttermin, aber der ist erst um drei.
+      Was hat dich her geführt?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Opa, ich mache gerade ein Projekt für die Schule —
+      wir sollen unsere Familiengeschichte recherchieren.
+      Du kennst doch die meisten Geschichten. Kannst du mir helfen?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Natürlich! Das mache ich doch gerne. Setz dich, ich mache uns schnell einen Tee.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Abschnitt 2.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Opa, was hat Urgroßvater eigentlich gemacht, als er nach Hamburg gezogen ist?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Zuerst hat er in der Textilfabrik am Hafen angefangen —
+      das war harte Arbeit, aber er hat gespart.
+      Und nach vier Jahren hat er mit dem gesparten Geld eine eigene Schneiderei aufgemacht.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das klingt nach einem richtigen Unternehmergeist!
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Ja, das war er. Eigensinnig, aber fleißig.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Abschnitt 3.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das Schlimmste ist, dass wir kaum Fotos oder Dokumente haben —
+      und die Abgabe ist schon in zwei Wochen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Ich verstehe das. So ein Projekt braucht Material.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Genau. Meine Lehrerin sagt, wir brauchen Belege, keine Geschichten aus dem Kopf.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Abschnitt 4.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Warte mal, ich glaube, auf meinem Dachboden steht noch eine Schachtel
+      mit alten Briefen und einigen Fotos meiner Eltern.
+      Die kannst du gerne haben.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Wirklich?! Das wäre unglaublich hilfreich!
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Ich hole sie gleich nach dem Tee runter.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Abschnitt 5.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Bleib doch zum Mittagessen — ich mache mein altes Gulasch,
+      und du kannst mir erzählen, was du noch brauchst.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Das klingt perfekt, Opa. Ich bleibe sehr gerne.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Gut so. Dann fangen wir mal an.
+    </prosody>
+  </voice>
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 3.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B1_mock15_listening_part1.ssml
+++ b/.planning/audio-prompts/B1_mock15_listening_part1.ssml
@@ -1,0 +1,106 @@
+<speak>
+  <!-- B1 Mock 15 — Teil 1 (5 True/False, short audio clips, playCount=1) -->
+  <!-- Narrator/Announcer: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions, task labels -->
+  <!-- Female speaker: de-DE-Wavenet-C (female, clear) rate="medium" — Lena voicenote, female roles -->
+  <!-- Male speaker: de-DE-Wavenet-D (male, warm) rate="medium" — support calls, system messages -->
+  <!-- No repeat — Teil 1 plays ONCE at B1 -->
+  <!-- Topic: Digitale Medien und Technologie — App-Support, Streaming, App-Store, Voicemail, Podcast-Workshop -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 1. Sie hören fünf kurze Texte. Entscheiden Sie bei jedem Text:
+      Ist die Aussage richtig oder falsch? Sie hören jeden Text nur einmal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Aufgabe 1: Kundensupport-Anruf — App stürzt ab, kein vergessenes Passwort -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 1.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Guten Tag, Sie sind mit dem Support der MobileApp GmbH verbunden. Was kann ich für Sie tun?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Hallo, ich habe ein Problem mit Ihrer App.
+      Ich kann mich gar nicht einloggen — die App stürzt immer ab, bevor ich das Passwort eingeben kann.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ich verstehe. Das klingt nach einem technischen Fehler in der App selbst.
+      Haben Sie das neueste Update installiert?
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 2: Kundenservice — Jahresabo automatisch verlängert -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 2.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Sehr geehrte Kundin, herzlichen Glückwunsch zu einem weiteren Jahr mit StreamMax.
+      Ihr Jahresabo wurde am ersten des Monats automatisch um ein weiteres Jahr verlängert.
+      Die Abbuchung in Höhe von 79 Euro 90 erfolgte wie vereinbart.
+      Vielen Dank für Ihre Treue!
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 3: App-Store-Meldung — App neu starten nach Update (nicht Smartphone) -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 3.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ein Update ist verfügbar. Bitte installieren Sie das Update
+      und starten Sie die App anschließend neu,
+      um alle neuen Funktionen nutzen zu können.
+      Das Update dauert nur wenige Sekunden.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 4: Lena Sprachnachricht — Foto sofort schicken, nicht nach dem Treffen -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 4.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Hey! Ich wollte kurz fragen — schick mir das Foto bitte schon jetzt.
+      Ich brauche es für den Post heute Abend, und bis wir uns sehen, ist es zu spät.
+      Danke, bis nachher!
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Aufgabe 5: Podcast-Workshop — nur Online-Anmeldung, keine telefonische Anmeldung -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Aufgabe 5.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Eine Durchsage zum Podcast-Workshop der Medienakademie:
+      Anmeldungen sind nur über unser Online-Formular auf der Website möglich —
+      telefonische Anmeldungen nehmen wir leider nicht entgegen.
+      Die Platzzahl ist begrenzt, also melden Sie sich jetzt an.
+      Den Link finden Sie in unserer E-Mail.
+    </prosody>
+  </voice>
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 1.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B1_mock15_listening_part2.ssml
+++ b/.planning/audio-prompts/B1_mock15_listening_part2.ssml
@@ -1,0 +1,161 @@
+<speak>
+  <!-- B1 Mock 15 — Teil 2 (10 True/False, radio report, playCount=1) -->
+  <!-- Narrator: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions -->
+  <!-- Moderatorin: de-DE-Wavenet-C (female, clear) rate="medium" — radio host -->
+  <!-- Experte Dr. Felix Kern: de-DE-Wavenet-D (male, warm) rate="medium" — Institut für Medienpädagogik -->
+  <!-- Zusatzstimme: de-DE-Wavenet-F (male, slightly older) rate="medium" — statistics voice -->
+  <!-- No repeat — Teil 2 plays ONCE at B1 -->
+  <!-- Topic: Medienkonsum der Deutschen — Doom-Scrolling, Social Media, Digital Detox, Schlaf -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 2. Sie hören einen Radiobericht. Entscheiden Sie, ob die folgenden zehn Aussagen
+      richtig oder falsch sind. Sie hören den Text nur einmal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Radio report begins -->
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Guten Morgen und willkommen zu unserem Morgenmagazin.
+      Heute beschäftigen wir uns damit, wie sich unser Medienkonsum in den letzten Jahren
+      grundlegend verändert hat.
+      Mein Gast ist Dr. Felix Kern vom Institut für Medienpädagogik und digitale Bildung.
+      Guten Morgen, Herr Dr. Kern!
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Guten Morgen!
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Wie viel fernsehen Jugendliche eigentlich noch?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Laut einer aktuellen Studie liegt die tägliche Fernsehzeit bei Jugendlichen zwischen 14 und 29 Jahren
+      bei durchschnittlich nur noch 45 Minuten.
+      Die gesamte Bildschirmzeit liegt aber bei etwa vier Stunden — der Rest verteilt sich auf Smartphones,
+      Tablets und Streaming.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Herr Dr. Kern, was sagen Sie zu Social Media — ist das nur schädlich?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Nein, Social Media hat durchaus positive Seiten — es fördert kreatives Ausdrücken
+      und globale Vernetzung. Das Problem liegt im unreflektierten Dauerkonsum.
+      Man scrollt, ohne wirklich etwas wahrzunehmen.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Doom-Scrolling — das hört man immer wieder. Was versteht man darunter?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Doom-Scrolling meint das endlose Durchscrollen von überwiegend negativen Schlagzeilen
+      und Meldungen, ohne bewusst zu lesen.
+      Man weiß danach, dass man etwas gesehen hat, aber nicht wirklich, was.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Haben Unternehmen reagiert und Social Media während der Arbeitszeit verboten?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Nur jedes fünfte Unternehmen hat bislang klare Regeln zum Social-Media-Konsum
+      in der Arbeitszeit aufgestellt. Die Mehrheit hat noch keine formellen Regelungen.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Wer nutzt eigentlich Digital-Detox-Programme?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-F">
+    <prosody rate="medium">
+      Interessanterweise sind die Hauptnutzer solcher Detox-Angebote junge Erwachsene
+      zwischen 25 und 35 Jahren — also die Generation, die am meisten mit digitalen Medien aufgewachsen ist.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Herr Dr. Kern, was ist Ihr erster praktischer Tipp?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Mein erster Tipp: Legen Sie das Smartphone mindestens eine Stunde vor dem Einschlafen weg.
+      Das verbessert nachweislich die Schlafqualität — und das merken die meisten Menschen sehr schnell.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Und sind gedruckte Zeitungen tatsächlich schon verschwunden?
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Gedruckte Zeitungen verlieren zwar Leser, aber sie sind noch nicht verschwunden —
+      besonders ältere Generationen lesen sie weiterhin regelmäßig.
+    </prosody>
+    <break time="1s"/>
+  </voice>
+
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Dr. Kern, vielen Dank!
+      Unsere Hörer können sich unter der kostenlosen Hotline-Nummer 0800-223344 weiter informieren.
+      Das war unser Morgenmagazin. Einen guten Tag!
+    </prosody>
+  </voice>
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 2.</prosody>
+  </voice>
+</speak>

--- a/.planning/audio-prompts/B1_mock15_listening_part3.ssml
+++ b/.planning/audio-prompts/B1_mock15_listening_part3.ssml
@@ -1,0 +1,312 @@
+<speak>
+  <!-- B1 Mock 15 — Teil 3 (5 MCQ, short dialogues, playCount=2) -->
+  <!-- Narrator: de-DE-Wavenet-B (male, neutral) rate="slow" — instructions, Gespräch labels -->
+  <!-- Female speaker: de-DE-Wavenet-C (female, clear) rate="medium" — Sofia, Mutter, female roles -->
+  <!-- Male speaker: de-DE-Wavenet-D (male, warm) rate="medium" — Jonas, Markus, Timo, male roles -->
+  <!-- Each conversation plays TWICE as per B1 Teil 3 spec -->
+  <!-- Topic: Digitale Medien im Alltag — Smartphone-Pause, Streaming-Problem, Social Media, Bildschirmzeit -->
+  <!-- Full transcript sourced from mock_15.json question explanations -->
+
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">
+      Hören, Teil 3. Sie hören fünf kurze Gespräche. Zu jedem Gespräch gibt es eine Aufgabe.
+      Was ist richtig? Kreuzen Sie an: a, b oder c. Sie hören jedes Gespräch zweimal.
+    </prosody>
+    <break time="2s"/>
+  </voice>
+
+  <!-- Gespräch 1: Jonas — Smartphone-Pause, weil zu viel Zeit am Handy statt mit Menschen -->
+  <!-- correct: b -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 1.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Jonas, ich habe gehört, du hast dein Smartphone eine Woche lang nicht benutzt?
+      War das dein Arzt, der das empfohlen hat?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Nein, kein Arzt. Ich habe eines Abends einfach gerechnet:
+      Vier Stunden am Handy, aber nur zwanzig Minuten wirkliches Gespräch mit meiner Mitbewohnerin.
+      Das hat mir zu denken gegeben.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Und wie war das dann, ohne Handy?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Die ersten zwei Tage war es seltsam. Danach eigentlich ganz angenehm.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Jonas, ich habe gehört, du hast dein Smartphone eine Woche lang nicht benutzt?
+      War das dein Arzt, der das empfohlen hat?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Nein, kein Arzt. Ich habe eines Abends einfach gerechnet:
+      Vier Stunden am Handy, aber nur zwanzig Minuten wirkliches Gespräch mit meiner Mitbewohnerin.
+      Das hat mir zu denken gegeben.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Und wie war das dann, ohne Handy?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Die ersten zwei Tage war es seltsam. Danach eigentlich ganz angenehm.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 2: Sofia — zuerst FAQ, dann telefonischen Support kontaktiert -->
+  <!-- correct: c -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 2.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Sofia, hattest du letzte Woche das Problem mit deinem Streaming-Dienst gelöst?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, endlich. Ich habe erstmal eine halbe Stunde in den FAQs gesucht,
+      aber die Lösung war nicht dabei.
+      Dann habe ich angerufen — nach zwanzig Minuten Wartezeit hat mir jemand geholfen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Und der Vertrag — bist du dabei geblieben?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, erstmal. Wenn es nochmal vorkommt, schreibe ich eine E-Mail an den Kundenservice.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Sofia, hattest du letzte Woche das Problem mit deinem Streaming-Dienst gelöst?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, endlich. Ich habe erstmal eine halbe Stunde in den FAQs gesucht,
+      aber die Lösung war nicht dabei.
+      Dann habe ich angerufen — nach zwanzig Minuten Wartezeit hat mir jemand geholfen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Und der Vertrag — bist du dabei geblieben?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ja, erstmal. Wenn es nochmal vorkommt, schreibe ich eine E-Mail an den Kundenservice.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 3: Markus — stört sich an ständiger Werbung auf neuer Plattform -->
+  <!-- correct: b -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 3.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Markus, nutzt du eigentlich die neue Plattform? Was hältst du davon?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Mich stört das einfach — jedes dritte Video ist eine Werbung.
+      Ich habe versucht, die Premium-Version zu kaufen, aber die ist mir zu teuer.
+      Ohne Premium ist es kaum erträglich.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Und deine Freunde sind auch kaum dort, oder?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ja, das auch. Aber die Werbung ist das Schlimmste. Das hält mich wirklich davon ab.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Markus, nutzt du eigentlich die neue Plattform? Was hältst du davon?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Mich stört das einfach — jedes dritte Video ist eine Werbung.
+      Ich habe versucht, die Premium-Version zu kaufen, aber die ist mir zu teuer.
+      Ohne Premium ist es kaum erträglich.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Und deine Freunde sind auch kaum dort, oder?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Ja, das auch. Aber die Werbung ist das Schlimmste. Das hält mich wirklich davon ab.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 4: Mutter schlägt gemeinsames Kochen vor, lehnt App-Lösung ab -->
+  <!-- correct: c -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 4.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ich mache mir Sorgen, wie viel du am Abend auf dem Handy bist.
+      Ich habe mir überlegt: Wir kochen abends wieder zusammen —
+      dann haben wir alle eine natürliche Pause vom Handy.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Könntest du nicht einfach eine App installieren, die die Zeit begrenzt?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Nein, das wirkt mir zu kontrollierend. Ich möchte, dass wir das zusammen entscheiden,
+      nicht durch eine App erzwingen. Kochen klingt doch schöner, oder?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Okay, das klingt eigentlich gar nicht schlecht.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Ich mache mir Sorgen, wie viel du am Abend auf dem Handy bist.
+      Ich habe mir überlegt: Wir kochen abends wieder zusammen —
+      dann haben wir alle eine natürliche Pause vom Handy.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Könntest du nicht einfach eine App installieren, die die Zeit begrenzt?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Nein, das wirkt mir zu kontrollierend. Ich möchte, dass wir das zusammen entscheiden,
+      nicht durch eine App erzwingen. Kochen klingt doch schöner, oder?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Okay, das klingt eigentlich gar nicht schlecht.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+
+  <!-- Gespräch 5: Timo plant Lese-/Filmclub — demokratisches Abstimmen über Titel ist wichtigstes Kriterium -->
+  <!-- correct: a -->
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Gespräch 5.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Timo, du willst einen Buch- und Filmclub gründen, oder? Was ist dir dabei am wichtigsten?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Das Wichtigste für mich ist, dass wir demokratisch abstimmen —
+      jeder schlägt einen Titel vor und dann wird gewählt.
+      Sonst bestimmt immer einer alles, und das hält die Gruppe nicht zusammen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Und treffen wir uns persönlich oder auch online?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Beides ist denkbar. Ich bin da flexibel. Aber das Abstimmen — das ist mir wirklich wichtig.
+    </prosody>
+  </voice>
+  <break time="2s"/>
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Sie hören das Gespräch jetzt noch einmal.</prosody>
+    <break time="1s"/>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Timo, du willst einen Buch- und Filmclub gründen, oder? Was ist dir dabei am wichtigsten?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Das Wichtigste für mich ist, dass wir demokratisch abstimmen —
+      jeder schlägt einen Titel vor und dann wird gewählt.
+      Sonst bestimmt immer einer alles, und das hält die Gruppe nicht zusammen.
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-C">
+    <prosody rate="medium">
+      Und treffen wir uns persönlich oder auch online?
+    </prosody>
+  </voice>
+  <voice name="de-DE-Wavenet-D">
+    <prosody rate="medium">
+      Beides ist denkbar. Ich bin da flexibel. Aber das Abstimmen — das ist mir wirklich wichtig.
+    </prosody>
+  </voice>
+  <break time="3s"/>
+
+  <voice name="de-DE-Wavenet-B">
+    <prosody rate="slow">Das ist das Ende von Teil 3.</prosody>
+  </voice>
+</speak>


### PR DESCRIPTION
## Summary

- 15 SSML listening scripts for B1 mocks 11–15 (3 parts per mock: Teil 1, Teil 2, Teil 3)
- Voice assignments match the M01–M10 convention: Wavenet-B narrator, Wavenet-C female primary, Wavenet-D male primary, Wavenet-A/F for secondary speakers
- Prosody rates use named values (`slow`/`medium`) consistent with existing B1 scripts
- Mock 14 Teil 2 honours `playCount: 2` from the JSON source — full repeat with "Sie hören den Text jetzt noch einmal" marker included
- Manifest at `.planning/audio-prompts/B1_M11-M15_manifest.md`

## Placeholder flags

Two files need content review before MP3 generation:

| File | Reason |
|------|--------|
| `B1_mock11_listening_part3.ssml` | No Teil 3 data in `mock_11.json` on `b1-upgrade/mock-11-new` — dialogues constructed from Arbeit/Beruf theme |
| `B1_mock12_listening_part3.ssml` | No Teil 3 data in `mock_12.json` on `b1-upgrade/mock-12-new` — dialogues constructed from Gesundheit/Ernährung theme |

Mocks 13, 14, 15 are fully sourced from JSON question explanations — no placeholders.

## Test plan

- [ ] Spot-check Part 1 text against the JSON `explanation` fields for M13/14/15 — quotes should match
- [ ] Verify M14 Teil 2 repeat plays correctly (two full renditions in the SSML)
- [ ] Review M11 and M12 Part 3 placeholder dialogues against intended question scope before running curl commands
- [ ] No code or content JSON files touched — only `.planning/audio-prompts/`