### PR TITLE
fix(content): C1 mocks 09 & 10 — R2 "x" cleanup + mock_10 listening time (#239)

### DIFF
--- a/apps/mobile/assets/content/C1/mock_09.json
+++ b/apps/mobile/assets/content/C1/mock_09.json
@@ -349,8 +349,7 @@
                 "b",
                 "c",
                 "d",
-                "e",
-                "x"
+                "e"
               ],
               "correctAnswer": "c",
               "explanation": "Absatz c) beschreibt epistemische Ungerechtigkeit in ihren zwei Ausprägungen — testimoniale und hermeneutische — und schließt, dass Ungerechtigkeit 'kognitive und kommunikative Dimensionen' hat. Diese Formulierung findet sich ausschließlich in Absatz c)."
@@ -364,8 +363,7 @@
                 "b",
                 "c",
                 "d",
-                "e",
-                "x"
+                "e"
               ],
               "correctAnswer": "b",
               "explanation": "Absatz b) argumentiert, dass Gerechtigkeitsprinzipien, die Individuen unabhängig von ihrer kulturellen Verortung betrachten, die menschliche Realität verfehlen. Die Verbindung zwischen kultureller Zugehörigkeit und dem Anspruch auf Gerechtigkeit ist zentrales Thema in Absatz b)."
@@ -379,8 +377,7 @@
                 "b",
                 "c",
                 "d",
-                "e",
-                "x"
+                "e"
               ],
               "correctAnswer": "a",
               "explanation": "Absatz a) stellt negative und positive Freiheit einander gegenüber und zeigt, dass negative Freiheit allein kein hinreichendes Ideal ist. Der Kontrast der beiden Begriffe ist das Kernthema von Absatz a)."
@@ -394,8 +391,7 @@
                 "b",
                 "c",
                 "d",
-                "e",
-                "x"
+                "e"
               ],
               "correctAnswer": "d",
               "explanation": "Absatz d) diskutiert Trigger-Warnungen und stellt explizit die Frage nach dem 'Verhältnis zwischen psychologischer Sicherheit und intellektueller Freiheit'. Dieser direkte Widerstreit findet sich nur in Absatz d)."
@@ -409,8 +405,7 @@
                 "b",
                 "c",
                 "d",
-                "e",
-                "x"
+                "e"
               ],
               "correctAnswer": "e",
               "explanation": "Absatz e) erklärt auf Basis von Anerkennungstheorien, dass symbolische und sprachliche Anerkennung 'konstitutiv für das, was Menschen als gutes Leben erfahren können' ist — und damit nicht auf 'bloß kulturelle' Fragen reduzierbar ist."
@@ -424,8 +419,7 @@
                 "b",
                 "c",
                 "d",
-                "e",
-                "x"
+                "e"
               ],
               "correctAnswer": "b",
               "explanation": "Absatz b) stellt den Kommunitarismus vor und zieht daraus explizit Konsequenzen für die Aneignungsdebatte: Wenn kulturelle Symbole konstitutiv für Identität sind, ist ihre Aneignung durch Außenstehende existenziell relevant. Diese Verbindung findet sich nur in Absatz b)."

--- a/apps/mobile/assets/content/C1/mock_10.json
+++ b/apps/mobile/assets/content/C1/mock_10.json
@@ -349,8 +349,7 @@
                 "b",
                 "c",
                 "d",
-                "e",
-                "x"
+                "e"
               ],
               "correctAnswer": "b",
               "explanation": "Absatz b) erklärt den Rebound-Effekt: Effizienzgewinne werden durch erhöhten Verbrauch kompensiert. Das ist das zentrale Argument dafür, dass technischer Fortschritt allein klimapolitisch unzureichend ist."
@@ -364,8 +363,7 @@
                 "b",
                 "c",
                 "d",
-                "e",
-                "x"
+                "e"
               ],
               "correctAnswer": "c",
               "explanation": "Absatz c) beschreibt die EU-Energiepolitik nach dem Ukraine-Krieg: Gleichzeitig wurden erneuerbare Energien ausgebaut und neue Gasverträge geschlossen — ein Widerspruch zwischen Dekarbonisierung und Versorgungssicherheit."
@@ -379,8 +377,7 @@
                 "b",
                 "c",
                 "d",
-                "e",
-                "x"
+                "e"
               ],
               "correctAnswer": "e",
               "explanation": "Absatz e) behandelt explizit, dass einkommensschwache Haushalte einen höheren Anteil ihres Einkommens für Strom zahlen und diskutiert alternative Finanzierungsmodelle zur Abmilderung dieser Ungleichheit."
@@ -394,8 +391,7 @@
                 "b",
                 "c",
                 "d",
-                "e",
-                "x"
+                "e"
               ],
               "correctAnswer": "d",
               "explanation": "Absatz d) unterscheidet Suffizienz von Effizienz und Konsistenz und erklärt, dass Suffizienz direkt in individuelle Präferenzen eingreift — weshalb sie als paternalistisch gilt und politisch am unbeliebtesten ist."
@@ -409,8 +405,7 @@
                 "b",
                 "c",
                 "d",
-                "e",
-                "x"
+                "e"
               ],
               "correctAnswer": "a",
               "explanation": "Absatz a) beschreibt den COP28-Schadensfonds und nennt ihn 'symbolisch', weil die zugesagten Mittel gemessen an den tatsächlichen Klimaschäden minimal sind."
@@ -424,8 +419,7 @@
                 "b",
                 "c",
                 "d",
-                "e",
-                "x"
+                "e"
               ],
               "correctAnswer": "a",
               "explanation": "Absatz a) argumentiert, dass echte Klimagerechtigkeit nicht nur Anpassungshilfen, sondern die Veränderung von Handels- und Finanzstrukturen erfordert — eine strukturelle Wirtschaftsdimension, die in keinem anderen Absatz thematisiert wird."
@@ -588,7 +582,7 @@
       ]
     },
     "listening": {
-      "totalTimeMinutes": 20,
+      "totalTimeMinutes": 40,
       "parts": [
         {
           "partNumber": 1,


### PR DESCRIPTION
## Summary

- **mock_09 R2**: removed `"x"` from `options` array in all 6 Lesen Teil 2 questions (6-item → 5-item `[a,b,c,d,e]`). Reference: mock_01/02/04/05/06/08 which have no `"x"` in R2 options. Instructions text mentioning `'x'` for "no match" is correct telc wording and was left intact.
- **mock_09 prepTime**: already `0` — confirmed correct per CLAUDE.md (C1 prepTime=0), no edit needed.
- **mock_10 R2**: same `"x"` removal across all 6 R2 questions.
- **mock_10 listening `totalTimeMinutes`**: `20` → `40` (canonical value confirmed from mock_07 gold reference).
- **mock_10 prepTime**: already `0` — verified, untouched per issue scope.

## Pedagogy gate

No `correctAnswer` was `"x"` in either file. All 12 R2 questions have answers in `[a,b,c,d,e]`. Every question maps cleanly to a distinct paragraph. Zero P0 issues.

## Quality gates

| Gate | Result |
|------|--------|
| `pnpm typecheck` | PASS (clean) |
| `pnpm test` (@fastrack/web) | PASS — 389 tests, 41 suites |
| Mobile test suite | Pre-existing Jest/Expo ESM failure (21 suites fail on main; unchanged) |
| JSON validity | PASS (both files parse cleanly) |
| `"x"` remaining in R2 options | 0 occurrences |
| language-checker | n/a (no German content rewritten) |

## Reference

Gold file: `apps/mobile/assets/content/C1/mock_07.json` — R2 options `[a,b,c,d,e]`, listening `totalTimeMinutes: 40`.

Closes #239