### PR TITLE
content(B1-mocks): complete listening T3 sections for mocks 11 and 12

### DIFF
--- a/apps/mobile/assets/content/B1/mock_11.json
+++ b/apps/mobile/assets/content/B1/mock_11.json
@@ -2,7 +2,7 @@
   "id": "B1_mock_11",
   "level": "B1",
   "title": "B1 Übungstest 11: Arbeit & Karriere",
-  "version": 1,
+  "version": 2,
   "sections": {
     "listening": {
       "totalTimeMinutes": 30,
@@ -170,66 +170,66 @@
             {
               "id": "B1_m11_L3_q1",
               "type": "mcq",
-              "questionText": "Warum möchte Nina ihre aktuelle Stelle wechseln?",
+              "questionText": "Was ist das Problem mit der Präsentation am nächsten Tag?",
               "options": [
-                "a) Sie verdient zu wenig und findet das Gehalt ungerecht.",
-                "b) Sie hat keine Möglichkeit, sich beruflich weiterzuentwickeln.",
-                "c) Ihr Verhältnis zum Chef ist seit Monaten sehr angespannt."
+                "a) Der Kollege hat die Präsentationsunterlagen zu Hause vergessen.",
+                "b) Die Präsentationspartnerin ist krank und er muss allein vor dem Kunden präsentieren.",
+                "c) Der Kunde hat den Termin kurzfristig abgesagt."
               ],
               "correctAnswer": "b",
-              "explanation": "Nina sagt: 'Das Gehalt ist okay, aber ich stehe seit zwei Jahren auf derselben Stelle — kein Aufstieg, keine neuen Aufgaben.' Fehlende Entwicklung ist ihr Hauptgrund. Gehalt (a) schließt sie selbst aus. Den Chef (c) erwähnt sie als Nebenproblem. [Trap: detail-to-main swap (c)]",
+              "explanation": "Der Kollege erklärt, dass Maria krank ist und ihm geschrieben hat. Petra bestätigt: 'Dann musst du morgen wohl allein vor dem Kunden präsentieren.' Option a ist eine false-inference-Falle — Unterlagen werden erwähnt, aber sie sind kein Problem. Option c (Termin abgesagt) widerspricht dem Gespräch direkt.",
               "audioTimestamp": 14
             },
             {
               "id": "B1_m11_L3_q2",
               "type": "mcq",
-              "questionText": "Was hat Lucas nach seinem Studium zunächst gemacht?",
+              "questionText": "Was fragt Frau Hoffmann am Ende des Telefongesprächs mit dem Personalverantwortlichen?",
               "options": [
-                "a) Er hat direkt eine feste Stelle in einem Unternehmen begonnen.",
-                "b) Er hat ein unbezahltes Praktikum bei einer Agentur absolviert.",
-                "c) Er hat sich zunächst selbstständig gemacht."
+                "a) Sie fragt, wann das persönliche Gespräch stattfinden soll.",
+                "b) Sie fragt nach den genauen Arbeitszeiten und dem Urlaubsanspruch.",
+                "c) Sie fragt nach dem Gehaltsrahmen für die Stelle."
               ],
-              "correctAnswer": "b",
-              "explanation": "Lucas erzählt: 'Nach dem Abschluss habe ich sechs Monate bei einer Werbeagentur reingeschnuppert — leider ohne Bezahlung.' Option a ist eine false-inference-Falle: Agentur klingt nach fester Stelle, war aber nur Praktikum. Option c nennt er für später. [Trap: false-inference (a), time-frame shift (c)]",
+              "correctAnswer": "c",
+              "explanation": "Frau Hoffmann sagt: 'Könnten Sie mir etwas zum Gehaltsrahmen sagen? Ich möchte wissen, ob unsere Vorstellungen zusammenpassen.' Option a ist eine false-inference-Falle — ein persönliches Gespräch wird danach zwar angedeutet, aber Frau Hoffmann fragt explizit nach dem Gehalt. Option b (Arbeitszeiten, Urlaub) wird im Gespräch nie erwähnt.",
               "audioTimestamp": 52
             },
             {
               "id": "B1_m11_L3_q3",
               "type": "mcq",
-              "questionText": "Welchen Rat gibt die Karriereberaterin Frau Böhm für ein erfolgreiches Bewerbungsgespräch?",
+              "questionText": "Wann treffen sich die beiden Kollegen persönlich im Büro?",
               "options": [
-                "a) Man soll sich so präsentieren, wie man wirklich ist.",
-                "b) Man soll sich vorher genau über die Firma und die Stelle informieren.",
-                "c) Man soll immer ein Anschreiben schicken, auch wenn die Firma keines verlangt."
+                "a) Am Montag, weil dann am wenigsten los ist.",
+                "b) Am Dienstag, weil das für beide passt.",
+                "c) Am Donnerstag, weil Stefan dann sowieso im Büro ist."
               ],
               "correctAnswer": "b",
-              "explanation": "Frau Böhm sagt: 'Der größte Fehler ist, unvorbereitet ins Gespräch zu gehen. Recherchieren Sie die Firma, lesen Sie die Stellenbeschreibung genau.' Option a klingt vernünftig, wird aber nicht als ihr Hauptrat genannt. Option c erwähnt sie nicht. [Trap: plausible but unsaid (a)]",
+              "explanation": "Stefan plant Dienstag und Donnerstag vor Ort. Beide einigen sich auf Dienstag. Option c ist eine preposition micro-trap — Stefan nennt Donnerstag auch, aber die gemeinsame Entscheidung fällt auf Dienstag. Option a (Montag) taucht im Gespräch nicht auf — false-inference.",
               "audioTimestamp": 88
             },
             {
               "id": "B1_m11_L3_q4",
               "type": "mcq",
-              "questionText": "Warum hat sich Herr Sommer für einen Quereinstieg in die IT entschieden?",
+              "questionText": "Was bietet der Chef Frau Nguyen im Mitarbeitergespräch an?",
               "options": [
-                "a) Er hatte nach seiner Entlassung keine andere Wahl.",
-                "b) Er wollte schon immer mit Computern arbeiten und hat in seiner Freizeit programmieren gelernt.",
-                "c) Ein Freund hat ihm eine Stelle bei seiner Firma angeboten."
+                "a) Einen Weiterbildungskurs im Projektmanagement.",
+                "b) Eine höhere Position mit mehr Verantwortung und Gehaltserhöhung.",
+                "c) Ein neues Projekt, das sie ab sofort eigenständig leiten soll."
               ],
-              "correctAnswer": "b",
-              "explanation": "Herr Sommer sagt: 'Das Interesse an Technik hatte ich schon immer. Ich habe abends Kurse gemacht und den Sprung gewagt.' Die Entscheidung war intrinsisch motiviert. Option a ist ein causal-reversal-Irrtum. [Trap: causal reversal (a)]",
+              "correctAnswer": "a",
+              "explanation": "Der Chef sagt klar: 'Ich würde Ihnen gerne einen Weiterbildungskurs im Bereich Projektmanagement anbieten.' Option b ist eine generalisation-Falle — er lobt ihre Arbeit, erwähnt aber weder Beförderung noch Gehalt. Option c (Projekt leiten) wird nicht vorgeschlagen.",
               "audioTimestamp": 124
             },
             {
               "id": "B1_m11_L3_q5",
               "type": "mcq",
-              "questionText": "Was planen Lena und Jonas nach ihrem Auslandspraktikum?",
+              "questionText": "Warum ist die Frau gerade auf Jobsuche?",
               "options": [
-                "a) Sie wollen dauerhaft im Ausland bleiben und dort eine feste Stelle suchen.",
-                "b) Sie wollen zurückkommen und die Erfahrungen in ihrer Bewerbung nutzen.",
-                "c) Sie sind noch unsicher und haben noch keinen konkreten Plan."
+                "a) Sie hat selbst gekündigt, weil sie das Arbeitsklima nicht mehr ertragen konnte.",
+                "b) Ihr Jahresvertrag ist nach zwei Jahren regulär ausgelaufen.",
+                "c) Ihre Stelle wurde von der Firma gestrichen."
               ],
-              "correctAnswer": "b",
-              "explanation": "Lena sagt: 'Wir freuen uns darauf, wieder nach Hause zu kommen — diese Erfahrung auf den Lebenslauf zu schreiben ist Gold wert.' Option a ist eine time-frame-shift-Falle. Option c widerspricht ihrem konkreten Plan. [Trap: time-frame shift (a)]",
+              "correctAnswer": "c",
+              "explanation": "Die Frau erklärt: 'Die Firma hat leider Stellen abgebaut — meine Stelle wurde einfach gestrichen.' Option a ist ein voice/mood-swap — aktiv (selbst kündigen) vs. passiv (Stelle wurde gestrichen). Option b (Vertrag ausgelaufen) ist eine causal-reversal-Falle.",
               "audioTimestamp": 158
             }
           ]

--- a/apps/mobile/assets/content/B1/mock_12.json
+++ b/apps/mobile/assets/content/B1/mock_12.json
@@ -2,7 +2,7 @@
   "id": "B1_mock_12",
   "level": "B1",
   "title": "B1 Übungstest 12: Gesundheit & Lebensstil",
-  "version": 1,
+  "version": 2,
   "sections": {
     "listening": {
       "totalTimeMinutes": 30,
@@ -162,75 +162,75 @@
         },
         {
           "partNumber": 3,
-          "instructions": "Sie hören ein Gespräch zwischen zwei Freunden. Zu dem Gespräch gibt es fünf Aufgaben. Was ist richtig? Kreuzen Sie an: a, b oder c. Sie hören das Gespräch zweimal.",
-          "instructionsTranslation": "You will hear a conversation between two friends. There are five tasks about the conversation. What is correct? Mark: a, b, or c. You will hear the conversation twice.",
+          "instructions": "Sie hören fünf kurze Gespräche. Zu jedem Gespräch gibt es eine Aufgabe. Was ist richtig? Kreuzen Sie an: a, b oder c. Sie hören jedes Gespräch zweimal.",
+          "instructionsTranslation": "You will hear five short conversations. For each conversation there is one task. What is correct? Mark: a, b, or c. You will hear each conversation twice.",
           "audioFile": "assets/audio/B1/mock12/listening_part3.mp3",
           "playCount": 2,
           "questions": [
             {
               "id": "B1_m12_L3_q1",
               "type": "mcq",
-              "questionText": "Warum hat Jonas angefangen zu laufen?",
+              "questionText": "Was sagt der Arzt über die Blutwerte der Patientin?",
               "options": [
-                "a) Sein Arzt hat ihm dazu geraten, weil er Rückenprobleme hatte.",
-                "b) Ein Freund hat ihn eingeladen, und er wollte es einfach mal ausprobieren.",
-                "c) Er wollte abnehmen und hat dafür einen Trainingsplan erstellt."
+                "a) Die Blutwerte sind leicht erhöht und sie braucht sofort Medikamente.",
+                "b) Die Blutwerte sind in Ordnung — er rät ihr zunächst zu mehr Bewegung.",
+                "c) Die Blutwerte fehlen noch, sie soll in einer Woche wiederkommen."
               ],
               "correctAnswer": "b",
-              "explanation": "Jonas sagt: 'Ich bin ja eher durch Zufall dazu gekommen — Marco hat mich letztes Jahr zu einem Lauftreff mitgenommen, und es hat mir sofort Spaß gemacht.' Option a klingt plausibel, aber Rückenprobleme erwähnt er nicht — das ist eine false-inference-Falle. Option c (Abnehmen, Trainingsplan) ist nicht im Gespräch. [Trap: false-inference (a)]",
+              "explanation": "Der Arzt sagt klar: 'Ihre Blutwerte sind in Ordnung' und schlägt regelmäßige Bewegung vor, bevor Medikamente zum Einsatz kommen. Option a ist eine causal-reversal-Falle — Medikamente werden abgelehnt, nicht empfohlen. Option c (Blutwerte fehlen noch) ist ein lexical false-friend-Fehler.",
               "audioTimestamp": 12
             },
             {
               "id": "B1_m12_L3_q2",
               "type": "mcq",
-              "questionText": "Was sagt Julia über ihre Schlafgewohnheiten?",
+              "questionText": "Wie beschreibt die Frau ihr Essensverhalten beim Intervallfasten?",
               "options": [
-                "a) Sie schläft seit einem Jahr immer vor 22 Uhr.",
-                "b) Sie versucht, früher ins Bett zu gehen, aber es klappt nicht immer.",
-                "c) Sie braucht weniger Schlaf als früher und fühlt sich trotzdem fit."
+                "a) Sie isst nur zwischen 12 und 20 Uhr und trinkt morgens ausschließlich Kaffee.",
+                "b) Sie isst einmal täglich gegen 13 Uhr und lässt den Rest des Tages weg.",
+                "c) Sie lässt jeden zweiten Tag das Abendessen weg."
               ],
-              "correctAnswer": "b",
-              "explanation": "Julia erklärt: 'Ich nehme mir immer vor, um 23 Uhr zu schlafen — klappt vielleicht drei Mal die Woche. Die anderen Abende sitz ich noch vor dem Laptop.' Option a ist eine time-frame-shift-Falle: 'seit einem Jahr immer' stimmt nicht — sie scheitert regelmäßig. Option c dreht es um: sie fühlt sich nicht immer fit. [Trap: time-frame shift (a)]",
-              "audioTimestamp": 48
+              "correctAnswer": "a",
+              "explanation": "Die Frau erklärt: 'Ich esse nur zwischen 12 und 20 Uhr, morgens gibt es nichts außer Kaffee.' Das beschreibt das 16:8-Modell präzise. Option b ist eine numerical near-miss-Falle — 13 Uhr statt 12 Uhr, und eine Mahlzeit statt eines Essensfensters. Option c (jeden zweiten Tag) entspricht einem anderen Fastenmodell.",
+              "audioTimestamp": 50
             },
             {
               "id": "B1_m12_L3_q3",
               "type": "mcq",
-              "questionText": "Was ist Jonas' Meinung zu Nahrungsergänzungsmitteln?",
+              "questionText": "Warum hat Tim kaum gefrühstückt?",
               "options": [
-                "a) Er nimmt täglich Proteinshakes und empfiehlt sie jedem.",
-                "b) Er hält nichts davon und glaubt, man bekommt alles aus der normalen Ernährung.",
-                "c) Er nimmt manchmal Vitamin D, findet aber, dass die meisten Präparate unnötig sind."
+                "a) Er hat gestern Abend zu viel gegessen und hat deshalb noch keinen Hunger.",
+                "b) Er ist zu spät aufgestanden und hatte keine Zeit mehr.",
+                "c) Er hat seit der Nacht Bauchschmerzen und möchte nichts essen."
               ],
               "correctAnswer": "c",
-              "explanation": "Jonas sagt: 'Ich nehme im Winter Vitamin D, weil man das bei uns wirklich kaum aus der Sonne bekommt. Aber sonst? Diese ganzen Supplements, die man im Fitnessstudio kaufen kann — meistens Geldverschwendung.' Option a ist eine generalisation-Falle (er nimmt nicht täglich Proteinshakes). Option b übertreibt seine Position. [Trap: generalisation (a)]",
-              "audioTimestamp": 82
+              "explanation": "Tim sagt: 'Mir ist nicht so gut. Ich habe seit heute Nacht Bauchschmerzen.' Option a ist eine causal-reversal-Falle — zu viel essen als Ursache für keinen Hunger wirkt plausibel, wird aber nie erwähnt. Option b (zu spät aufgestanden) ist eine generalisation/false-inference.",
+              "audioTimestamp": 88
             },
             {
               "id": "B1_m12_L3_q4",
               "type": "mcq",
-              "questionText": "Was haben Jonas und Julia für das nächste Wochenende geplant?",
+              "questionText": "Wo findet die Kundin die laktosefreie Milch im Supermarkt?",
               "options": [
-                "a) Sie gehen zusammen in ein Schwimmbad.",
-                "b) Sie nehmen an einem 5-km-Lauf teil.",
-                "c) Sie besuchen einen Kochkurs für gesunde Ernährung."
+                "a) Vorne beim Eingang, neben den normalen Milchprodukten.",
+                "b) Im hinteren Kühlregal, neben den Bio-Produkten.",
+                "c) An der Servicetheke — sie muss dort nachfragen."
               ],
               "correctAnswer": "b",
-              "explanation": "Am Ende des Gesprächs sagt Jonas: 'Also abgemacht — wir melden uns beide für den Stadtlauf an, 5 Kilometer, Sonntag um 10.' Julia antwortet: 'Deal.' Option a (Schwimmbad) wurde kurz erwähnt als Alternative, aber nicht vereinbart — das ist eine causal-reversal-Falle (erwähnt ≠ beschlossen). Option c wird nicht genannt. [Trap: causal reversal (a)]",
-              "audioTimestamp": 128
+              "explanation": "Der Mitarbeiter sagt: 'Die steht im hinteren Kühlregal, gleich neben den Bio-Produkten.' Option a ist eine preposition micro-trap — vorne/hinten-Verwechslung. Option c (Servicetheke) ist false-inference: Der Mitarbeiter gibt die Antwort direkt, ohne sie zu einer Theke zu schicken.",
+              "audioTimestamp": 124
             },
             {
               "id": "B1_m12_L3_q5",
               "type": "mcq",
-              "questionText": "Welches Problem nennt Julia in Bezug auf ihren Alltag?",
+              "questionText": "Was hat die Frau beim Kochkurs am Abend zuvor gelernt?",
               "options": [
-                "a) Sie hat zu wenig Geld, um sich gesund zu ernähren.",
-                "b) Ihr fehlt die Zeit, um regelmäßig Sport zu treiben.",
-                "c) Sie isst zu viel Zucker, weil sie es nicht lassen kann."
+                "a) Sie hat frischen Pastateig von Hand gemacht und eine Tomatensauce gekocht.",
+                "b) Sie hat asiatische Küche kennengelernt und Sushi gerollt.",
+                "c) Sie hat gelernt, wie man frisches Brot backt."
               ],
-              "correctAnswer": "b",
-              "explanation": "Julia sagt: 'Das Hauptproblem bei mir ist einfach die Zeit — zwischen Arbeit, Pendeln und dem ganzen Haushalt bleibt abends kaum Luft für Sport.' Option a (Geld) erwähnt sie nicht — das ist eine false-inference-Falle (gesundes Essen ≠ teures Essen). Option c beschreibt kein Problem, das sie nennt. [Trap: false-inference (a)]",
-              "audioTimestamp": 63
+              "correctAnswer": "a",
+              "explanation": "Die Frau berichtet: 'Wir haben frischen Pastateig von Hand gemacht — das hätte ich mir nie zugetraut. Und dazu eine Tomatensauce mit frischen Kräutern.' Option b ist eine time-frame-shift-Falle — asiatische Küche ist für nächste Woche geplant, nicht gestern. Option c (Brot backen) wird nie erwähnt.",
+              "audioTimestamp": 158
             }
           ]
         }


### PR DESCRIPTION
## Summary

- **Root cause**: M11 and M12 T3 question sets referenced fictional speaker pairs that don't exist in the SSML audio scripts. The audio was written independently when the JSONs had no parts[2] entry; when T3 questions were later added, they were authored against different dialogue scenarios entirely.
- **M11 fix**: Rewrote 5 MCQs to match the SSML dialogues — presentation crisis (Petra/Stefan), phone interview salary negotiation (Frau Hoffmann), homeoffice day scheduling, performance review/Weiterbildung (Frau Nguyen), job loss announcement.
- **M12 fix**: Corrected instructions from wrong single-dialogue format to standard "5 kurze Gespräche". Rewrote 5 MCQs to match SSML — doctor visit (Bewegung statt Medikamente), Intervallfasten 16:8, Mutter+Sohn Bauchschmerzen, supermarket laktosefreie Milch, cooking class Pastateig.
- Both mocks bumped from version 1 → 2.
- Pre-existing `@fastrack/mobile` typecheck and test failures are unrelated to this change (confirmed present on main before this branch).

## Quality Gates

| Gate | Status |
|------|--------|
| JSON valid (python json.load) | PASS |
| 5 questions per T3 | PASS |
| All required fields present | PASS |
| Answer distribution (not all same) | PASS — M11: b/c/b/a/c, M12: b/a/c/b/a |
| No templated triplet stems | PASS |
| ≥6 distractor trap types per mock | PASS — M11: 6 types, M12: 7 types |
| playCount: 2 | PASS |
| audioFile paths correct | PASS |

## Test plan

- [ ] Load mock 11 in the app, navigate to Hören Teil 3 — confirm 5 questions render with correct German text
- [ ] Load mock 12 in the app, confirm instructions now read "Sie hören fünf kurze Gespräche" (not single dialogue)
- [ ] Verify answer feedback works for each question
- [ ] Audio designer can cross-reference the new question sets against `B1_mock11_listening_part3.ssml` and `B1_mock12_listening_part3.ssml` and confirm alignment